### PR TITLE
Archive rfc6765.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6765.txt
+++ b/www.ietf.org/rfc/rfc6765.txt
@@ -1,0 +1,4091 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          E. Beili
+Request for Comments: 6765                              Actelis Networks
+Category: Standards Track                                 M. Morgenstern
+ISSN: 2070-1721                                              ECI Telecom
+                                                           February 2013
+
+
+                  xDSL Multi-Pair Bonding (G.Bond) MIB
+
+Abstract
+
+   This document defines a Management Information Base (MIB) module for
+   use with network management protocols in TCP/IP-based internets.
+   This document defines an extension to the Interfaces Group MIB with a
+   set of common objects for managing multi-pair bonded Digital
+   Subscriber Line (xDSL) interfaces, as defined in ITU-T
+   Recommendations G.998.1, G.998.2, and G.998.3.  The textual
+   conventions defining the bonding schemes are contained in a separate
+   MIB module maintained by Internet Assigned Numbers Authority (IANA).
+   The MIB modules specific to each bonding technology are defined in
+   G9981-MIB, G9982-MIB, and G9983-MIB, respectively.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6765.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 1]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. The Internet-Standard Management Framework ......................4
+   3. The Broadband Forum Management Framework for xDSL Bonding .......4
+   4. Relationship to Other MIB Modules ...............................5
+      4.1. Relationship to Interfaces Group MIB Module ................5
+           4.1.1. Layering Model ......................................5
+           4.1.2. xDSL Bonding ........................................7
+           4.1.3. Discovery Operation .................................8
+           4.1.4. Initialization of G.Bond Ports .....................10
+           4.1.5. Usage of the ifTable ...............................11
+      4.2. Relationship to G.Bond ATM, ETH, and TDIM MIB Modules .....13
+      4.3. Relationship to xDSL MIB Modules ..........................13
+      4.4. Addition of New Bonding Schemes ...........................13
+   5. MIB Structure ..................................................13
+      5.1. Overview ..................................................13
+      5.2. Performance Monitoring ....................................14
+      5.3. Mapping of Broadband Forum TR-159 Managed Objects .........14
+   6. xDSL Multi-Pair Bonding MIB Definitions ........................19
+   7. IANA-Maintained G.Bond TC Definitions ..........................65
+   8. Security Considerations ........................................67
+   9. IANA Considerations ............................................69
+   10. Acknowledgments ...............................................69
+   11. References ....................................................70
+      11.1. Normative References .....................................70
+      11.2. Informative References ...................................71
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 2]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+1.  Introduction
+
+   xDSL Multi-pair bonding allows a service provider to provide high-
+   bandwidth services to business and residential customers over
+   multiple xDSL lines, with greater speed and resiliency than service
+   over a single xDSL line, bridging the gap between xDSL and fiber-
+   based transport.
+
+   Currently, there are three xDSL Multi-pair bonding schemes, also
+   known under the collective name "G.Bond":
+
+   o  ATM-Based Multi-pair bonding, as specified in ITU-T Recommendation
+      G.998.1 [G.998.1], which defines a method for the bonding (or
+      aggregating) of multiple xDSL lines (or individual bearer channels
+      in multiple xDSL lines) into a single bidirectional logical link
+      carrying an ATM stream.  This specification can be viewed as an
+      evolution of the legacy Inverse Multiplexing for ATM (IMA)
+      technology [AF-PHY-0086], applied to xDSL with variable rates on
+      each line/bearer channel.
+
+   o  Ethernet-Based Multi-pair bonding, as specified in ITU-T
+      Recommendation G.998.2 [G.998.2], which defines a method for the
+      bonding (or aggregating) of multiple xDSL lines (or individual
+      bearer channels in multiple xDSL lines) into a single
+      bidirectional logical link carrying an Ethernet stream.  This
+      specification can be viewed as IEEE 802.3-2005 [802.3] Clause 61,
+      Physical Medium Entity (PME) Aggregation, generalized to work over
+      any xDSL technology (2Base-TL and 10Pass-TS interfaces defined by
+      IEEE use G.SHDSL (Single-pair High-speed DSL) and VDSL (Very high
+      speed DSL) technology, respectively).
+
+   o  Multi-pair bonding using Time-Division Inverse Multiplexing
+      (TDIM), specified in ITU-T Recommendation G.998.3 [G.998.3], which
+      defines a method for the bonding (or aggregating) of multiple xDSL
+      lines into a single bidirectional logical link carrying a mix of
+      various traffic streams (e.g., Ethernet, ATM, TDM).
+
+   Architecturally, all three bonding schemes define a new "bonded"
+   Transport Protocol Specific - Transmission Convergence (TPS-TC)
+   sub-layer, stacked above multiple ATM-TC, Ethernet/Packet Transfer
+   Mode-TC (PTM-TC), or Synchronous Transfer Mode-TC (STM-TC) (clear
+   channel) sub-layers for the ATM, Ethernet, or TDIM bonding,
+   respectively.  Each underlying TPS-TC sub-layer represents a
+   protocol-specific interface to an xDSL line or an individual bearer
+   channel of an xDSL line.  Bonding of multiple bearer channels in the
+   same xDSL line is not allowed.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 3]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   All schemes allow bonding of up to 32 individual line/channel
+   sub-layers with variable rates, providing common functionality for
+   the configuration, initialization, operation, and monitoring of the
+   bonded link.
+
+   This document defines a MIB module common to all 3 schemes.
+   Additional managed objects specific to each bonding technology are
+   defined in the G9981-MIB [RFC6768], G9982-MIB [RFC6767], and
+   G9983-MIB [RFC6766] modules.
+
+   The textual conventions listing the bonding schemes are defined in a
+   separate, IANA-maintained MIB module, the first version of which is
+   provided in this document.  This arrangement would allow for future
+   bonding schemes to be easily supported, without the need to update
+   the common GBOND-MIB module.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This document specifies a
+   MIB module that is compliant to the SMIv2, which is described in STD
+   58, RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC
+   2580 [RFC2580].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14, RFC 2119 [RFC2119].
+
+3.  The Broadband Forum Management Framework for xDSL Bonding
+
+   This document makes use of the Broadband Forum technical report
+   "Management Framework for xDSL Bonding" [TR-159], defining a
+   management model and a hierarchy of management objects for the bonded
+   xDSL interfaces.
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 4]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+4.  Relationship to Other MIB Modules
+
+   This section outlines the relationship of the MIB modules defined in
+   this document with other MIB modules described in the relevant RFCs.
+   Specifically, the following MIB modules are discussed: the Interfaces
+   Group MIB (IF-MIB), Inverse Stack Table MIB (IF-INVERTED-STACK-MIB),
+   and Interface Stack Capability MIB (IF-CAP-STACK-MIB); G.Bond scheme-
+   specific modules G.Bond/ATM (G9981-MIB), G.Bond/Ethernet (G9982-MIB),
+   and G.Bond/TDIM (G9983-MIB); and DSL-specific MIB modules ADSL
+   (ADSL-LINE-EXT-MIB), ADSL2 (ADSL2-LINE-MIB), SHDSL
+   (HDSL2-SHDSL-LINE-MIB), VDSL (VDSL-LINE-MIB), and VDSL2
+   (VDSL2-LINE-MIB).
+
+4.1.  Relationship to Interfaces Group MIB Module
+
+   A bonded xDSL port is a stacked (a.k.a. aggregated or bonded)
+   interface and as such is managed using generic interface management
+   objects defined in the IF-MIB [RFC2863].
+
+   The stack management, i.e., actual connection of the sub-layers to
+   the top layer interface, is done via the ifStackTable, as defined in
+   the IF-MIB [RFC2863] and its inverse -- the ifInvStackTable, as
+   defined in the IF-INVERTED-STACK-MIB [RFC2864].
+
+   The ifCapStackTable and its inverse -- the ifInvCapStackTable, as
+   defined in the IF-CAP-STACK-MIB [RFC5066] -- extend the stack
+   management with an ability to describe possible connections or cross-
+   connect capability, when a flexible cross-connect matrix is present
+   between the interface layers.
+
+4.1.1.  Layering Model
+
+   A G.Bond interface can aggregate up to 32 channel sub-layers, with
+   each channel representing an xDSL line or an xDSL bearer channel.
+   For the purpose of brevity we will refer to the bonded interface as
+   the Generic Bonding Sub-layer (GBS) and to the channel sub-layer as
+   the Bonding Channel Entity (BCE).
+
+   A generic G.Bond device can have a number of GBS ports, each
+   connected to a particular upper layer (e.g., a Media Access Control
+   (MAC) interface for the G.998.2 scheme), while simultaneously cross-
+   connected to a number of underlying BCEs, with a single-GBS-per-BCE
+   relationship.
+
+   A GBS port is represented in the Interfaces table (ifTable) as a
+   separate interface with an ifType reflecting a particular bonding
+   scheme, e.g., g9981(263), g9982(264), or g9983(265).
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 5]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   Each BCE in the aggregated GBS port is represented in the ifTable as
+   a separate interface with an ifType relevant to a particular xDSL
+   technology, e.g., shdsl(169) or vdsl(97).  The ifType values are
+   defined in [IANAifType-MIB].
+
+   The following figure shows the layering diagram and corresponding use
+   of the ifTable for the bonded xDSL interfaces:
+
+   .-----------------------------.  -
+   |            GBS              |  ^ 1 ifEntry
+   |          (TPS-TC)           |  v    ifType: g9981(263), g9982(264),
+   +-----------------+---+-------+  -            g9983(265), etc.
+   | TPS-TC \        |   |       |  ^
+   +---------\       |   |       |  | N ifEntry  (N=1..32)
+   | PMS-TC   )BCE 1 |...| BCE N |  )    ifType: adsl(94), shdsl(169),
+   +---------/       |   |       |  |            vdsl(97), vdsl2(251),
+   | PMD    /        |   |       |  v            etc.
+   '-----------------+---+-------'  -
+
+    BCE    - Bonding Channel Entity
+    GBS    - Generic Bonding Sub-layer
+    PMD    - Physical Medium Dependent
+    TPS-TC - Transport Protocol Specific - Transmission Convergence
+    PMS-TC - Physical Media Specific - Transmission Convergence
+
+            Figure 1: Use of ifTable for Bonded xDSL Interfaces
+
+   The ifStackTable is indexed by the ifIndex values of the aggregated
+   G.Bond port (GBS) and the BCEs connected to it.  The ifStackTable
+   allows a network management application to determine which BCEs are
+   connected to a particular GBS and change connections (if supported by
+   the application).  The ifInvStackTable, being an inverted version of
+   the ifStackTable, provides an efficient means for a network
+   management application to read a subset of the ifStackTable and
+   thereby determine which GBS runs on top of a particular BCE.
+
+   The ifCapStackTable, defined in the IF-CAP-STACK-MIB module,
+   specifies for each higher-layer interface (e.g., GBS port) a list of
+   lower-layer interfaces (e.g., BCEs), which can possibly be cross-
+   connected to that higher-layer interface, determined by the cross-
+   connect capability of the device.  This table, modeled after the
+   ifStackTable, is read only, reflecting current cross-connect
+   capability of a stacked interface, which can be dynamic in some
+   implementations (e.g., if xDSL lines are located on a pluggable
+   module and the module is pulled out).  Note that BCE availability per
+   GBS, described by the ifCapStackTable, can be constrained by other
+   parameters -- for example, by the aggregation capacity of a GBS or by
+   the BCE in question being already connected to another GBS.  So, in
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 6]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   order to ensure that a particular BCE can be connected to the GBS,
+   all respective parameters (e.g., ifCapStackTable, ifStackTable, and
+   gBondPortCapCapacity) SHALL be inspected.
+
+   The ifInvCapStackTable, also defined in the IF-CAP-STACK-MIB module,
+   describes which higher-layer interfaces (e.g., GBS ports) can
+   possibly be connected to a particular lower-layer interface (e.g.,
+   BCE), providing inverted mapping of the ifCapStackTable.  While it
+   contains no additional information beyond that already contained in
+   the ifCapStackTable, the ifInvCapStackTable has the ifIndex values in
+   its INDEX clause in the reverse order, i.e., the lower-layer
+   interface first, and the higher-layer interface second, providing
+   efficient means for a network management application to read a subset
+   of the ifCapStackTable and thereby determine which interfaces can be
+   connected to run on top of a particular interface.
+
+4.1.2.  xDSL Bonding
+
+   The G.998.x Bonding allows a number of BCEs to be aggregated onto a
+   single logical GBS port by splitting the incoming traffic into
+   multiple streams, transmitting each stream over a specific BCE, and
+   combining the streams at the remote GBS port, preserving the original
+   traffic order.
+
+   The Ethernet frames MAY be fragmented before the transmission and
+   reassembled at the remote end to minimize transportation delay.  The
+   G.998.2 (G.Bond/Ethernet) ports with multiple BCEs MUST perform the
+   fragmentation and reassembly of the Ethernet frames.  However, for
+   single-BCE G.998.2 ports this function MAY be omitted (a.k.a. bonding
+   bypass), to minimize fragmentation overhead and additional processing
+   delay as well as to be able to interoperate with non-G.998 DSL
+   equipment.
+
+   The agent is REQUIRED to indicate all supported bonding schemes (for
+   example, ATM, Ethernet, and TDIM), including OPTIONAL support for the
+   bonding bypass in G.998.2 single-BCE ports.
+
+   The GBOND-MIB module allows a network management application to query
+   Bonding capability and enable/disable it if supported.  Note that
+   enabling Bonding (by setting the value of the
+   gBondPortConfAdminScheme and gBondPortConfPeerAdminScheme objects to
+   any supported bonding scheme other than 'none') effectively turns on
+   the fragmentation and reassembly function, even on a single-BCE port.
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 7]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+4.1.3.  Discovery Operation
+
+   The G.Bond ports may optionally support a discovery operation whereby
+   BCEs, during initialization, exchange information about their
+   respective aggregation groups (GBS), via the [G.994.1] handshake
+   (G.hs) protocol.  This information can then be used to detect copper
+   misconnections or for an automatic assignment of the local BCEs into
+   aggregation groups instead of a fixed preconfiguration.
+
+   The MIB module defined in this document allows a network management
+   application to control the G.Bond discovery mechanism and query its
+   results.
+
+   Two tables are used by the G.Bond discovery mechanism: the
+   ifStackTable and the ifCapStackTable.  The following pseudocode gives
+   an example of the discovery and automatic BCE assignment for a
+   generic multi-GBS G.Bond device, located at the Central Office (CO),
+   using objects defined in this MIB module as well as the
+   IF-CAP-STACK-MIB and IF-MIB modules [Note that automatic BCE
+   assignment is only shown here for the purposes of the example.  Fixed
+   BCE pre-assignment, manual assignment, or auto-assignment using an
+   alternative internal algorithm may be chosen by a particular
+   implementation]:
+
+   // Go over all GBS ports in the CO device
+   FOREACH gbs[i] IN CO_device
+   { // Perform discovery and auto-assignment on GBS ports
+     // with room for more channels.
+     IF ( gbs[i].NumBCEs < gbs[i].BondCapacity )
+     { // Assign a unique 6-octet local discovery code to the GBS,
+       // e.g., MAC address of the associated port or some other
+       // unique number specifically allocated for this purpose.
+       dc = gbs[i].DiscoveryCode = MAC[i];
+       // Go over all disconnected channels, which can
+       // potentially be connected to the GBS.
+       FOREACH bce[j] IN ifCapStackTable[gbs[i]] AND
+                      NOT IN ifStackTable[gbs[i]]  // not connected
+       { // Try to grab the Remote Terminal device (RT) by writing the
+         // value of the local 6-byte discovery code to the remote
+         // discovery code register (via a handshake mechanism).
+         // This operation is an atomic Set-if-Clear action; i.e., it
+         // would succeed only if the remote discovery register was
+         // zero.  Read the remote discovery code register via a Get
+         // operation to see if the RT, attached via the BCE,
+         // is indeed marked as being the CO_device peer.
+         bce[j].RemoteDiscoveryCode = dc;          // Set-if-Clear
+         r = bce[j].RemoteDiscoveryCode;           // Get
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 8]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+         IF ( r == dc AND gbs[i].NumBCEs < gbs[i].BondCapacity )
+         { // RT connected via BCE[j] is/was a peer
+           // for GBS[i], and there is room for another BCE in the
+           // GBS[i] aggregation group (max. Bonding capacity is
+           // not reached yet).
+           // Connect this BCE to the GBS (via the ifStackTable; the
+           // ifInvStackTable, which is the inverse of the ifStackTable,
+           // is updated automatically; i.e., gbs[i] is auto-added
+           // to ifInvStackTable[bce[j]]).
+           ADD bce[j] TO ifStackTable[gbs[i]];
+           gbs[i].NumBCEs = gbs[i].NumBCEs + 1;
+           // Discover all other disconnected BCEs
+           // attached to the same RT and connect them to
+           // the GBS, provided there is enough room for more BCEs.
+           FOREACH bce[k] IN ifCapStackTable[gbs[i]] and
+                          NOT IN ifStackTable[gbs[i]]
+           { // Get the remote discovery code from the BCE to see if
+             // it belongs to a connected RT "grabbed" by
+             // the CO_device.
+             r = bce[k].RemoteDiscoveryCode;
+             IF ( r == dc AND gbs[i].NumBCEs < gbs[i].BondCapacity )
+             { // Physically connect the BCE to the GBS.
+               // (gbs[i] is auto-added TO ifInvStackTable[bce[k]]).
+               ADD bce[k] TO ifStackTable[gbs[i]];
+               gbs[i].NumBCEs = gbs[i].NumBCEs + 1;
+             }
+           }
+         }
+         // At this point we have discovered all local BCEs that
+         // are physically connected to the same RT and
+         // connected them to GBS[i].  Go to the next GBS.
+         BREAK;
+       }
+     }
+   }
+
+   An SNMP agent for a G.Bond device builds the ifCapStackTable and its
+   inverse -- the ifInvCapStackTable -- on device initialization,
+   according to the cross-connect capabilities of the device.
+
+   Adding a BCE to the ifStackTable row for a specific GBS involves
+   actual connection of the BCE to the GBS.
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 9]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   Note that a GBS port does not have to be operationally 'down' for the
+   connection to succeed.  In fact, a dynamic BCE addition (and removal)
+   MAY be implemented with an available BCE being initialized first (by
+   setting its ifAdminStatus to 'up') and then added to an operationally
+   'up' GBS port, by modifying a respective ifStackTable (and respective
+   ifInvStackTable) entry.
+
+   It is RECOMMENDED that removal of the last operationally 'up' BCE
+   from an operationally 'up' GBS, i.e., modification of a respective
+   entry in the ifStackTable, and a corresponding entry in the
+   ifInvStackTable, would be rejected by the implementation (in the case
+   of SNMP, with the error inconsistentValue), as this action would
+   completely drop the link.
+
+   In addition to the standard handshake-based discovery described
+   above, [G.998.2] defines an optional frame-based discovery and pair
+   management.  These frame-based methods are discussed in [RFC6767].
+
+4.1.4.  Initialization of G.Bond Ports
+
+   G.Bond ports built on top of xDSL technology require a lengthy
+   initialization or 'training' process before any data can pass.
+   During this initialization, both ends of a link (peers) work
+   cooperatively to achieve a required data rate on a particular copper
+   pair.  Sometimes, when the copper line is too long or the noise on
+   the line is too high, that 'training' process may fail to achieve a
+   specific target rate with required characteristics.
+
+   The ifAdminStatus object from the IF-MIB controls the desired state
+   of a GBS with all the BCEs connected to it or of an individual BCE
+   port.  Setting this object to 'up' instructs a particular GBS or a
+   BCE to start the initialization process, which may take tens of
+   seconds for G.Bond ports.  The ifOperStatus object from the IF-MIB
+   shows the operational state of an interface for the GBS, extended by
+   the gBondPortStatFltStatus object defined in this document, and a
+   corresponding *Status object from a relevant xDSL line MIB for BCE
+   interfaces.
+
+   A disconnected BCE may be initialized by changing the ifAdminStatus
+   from 'down' to 'up'.  Changing the ifAdminStatus to 'up' on the GBS
+   initializes all BCEs connected to that particular GBS.  Note that in
+   the case of bonding, some interfaces may fail to initialize while
+   others succeed.  The GBS is considered operationally 'up' if at least
+   one bonded BCE is operationally 'up'.  When all BCEs connected to the
+   GBS are 'down', the GBS SHALL be considered operationally
+   'lowerLayerDown'.  The GBS SHALL be considered operationally
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 10]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   'notPresent' if it is not connected to any BCE.  The GBS/BCE
+   interface SHALL remain operationally 'down' during initialization,
+   indicated by the 'init' value of the gBondPortStatFltStatus object.
+
+4.1.5.  Usage of the ifTable
+
+   Both BCE and GBS interfaces are managed using interface-specific
+   management objects defined in the GBOND-MIB module and generic
+   interface objects from the ifTable of the IF-MIB, with all management
+   table entries referenced by the interface index ifIndex.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 11]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   The following table summarizes G.Bond-specific interpretations for
+   some of the ifTable objects specified by the mandatory
+   ifGeneralInformationGroup:
+
+   +---------------+---------------------------------------------------+
+   | IF-MIB Object | G.Bond Interpretation                             |
+   +---------------+---------------------------------------------------+
+   | ifIndex       | Interface index.  Note that each BCE and each GBS |
+   |               | in the G.Bond PHY MUST have a unique index, as    |
+   |               | there are some GBS- and BCE-specific attributes   |
+   |               | accessible only on the GBS or BCE level.          |
+   +---------------+---------------------------------------------------+
+   | ifType        | g9981(263), g9982(264), or g9983(265) for the     |
+   |               | ATM, Ethernet, or TDIM GBS, respectively;         |
+   |               | shdsl(169) for the G.SHDSL BCE, vdsl(97) for the  |
+   |               | VDSL BCE, etc.                                    |
+   +---------------+---------------------------------------------------+
+   | ifSpeed       | Operating data rate for the BCE.  For the GBS, it |
+   |               | is the sum of the current operating data rates of |
+   |               | all BCEs in the aggregation group, without the    |
+   |               | encapsulation overhead and G.Bond overhead, but   |
+   |               | accounting for Inter-Frame Gaps (IFG).  When a    |
+   |               | GBS or a BCE is operating in an asymmetrical      |
+   |               | fashion (the upstream data rate differs from the  |
+   |               | downstream one), the lowest of the values is      |
+   |               | shown.                                            |
+   +---------------+---------------------------------------------------+
+   | ifAdminStatus | Setting this object to 'up' instructs a           |
+   |               | particular GBS (with all BCEs connected to it) or |
+   |               | a BCE to start the initialization process.        |
+   +---------------+---------------------------------------------------+
+   | ifOperStatus  | A relevant *Status object from a particular line  |
+   |               | MIB supplements the value of ifOperStatus for     |
+   |               | BCEs.  gBondPortStatFltStatus supplements the     |
+   |               | value of ifOperStatus for a GBS.  Note that both  |
+   |               | relevant objects shall be inspected to determine  |
+   |               | the real operational status of a BCE/GBS port,    |
+   |               | e.g., a GBS port may be operationally 'up' with   |
+   |               | gBondPortStatFltStatus indicating lowRate(4)      |
+   |               | fault condition, or 'down' with no gBond faults.  |
+   +---------------+---------------------------------------------------+
+
+             Table 1: G.Bond Interpretation of IF-MIB Objects
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 12]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+4.2.  Relationship to G.Bond ATM, ETH, and TDIM MIB Modules
+
+   The MIB module defined in this document is common to all G.998
+   bonding schemes.  It MUST be used in conjunction with a bonding
+   scheme-specific MIB module:
+
+   o  G9981-MIB [RFC6768] for a G.998.1 bonded interface.
+
+   o  G9982-MIB [RFC6767] for a G.998.2 bonded interface.
+
+   o  G9983-MIB [RFC6766] for a G.998.3 bonded interface.
+
+4.3.  Relationship to xDSL MIB Modules
+
+   Each xDSL technology is described in a relevant xDSL line MIB module:
+   e.g., the HDSL2-SHDSL-LINE-MIB [RFC4319] for G.SHDSL,
+   ADSL-LINE-EXT-MIB [RFC3440] for ADSL, ADSL2-LINE-MIB [RFC4706] for
+   ADSL2, VDSL-LINE-MIB [RFC3728] for VDSL, or VDSL2-LINE-MIB [RFC5650]
+   for VDSL2.
+
+   These MIB modules are used to manage individual xDSL lines/channels
+   (BCEs).
+
+4.4.  Addition of New Bonding Schemes
+
+   In case a new bonding scheme is introduced in a revision of G.998,
+   IANA can update the IANA-maintained MIB module, adding the
+   corresponding new value to the IANAgBondScheme and
+   IANAgBondSchemeList textual conventions, as well as listing the new
+   scheme-specific MIB module's name (e.g., G998x-MIB).
+
+   Any scheme-specific aspect of an existing GBOND-MIB object SHALL be
+   described in the corresponding G998x-MIB module, to prevent an
+   unnecessary reissue of the GBOND-MIB module.  For example, an exact
+   definition of an Errored Second (ES) or a Severely Errored Second
+   (SES) can be bonding-scheme specific; see the definitions for the
+   gBondPortPmCurES and gBondPortPmCurSES objects.
+
+5.  MIB Structure
+
+5.1.  Overview
+
+   The main management objects defined in the GBOND-MIB module are split
+   into 2 groups, structured as recommended by RFC 4181 [RFC4181]:
+
+   o  gBondPort - containing objects for configuration, capabilities,
+      status, historical Performance Monitoring, and notifications,
+      common to all G.Bond ports (GBS).
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 13]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   o  gBondBce - containing a single common object for configuration of
+      the remote discovery code per BCE.  Note that the rest of the
+      objects for BCE configuration, capabilities, status, and
+      notifications are located in relevant xDSL line MIB modules as
+      well as in the bonding scheme-specific MIB modules.
+
+5.2.  Performance Monitoring
+
+   The OPTIONAL Performance Monitoring counters, thresholds, and history
+   buckets (interval-counters) defined in [TR-159] are implemented using
+   the textual conventions defined in the HC-PerfHist-TC-MIB [RFC3705].
+   The HC-PerfHist-TC-MIB defines 64-bit versions of the textual
+   conventions found in the PerfHist-TC-MIB [RFC3593].
+
+   The agent SHOULD align the beginning of each interval to a fifteen-
+   minute boundary of a wall clock.  Likewise, the beginning of each
+   one-day interval SHOULD be aligned with the start of a day.
+
+   The rationale behind this is to simplify collection and analysis of
+   Performance Monitoring (PM) from multiple agents by a network
+   management system (NMS) -- each PM interval can be "time-stamped"
+   using the gBond*IntervalIndex object, from the fact that the 1-day
+   interval starts at 00:00 and the 15-minute intervals are aligned with
+   each 1/4 hour and the network-wide "wall clock", typically
+   distributed via NTP or the Simple Network Time Protocol (SNTP)
+   [RFC5905].  If the agent does not have access to the wall clock, a
+   local clock can be used.  In this case, as well as when coping with
+   multiple time zones, the NMS would have to correlate the difference
+   between the agent's local clock (available, for example, via the
+   hrSystemDate object from the HOST-RESOURCES-MIB [RFC2790]) and the
+   wall clock.
+
+   Counters are not reset when a GBS is re-initialized, but rather only
+   when the agent is reset or re-initialized.
+
+   Note that the accumulation of certain performance events for a
+   monitored entity is inhibited (counting stops) during periods of
+   service unavailability on that monitored entity.  The DESCRIPTION
+   clause of Performance Monitoring counters in this MIB module
+   specifies which of the counters are inhibited during periods of
+   service unavailability.
+
+5.3.  Mapping of Broadband Forum TR-159 Managed Objects
+
+   This section contains the mapping between relevant managed objects
+   (attributes) defined in [TR-159] and managed objects defined in this
+   document and in associated MIB modules, i.e., the IF-MIB [RFC2863].
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 14]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+ +--------------------------------+------------------------------------+
+ | G.Bond Managed Object          | Corresponding SNMP Object          |
+ +--------------------------------+------------------------------------+
+ | oBondingGroup - Basic Package  |                                    |
+ | (Mandatory)                    |                                    |
+ +--------------------------------+------------------------------------+
+ | aGroupID                       | ifIndex (IF-MIB)                   |
+ +--------------------------------+------------------------------------+
+ | aGroupBondSchemesSupported     | gBondPortCapSchemesSupported       |
+ +--------------------------------+------------------------------------+
+ | aGroupPeerBondSchemesSupported | gBondPortCapPeerSchemesSupported   |
+ +--------------------------------+------------------------------------+
+ | aGroupAdminBondScheme          | gBondPortConfAdminScheme           |
+ +--------------------------------+------------------------------------+
+ | aGroupPeerAdminBondScheme      | gBondPortConfPeerAdminScheme       |
+ +--------------------------------+------------------------------------+
+ | aGroupOperBondScheme           | gBondPortStatOperScheme            |
+ +--------------------------------+------------------------------------+
+ | aGroupPeerOperBondScheme       | gBondPortStatPeerOperScheme        |
+ +--------------------------------+------------------------------------+
+ | aGroupEnd                      | gBondPortStatSide                  |
+ +--------------------------------+------------------------------------+
+ | aGroupOperState                | ifOperStatus (IF-MIB)              |
+ +--------------------------------+------------------------------------+
+ | aGroupAdminState               | ifAdminStatus (IF-MIB)             |
+ +--------------------------------+------------------------------------+
+ | aGroupStatus                   | gBondPortStatFltStatus             |
+ +--------------------------------+------------------------------------+
+ | aGroupCapacity                 | gBondPortCapCapacity               |
+ +--------------------------------+------------------------------------+
+ | aGroupPeerCapacity             | gBondPortCapPeerCapacity           |
+ +--------------------------------+------------------------------------+
+ | aGroupNumChannels              | gBondPortStatNumBCEs               |
+ +--------------------------------+------------------------------------+
+ | aGroupName                     | ifName (IF-MIB)                    |
+ +--------------------------------+------------------------------------+
+ | aGroupDiscoveryCode            | gBondPortConfDiscoveryCode         |
+ +--------------------------------+------------------------------------+
+ | aGroupUpRate                   | gBondPortStatUpDataRate            |
+ +--------------------------------+------------------------------------+
+ | aGroupDownRate                 | gBondPortStatDnDataRate            |
+ +--------------------------------+------------------------------------+
+ | aGroupTargetUpRate             | gBondPortConfTargetUpDataRate      |
+ +--------------------------------+------------------------------------+
+ | aGroupTargetDownRate           | gBondPortConfTargetDnDataRate      |
+ +--------------------------------+------------------------------------+
+ | aGroupThreshLowUpRate          | gBondPortConfThreshLowUpRate       |
+ +--------------------------------+------------------------------------+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 15]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+ +--------------------------------+------------------------------------+
+ | aGroupThreshLowDownRate        | gBondPortConfThreshLowDnRate       |
+ +--------------------------------+------------------------------------+
+ | aGroupLowRateCrossingEnable    | gBondPortConfLowRateCrossingEnable |
+ +--------------------------------+------------------------------------+
+ | nGroupLowUpRateCrossing        | gBondLowUpRateCrossing             |
+ +--------------------------------+------------------------------------+
+ | nGroupLowDownRateCrossing      | gBondLowDnRateCrossing             |
+ +--------------------------------+------------------------------------+
+ | aGroupLinkUpDownEnable         | ifLinkUpDownTrapEnable (IF-MIB)    |
+ +--------------------------------+------------------------------------+
+ | nGroupLinkUp                   | linkUp (IF-MIB)                    |
+ +--------------------------------+------------------------------------+
+ | nGroupLinkDown                 | linkDown (IF-MIB)                  |
+ +--------------------------------+------------------------------------+
+ | oBondingGroup - PM Package     |                                    |
+ | (Optional)                     |                                    |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfES                   | gBondPortPmCurES                   |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfSES                  | gBondPortPmCurSES                  |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfUAS                  | gBondPortPmCurUAS                  |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinValidIntervals  | gBondPortPmCur15MinValidIntervals  |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinInvalidIntervals| gBondPortPmCur15MinInvalidIntervals|
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr15MinTimeElapsed | gBondPortPmCur15MinTimeElapsed     |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr15MinES          | gBondPortPmCur15MinES              |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr15MinSES         | gBondPortPmCur15MinSES             |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr15MinUAS         | gBondPortPmCur15MinUAS             |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfTcaEnable            | gBondPortConfPmTcaEnable           |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold15MinES     | gBondPortPmTcaProfileThresh15MinES |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold15MinSES    | gBondPortPmTcaProfileThresh15MinSES|
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold15MinUAS    | gBondPortPmTcaProfileThresh15MinUAS|
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca15MinES           | gBondPmTca15MinESCrossing          |
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca15MinSES          | gBondPmTca15MinSESCrossing         |
+ +--------------------------------+------------------------------------+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 16]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca15MinUAS          | gBondPmTca15MinUASCrossing         |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayValidIntervals   | gBondPortPmCur1DayValidIntervals   |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayInvalidIntervals | gBondPortPmCur1DayInvalidIntervals |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr1DayTimeElapsed  | gBondPortPmCur1DayTimeElapsed      |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr1DayES           | gBondPortPmCur1DayIntervalES       |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr1DaySES          | gBondPortPmCur1DayIntervalSES      |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfCurr1DayUAS          | gBondPortPmCur1DayIntervalUAS      |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold1DayES      | gBondPortPmTcaProfileThresh1DayES  |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold1DaySES     | gBondPortPmTcaProfileThresh1DaySES |
+ +--------------------------------+------------------------------------+
+ | aGroupPerfThreshold1DayUAS     | gBondPortPmTcaProfileThresh1DayUAS |
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca1DayES            | gBondPmTca1DayESCrossing           |
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca1DaySES           | gBondPmTca1DaySESCrossing          |
+ +--------------------------------+------------------------------------+
+ | nGroupPerfTca1DayUAS           | gBondPmTca1DayUASCrossing          |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinIntervalNumber  | gBondPortPm15MinIntervalIndex      |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinIntervalValid   | gBondPortPm15MinIntervalValid      |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinIntervalES      | gBondPortPm15MinIntervalES         |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinIntervalSES     | gBondPortPm15MinIntervalSES        |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf15MinIntervalUAS     | gBondPortPm15MinIntervalUAS        |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalNumber   | gBondPortPm1DayIntervalIndex       |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalValid    | gBondPortPm1DayIntervalValid       |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalMoniSecs | gBondPortPm1DayIntervalMoniTime    |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalES       | gBondPortPm1DayIntervalES          |
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalSES      | gBondPortPm1DayIntervalSES         |
+ +--------------------------------+------------------------------------+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 17]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+ +--------------------------------+------------------------------------+
+ | aGroupPerf1DayIntervalUAS      | gBondPortPm1DayIntervalUAS         |
+ +--------------------------------+------------------------------------+
+ | oLine - Basic Package          |                                    |
+ | (Mandatory)                    |                                    |
+ +--------------------------------+------------------------------------+
+ | aLineID                        | ifIndex (IF-MIB)                   |
+ +--------------------------------+------------------------------------+
+ | aLineType                      | ifType (IF-MIB)                    |
+ +--------------------------------+------------------------------------+
+ | aLineOperState                 | ifOperStatus (IF-MIB)              |
+ +--------------------------------+------------------------------------+
+ | aLineStatus                    | *dsl*CurrStatus (*DSL-LINE-MIB)    |
+ +--------------------------------+------------------------------------+
+ | aLineEnd                       | *dsl*Side (*DSL-LINE-MIB)          |
+ +--------------------------------+------------------------------------+
+ | aLineAdminState                | ifAdminStatus (IF-MIB)             |
+ +--------------------------------+------------------------------------+
+ | aLineRemoteDiscoveryCode       | gBondBceConfRemoteDiscoveryCode    |
+ +--------------------------------+------------------------------------+
+ | aLineUpDownEnable              | ifLinkUpDownTrapEnable (IF-MIB)    |
+ +--------------------------------+------------------------------------+
+ | nLineUp                        | LinkUp (IF-MIB)                    |
+ +--------------------------------+------------------------------------+
+ | nLineDown                      | LinkDown (IF-MIB)                  |
+ +--------------------------------+------------------------------------+
+ | oChannel - Basic Package       |                                    |
+ | (Mandatory)                    |                                    |
+ +--------------------------------+------------------------------------+
+ | aChannelID                     | ifIndex (IF-MIB)                   |
+ +--------------------------------+------------------------------------+
+ | aChannelGroupID                |                                    |
+ +--------------------------------+------------------------------------+
+ | aChannelType                   | ifType (IF-MIB)                    |
+ +--------------------------------+------------------------------------+
+ | aChannelOperState              | ifOperStatus (IF-MIB)              |
+ +--------------------------------+------------------------------------+
+ | aChannelStatus                 | *dsl*CurrStatus (*DSL-LINE-MIB),   |
+ |                                | xdsl2ChStatus*Status               |
+ |                                | (VDSL2-LINE-MIB)                   |
+ +--------------------------------+------------------------------------+
+
+                 Table 2: Mapping of TR-159 Managed Objects
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 18]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+6.  xDSL Multi-Pair Bonding MIB Definitions
+
+   The GBOND-MIB module IMPORTS objects from SNMPv2-SMI [RFC2578],
+   SNMPv2-TC [RFC2579], SNMPv2-CONF [RFC2580], SNMP-FRAMEWORK-MIB
+   [RFC3411], IF-MIB [RFC2863], and HC-PerfHist-TC-MIB [RFC3705].
+   The module has been structured as recommended by [RFC4181].
+
+GBOND-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    NOTIFICATION-TYPE,
+    mib-2,
+    Unsigned32,
+    Gauge32
+      FROM SNMPv2-SMI           -- RFC 2578
+    TEXTUAL-CONVENTION,
+    TruthValue,
+    RowStatus,
+    PhysAddress
+      FROM SNMPv2-TC            -- RFC 2579
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP,
+    NOTIFICATION-GROUP
+      FROM SNMPv2-CONF          -- RFC 2580
+    SnmpAdminString
+      FROM SNMP-FRAMEWORK-MIB   -- RFC 3411
+    ifIndex
+      FROM IF-MIB               -- RFC 2863
+    HCPerfCurrentCount,
+    HCPerfIntervalCount,
+    HCPerfIntervalThreshold,
+    HCPerfValidIntervals,
+    HCPerfInvalidIntervals,
+    HCPerfTimeElapsed,
+    HCPerfTotalCount
+      FROM  HC-PerfHist-TC-MIB  -- RFC 3705
+    IANAgBondScheme,
+    IANAgBondSchemeList
+      FROM  IANA-GBOND-TC-MIB
+    ;
+------------------------------------------------------------------------
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 19]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+  gBondMIB MODULE-IDENTITY
+    LAST-UPDATED "201302200000Z"  -- 20 February 2013
+    ORGANIZATION "IETF ADSL MIB Working Group"
+    CONTACT-INFO
+      "WG charter:
+        http://datatracker.ietf.org/wg/adslmib/charter/
+
+      Mailing Lists:
+        General Discussion: adslmib@ietf.org
+        To Subscribe: adslmib-request@ietf.org
+        In Body: subscribe your_email_address
+
+       Chair: Menachem Dodge
+      Postal: ECI Telecom, Ltd.
+              30 Hasivim St.
+              Petach-Tikva  4951169
+              Israel
+       Phone: +972-3-926-8421
+       EMail: menachemdodge1@gmail.com
+
+      Editor: Edward Beili
+      Postal: Actelis Networks, Inc.
+              25 Bazel St., P.O.B. 10173
+              Petach-Tikva  49103
+              Israel
+       Phone: +972-3-924-3491
+       EMail: edward.beili@actelis.com
+
+      Editor: Moti Morgenstern
+      Postal: ECI Telecom
+              30 Hasivim St.
+              Petach-Tikva  4951169
+              Israel
+       Phone: +972-3-926-6258
+       EMail: moti.morgenstern@ecitele.com"
+
+    DESCRIPTION
+      "The objects in this MIB module are used to manage the
+      multi-pair bonded xDSL interfaces, as defined in ITU-T
+      Recommendations G.998.1, G.998.2, and G.998.3.
+
+      This MIB module MUST be used in conjunction with a bonding
+      scheme-specific MIB module, that is, G9981-MIB, G9982-MIB,
+      or G9983-MIB.
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 20]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+      The following references are used throughout this MIB module:
+
+      [G.998.1] refers to:
+        ITU-T Recommendation G.998.1: 'ATM-based multi-pair bonding',
+        January 2005.
+
+      [G.998.2] refers to:
+        ITU-T Recommendation G.998.2: 'Ethernet-based multi-pair
+        bonding', January 2005.
+
+      [G.998.3] refers to:
+        ITU-T Recommendation G.998.3: 'Multi-pair bonding using
+        time-division inverse multiplexing', January 2005.
+
+      [TR-159] refers to:
+        Broadband Forum Technical Report: 'Management Framework for
+        xDSL Bonding', December 2008.
+
+      Naming Conventions:
+        BCE   - Bonding Channel Entity
+        BTU   - Bonding Terminating Unit
+        BTU-C - Bonding Terminating Unit, CO side
+        BTU-R - Bonding Terminating Unit, Remote Terminal (CPE) side
+        CO    - Central Office
+        CPE   - Customer Premises Equipment
+        GBS   - Generic Bonding Sub-layer
+        PM    - Performance Monitoring
+        SNR   - Signal to Noise Ratio
+        TCA   - Threshold Crossing Alert
+
+     Copyright (c) 2013 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, is permitted pursuant to, and subject to the license
+     terms contained in, the Simplified BSD License set forth in Section
+     4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info)."
+
+    REVISION    "201302200000Z"  -- 20 February 2013
+    DESCRIPTION "Initial version, published as RFC 6765."
+
+    ::= { mib-2 211 }
+
+   -- Sections of the module
+   -- Structured as recommended by RFC 4181, Appendix D
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 21]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   gBondObjects     OBJECT IDENTIFIER ::= { gBondMIB 1 }
+
+   gBondConformance OBJECT IDENTIFIER ::= { gBondMIB 2 }
+
+   -- Groups in the module
+
+   gBondPort        OBJECT IDENTIFIER ::= { gBondObjects 1 }
+
+   gBondBce         OBJECT IDENTIFIER ::= { gBondObjects 2 }
+
+   -- Textual Conventions
+
+   GBondPm1DayIntervalThreshold ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "d"
+     STATUS      current
+     DESCRIPTION
+       "This textual convention defines a range of values that may be
+       set in a fault threshold alarm control for a 1-day Performance
+       Monitoring interval.
+       As the number of seconds in a 1-day interval numbers at most
+       86400, objects of this type may have a range of 0...86400,
+       where the value of 0 disables the alarm."
+     SYNTAX      Unsigned32 (0..86400)
+
+
+   -- Port Notifications group
+
+   gBondPortNotifications OBJECT IDENTIFIER ::= { gBondPort 0 }
+
+   gBondLowUpRateCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortStatUpDataRate,
+       gBondPortConfThreshLowUpRate
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the G.Bond port's upstream
+       data rate has reached/dropped below or exceeded the low
+       upstream rate threshold, specified by
+       gBondPortConfThreshLowUpRate.
+
+       This notification MAY be sent for the -O subtype ports
+       while the port is 'up', on the crossing event in both
+       directions: from normal (rate is above the threshold) to low
+       (rate equals the threshold or is below it) and from low to
+       normal.  This notification is not applicable to the -R
+       subtypes.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 22]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       It is RECOMMENDED that a small debouncing period of 2.5 sec,
+       between the detection of the condition and notification,
+       be implemented to prevent simultaneous LinkUp/LinkDown and
+       gBondLowUpRateCrossing notifications from being sent.
+
+       The adaptive nature of the G.Bond technology allows the port
+       to adapt itself to the changes in the copper environment;
+       e.g., an impulse noise, alien crosstalk, or a
+       micro-interruption may temporarily drop one or more BCEs in
+       the aggregation group, causing a rate degradation of the
+       aggregated G.Bond link.  The dropped BCEs would then try to
+       re-initialize, possibly at a lower rate than before, adjusting
+       the rate to provide the required target SNR margin.
+
+       Generation of this notification is controlled by the
+       gBondPortConfLowRateCrossingEnable object.
+
+       This object maps to the TR-159 notification
+       nGroupLowUpRateCrossing."
+     REFERENCE
+       "[TR-159], Section 5.5.1.24"
+     ::= { gBondPortNotifications 1 }
+
+   gBondLowDnRateCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortStatDnDataRate,
+       gBondPortConfThreshLowDnRate
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the G.Bond port's downstream
+       data rate has reached/dropped below or exceeded the low
+       downstream rate threshold, specified by
+       gBondPortConfThreshLowDnRate.
+
+       This notification MAY be sent for the -O subtype ports
+       while the port is 'up', on the crossing event in both
+       directions: from normal (rate is above the threshold) to low
+       (rate equals the threshold or is below it) and from low to
+       normal.  This notification is not applicable to the -R
+       subtypes.
+
+       It is RECOMMENDED that a small debouncing period of 2.5 sec,
+       between the detection of the condition and notification,
+       be implemented to prevent simultaneous LinkUp/LinkDown and
+       gBondLowDnRateCrossing notifications from being sent.
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 23]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       The adaptive nature of the G.Bond technology allows the port
+       to adapt itself to the changes in the copper environment;
+       e.g., an impulse noise, alien crosstalk, or a
+       micro-interruption may temporarily drop one or more BCEs in
+       the aggregation group, causing a rate degradation of the
+       aggregated G.Bond link.  The dropped BCEs would then try to
+       re-initialize, possibly at a lower rate than before,
+       adjusting the rate to provide the required target SNR margin.
+
+       Generation of this notification is controlled by the
+       gBondPortConfLowRateCrossingEnable object.
+
+       This object maps to the TR-159 notification
+       nGroupLowDownRateCrossing."
+     REFERENCE
+       "[TR-159], Section 5.5.1.25"
+     ::= { gBondPortNotifications 2}
+
+   gBondPmTca15MinESCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur15MinES,
+       gBondPortPmTcaProfileThresh15MinES
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the Errored Seconds threshold,
+       specified by gBondPortPmTcaProfileThresh15MinES, has been
+       reached or exceeded for the GBS port.
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh15MinES objects.
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca15MinES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.42"
+     ::= { gBondPortNotifications 3}
+
+   gBondPmTca15MinSESCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur15MinSES,
+       gBondPortPmTcaProfileThresh15MinSES
+     }
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 24]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     DESCRIPTION
+       "This notification indicates that the Severely Errored Seconds
+       threshold, specified by gBondPortPmTcaProfileThresh15MinSES,
+       has been reached or exceeded for the GBS port.
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh15MinSES objects.
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca15MinSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.43"
+     ::= { gBondPortNotifications 4}
+
+   gBondPmTca15MinUASCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur15MinUAS,
+       gBondPortPmTcaProfileThresh15MinUAS
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the Unavailable Seconds
+       threshold, specified by gBondPortPmTcaProfileThresh15MinUAS,
+       has been reached or exceeded for the GBS port.
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh15MinUAS objects.
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca15MinUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.44"
+     ::= { gBondPortNotifications 5}
+
+   gBondPmTca1DayESCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur1DayES,
+       gBondPortPmTcaProfileThresh1DayES
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the Errored Seconds threshold,
+       specified by gBondPortPmTcaProfileThresh1DayES, has been
+       reached or exceeded for the GBS port.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 25]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh1DayES objects.
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca1DayES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.54"
+     ::= { gBondPortNotifications 6}
+
+   gBondPmTca1DaySESCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur1DaySES,
+       gBondPortPmTcaProfileThresh1DaySES
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the Severely Errored Seconds
+       threshold, specified by gBondPortPmTcaProfileThresh1DaySES,
+       has been reached or exceeded for the GBS port.
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh1DaySES objects.
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca1DaySES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.55"
+     ::= { gBondPortNotifications 7}
+
+   gBondPmTca1DayUASCrossing NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       gBondPortPmCur1DayUAS,
+       gBondPortPmTcaProfileThresh1DayUAS
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the Unavailable Seconds
+       threshold, specified by gBondPortPmTcaProfileThresh1DayUAS,
+       has been reached or exceeded for the GBS port.
+
+       Generation of this notification is controlled by the
+       gBondPortConfPmTcaEnable and
+       gBondPortPmTcaProfileThresh1DayUAS objects.
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 26]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object maps to the TR-159 notification
+       nGroupPerfTca1DayUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.56"
+     ::= { gBondPortNotifications 8}
+
+   -- G.Bond Port (GBS) group
+
+   gBondPortConfTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for configuration of G.Bond GBS ports.  Entries in this
+       table MUST be maintained in a persistent manner."
+     ::= { gBondPort 1 }
+
+   gBondPortConfEntry OBJECT-TYPE
+     SYNTAX      GBondPortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port Configuration table.
+       Each entry represents a G.Bond port indexed by the ifIndex.
+       Note that a G.Bond GBS port runs on top of a single
+       or multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { gBondPortConfTable 1 }
+
+   GBondPortConfEntry ::=
+     SEQUENCE {
+       gBondPortConfAdminScheme              IANAgBondScheme,
+       gBondPortConfPeerAdminScheme          IANAgBondScheme,
+       gBondPortConfDiscoveryCode            PhysAddress,
+       gBondPortConfTargetUpDataRate         Unsigned32,
+       gBondPortConfTargetDnDataRate         Unsigned32,
+       gBondPortConfThreshLowUpRate          Unsigned32,
+       gBondPortConfThreshLowDnRate          Unsigned32,
+       gBondPortConfLowRateCrossingEnable    TruthValue,
+       gBondPortConfPmTcaConfProfile         SnmpAdminString,
+       gBondPortConfPmTcaEnable              TruthValue
+     }
+
+   gBondPortConfAdminScheme  OBJECT-TYPE
+     SYNTAX      IANAgBondScheme
+     MAX-ACCESS  read-write
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 27]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     DESCRIPTION
+       "A desired bonding scheme for a G.Bond GBS port.
+       The following values instruct the port to use the corresponding
+       bonding scheme if supported:
+         none(0)       - instructs the port not to use bonding
+                         (only on a single-BCE G.998.2 GBS)
+         g9981(1)      - instructs the port to use G.998.1 bonding
+         g9982(2)      - instructs the port to use G.998.2 bonding
+         g9983(3)      - instructs the port to use G.998.3 bonding
+
+       Changing of the gBondPortConfAdminScheme object MUST be
+       performed when the link is administratively 'down', as indicated
+       by the ifAdminStatus object in the IF-MIB.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), if the link is 'up' or
+       initializing.  Attempts to change this object to an unsupported
+       bonding scheme (see gBondPortCapSchemesSupported) SHALL be
+       rejected (in the case of SNMP, with the error wrongValue).
+       Setting this object to the value of 'none' must be rejected for
+       GBS ports with multiple BCEs (with the error inconsistentValue).
+
+       This object maps to the TR-159 attribute aGroupAdminBondScheme."
+     REFERENCE
+       "[TR-159], Section 5.5.1.6; RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { gBondPortConfEntry 1 }
+
+   gBondPortConfPeerAdminScheme  OBJECT-TYPE
+     SYNTAX      IANAgBondScheme
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "A desired bonding scheme for a peer (link partner) G.Bond
+       port (GBS).
+       The following values instruct the peer port to use the
+       corresponding bonding scheme if supported:
+         none(0)       - instructs the port not to use bonding
+                         (only on a single-BCE G.998.2 GBS)
+         g9981(1)      - instructs the port to use G.998.1 bonding
+         g9982(2)      - instructs the port to use G.998.2 bonding
+         g9983(3)      - instructs the port to use G.998.3 bonding
+
+       Changing of this object MUST be performed when the link is
+       administratively 'down', as indicated by the ifAdminStatus
+       object in the IF-MIB.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), if the link is 'up' or
+       initializing.  Attempts to change this object to an unsupported
+       bonding scheme (see gBondPortCapPeerSchemesSupported) SHALL be
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 28]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       rejected (in the case of SNMP, with the error wrongValue).
+       Setting this object to the value of 'none' must be rejected for
+       GBS ports with multiple BCEs (with the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aGroupPeerAdminBondScheme."
+     REFERENCE
+       "[TR-159], Section 5.5.1.7; RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { gBondPortConfEntry 2 }
+
+   gBondPortConfDiscoveryCode  OBJECT-TYPE
+     SYNTAX      PhysAddress (SIZE (6))
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "A discovery code of the G.Bond port (GBS).
+       A unique 6-octet-long code used by the Discovery function.
+       This object MUST be instantiated for the -O subtype GBS before
+       write operations on the gBondBceConfRemoteDiscoveryCode
+       (Set_if_Clear and Clear_if_Same) are performed by BCEs
+       associated with the GBS.
+       The initial value of this object for -R subtype ports after
+       reset is all zeroes.  For -R subtype ports, the value of this
+       object cannot be changed directly.  This value may be changed
+       as a result of a write operation on the
+       gBondBceConfRemoteDiscoveryCode object of a remote BCE of -O
+       subtype, connected to one of the local BCEs associated with
+       the GBS.
+
+       Discovery MUST be performed when the link is administratively
+       'down', as indicated by the ifAdminStatus object in the IF-MIB.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), if the link is 'up' or
+       initializing.
+
+       This object maps to the TR-159 attribute
+       aGroupDiscoveryCode."
+     REFERENCE
+       "[TR-159], Section 5.5.1.20; [802.3], Sections 61.2.2.8.3,
+       61.2.2.8.4, 45.2.6.6.1, 45.2.6.8, 61A.2;
+       RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { gBondPortConfEntry 3 }
+
+   gBondPortConfTargetUpDataRate  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0|1..10000000)
+     UNITS       "Kbps"
+     MAX-ACCESS  read-write
+     STATUS      current
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 29]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     DESCRIPTION
+       "A desired G.Bond port data rate in the upstream direction,
+       in Kbps, to be achieved during initialization, under
+       restrictions placed upon the member BCEs by their respective
+       configuration settings.
+       This object represents a sum of individual BCE upstream data
+       rates, modified to compensate for fragmentation and
+       encapsulation overhead (e.g., for an Ethernet service, the
+       target data rate of 10 Mbps SHALL allow lossless transmission
+       of full-duplex 10-Mbps Ethernet frame stream with minimal
+       inter-frame gap).
+       Note that the target upstream data rate may not be achieved
+       during initialization (e.g., due to unavailability of required
+       BCEs) or the initial bandwidth could deteriorate, so that the
+       actual upstream data rate (gBondPortStatUpDataRate) could be less
+       than gBondPortConfTargetUpDataRate.
+
+       The value is limited above by 10 Gbps, to accommodate very
+       high speed bonded xDSL interfaces (e.g., 32 x 100 Mbps).
+
+       The value between 1 and 10000000 indicates that the total
+       upstream data rate of the G.Bond port after initialization
+       SHALL be equal to the target data rate or less, if the target
+       upstream data rate cannot be achieved under the restrictions
+       configured for BCEs.  In cases where the copper environment
+       allows a higher upstream data rate to be achieved than that
+       specified by this object, the excess capability SHALL be
+       either converted to an additional SNR margin or reclaimed by
+       minimizing transmit power.
+
+       The value of 0 means that the target data rate is not
+       fixed and SHALL be set to the maximum attainable rate during
+       initialization (best effort), under specified spectral
+       restrictions and with a desired SNR margin per BCE.
+
+       This object is read-write for the -O subtype G.Bond ports.
+       It is irrelevant for the -R subtypes -- attempts to read or
+       change this object for such ports MUST be rejected (in the case
+       of SNMP, with the error inconsistentValue).
+
+       Changing of the target upstream data rate MUST be performed
+       when the link is administratively 'down', as indicated by the
+       ifAdminStatus object in the IF-MIB.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), if the link is 'up' or
+       initializing.
+
+       This object maps to the TR-159 attribute aGroupTargetUpRate."
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 30]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.1.17; RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { gBondPortConfEntry 4 }
+
+   gBondPortConfTargetDnDataRate  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0|1..10000000)
+     UNITS       "Kbps"
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "A desired G.Bond port data rate in the downstream direction,
+       in Kbps, to be achieved during initialization, under
+       restrictions placed upon the member BCEs by their respective
+       configuration settings.
+       This object represents a sum of individual BCE downstream data
+       rates, modified to compensate for fragmentation and
+       encapsulation overhead (e.g., for an Ethernet service, the
+       target data rate of 10 Mbps SHALL allow lossless transmission
+       of full-duplex 10-Mbps Ethernet frame stream with minimal
+       inter-frame gap).
+       Note that the target downstream data rate may not be achieved
+       during initialization (e.g., due to unavailability of required
+       BCEs) or the initial bandwidth could deteriorate, so that the
+       actual downstream data rate (gBondPortStatDnDataRate) could be
+       less than gBondPortConfTargetDnDataRate.
+
+       The value is limited above by 10 Gbps, to accommodate very
+       high speed bonded xDSL interfaces (e.g., 32 x 100 Mbps).
+
+       The value between 1 and 10000000 indicates that the total
+       downstream data rate of the G.Bond port after initialization
+       SHALL be equal to the target data rate or less, if the target
+       downstream data rate cannot be achieved under the restrictions
+       configured for BCEs.  In cases where the copper environment
+       allows a higher downstream data rate to be achieved than that
+       specified by this object, the excess capability SHALL be
+       either converted to an additional SNR margin or reclaimed by
+       minimizing transmit power.
+
+       The value of 0 means that the target data rate is not
+       fixed and SHALL be set to the maximum attainable rate during
+       initialization (best effort), under specified spectral
+       restrictions and with a desired SNR margin per BCE.
+
+       This object is read-write for the -O subtype G.Bond ports.
+       It is irrelevant for the -R subtypes -- attempts to read or
+       change this object for such ports MUST be rejected (in the case
+       of SNMP, with the error inconsistentValue).
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 31]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       Changing of the target downstream data rate MUST be performed
+       when the link is administratively 'down', as indicated by the
+       ifAdminStatus object in the IF-MIB.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), if the link is 'up' or
+       initializing.
+
+       This object maps to the TR-159 attribute aGroupTargetDownRate."
+     REFERENCE
+       "[TR-159], Section 5.5.1.18; RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { gBondPortConfEntry 5 }
+
+   gBondPortConfThreshLowUpRate  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..10000000)
+     UNITS       "Kbps"
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "This object configures the G.Bond port low upstream rate
+       crossing alarm threshold.  When the current value of
+       gBondPortStatUpDataRate for this port reaches/drops below or
+       exceeds this threshold, a gBondLowUpRateCrossing notification
+       MAY be generated if enabled by
+       gBondPortConfLowRateCrossingEnable.
+
+       This object is read-write for the -O subtype G.Bond ports.
+       It is irrelevant for the -R subtypes -- attempts to read or
+       change this object for such ports MUST be rejected (in the case
+       of SNMP, with the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aGroupthreshLowUpRate."
+     REFERENCE
+       "[TR-159], Section 5.5.1.21"
+     ::= { gBondPortConfEntry 6 }
+
+   gBondPortConfThreshLowDnRate  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..10000000)
+     UNITS       "Kbps"
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "This object configures the G.Bond port low downstream rate
+       crossing alarm threshold.  When the current value of
+       gBondPortStatDnDataRate for this port reaches/drops below or
+       exceeds this threshold, a gBondLowDnRateCrossing notification
+       MAY be generated if enabled by
+       gBondPortConfLowRateCrossingEnable.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 32]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object is read-write for the -O subtype G.Bond ports.
+       It is irrelevant for the -R subtypes -- attempts to read or
+       change this object for such ports MUST be rejected (in the case
+       of SNMP, with the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aGroupThreshLowDownRate."
+     REFERENCE
+       "[TR-159], Section 5.5.1.22"
+     ::= { gBondPortConfEntry 7 }
+
+   gBondPortConfLowRateCrossingEnable  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "Indicates whether gBondLowUpRateCrossing and
+       gBondLowDnRateCrossing notifications should be generated
+       for this interface.
+
+       A value of true(1) indicates that the notifications are
+       enabled.  A value of false(2) indicates that the notifications
+       are disabled.
+
+       This object is read-write for the -O subtype G.Bond ports.
+       It is irrelevant for the -R subtypes -- attempts to read or
+       change this object for such ports MUST be rejected (in the case
+       of SNMP, with the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aGroupLowRateCrossingEnable."
+     REFERENCE
+       "[TR-159], Section 5.5.1.23"
+     ::= { gBondPortConfEntry 8 }
+
+   gBondPortConfPmTcaConfProfile  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE (1..32))
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "The value of this object is the index of the row in the GBS
+       Port Alarm Configuration Profile table for Performance Monitoring
+       Threshold Crossing Alerts -- the gBondPortAlarmConfProfileTable,
+       which applies to this GBS port."
+     DEFVAL  { "DEFVAL" }
+     ::= { gBondPortConfEntry 9 }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 33]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   gBondPortConfPmTcaEnable  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "Indicates whether the gBondPerfTca*Crossing set of
+       notifications should be generated for this interface.
+
+       A value of true(1) indicates that the notifications are
+       enabled.  A value of false(2) indicates that the notifications
+       are disabled.
+
+       This object maps to the TR-159 attribute aGroupPerfTcaEnable."
+     REFERENCE
+       "[TR-159], Section 5.5.1.38"
+     ::= { gBondPortConfEntry 10 }
+
+
+   gBondPortCapTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortCapEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for capabilities of G.Bond ports.  Entries in this table
+       MUST be maintained in a persistent manner."
+     ::= { gBondPort 2 }
+
+   gBondPortCapEntry OBJECT-TYPE
+     SYNTAX      GBondPortCapEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port Capability table.
+       Each entry represents a G.Bond port indexed by the ifIndex.
+       Note that a G.Bond GBS port runs on top of a single
+       or multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { gBondPortCapTable 1 }
+
+   GBondPortCapEntry ::=
+     SEQUENCE {
+       gBondPortCapSchemesSupported          IANAgBondSchemeList,
+       gBondPortCapPeerSchemesSupported      IANAgBondSchemeList,
+       gBondPortCapCapacity                  Unsigned32,
+       gBondPortCapPeerCapacity              Unsigned32
+     }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 34]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   gBondPortCapSchemesSupported          OBJECT-TYPE
+     SYNTAX      IANAgBondSchemeList
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Bonding capability of the G.Bond port (GBS).  This is a
+       read-only bitmap of the possible bonding schemes supported by
+       the GBS.  The various bit positions are:
+         none(0)       - GBS is capable of bonding bypass on a
+                         single-BCE G.998.2 GBS
+         g9981(1)      - GBS is capable of G.998.1 bonding
+         g9982(2)      - GBS is capable of G.998.2 bonding
+         g9983(3)      - GBS is capable of G.998.3 bonding
+
+       Note that for ports supporting multiple bonding schemes, the
+       actual administrative scheme is set via gBondPortConfAdminScheme
+       object.  The current operating bonding scheme is reflected in
+       the gBondPortStatOperScheme object.
+
+       This object maps to the TR-159 attribute
+       aGroupBondSchemesSupported."
+     REFERENCE
+       "[TR-159], Section 5.5.1.2"
+     ::= { gBondPortCapEntry 1 }
+
+   gBondPortCapPeerSchemesSupported  OBJECT-TYPE
+     SYNTAX      IANAgBondSchemeList
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Bonding capability of the peer G.Bond port (GBS).  This is a
+       read-only bitmap of the possible bonding schemes supported by
+       the link partner GBS.  The various bit positions are:
+         none(0)       - peer GBS does not support bonding, or
+                         the peer unit could not be reached, or
+                         peer GBS is capable of bonding bypass on a
+                         single-BCE G.998.2 GBS
+         g9981(1)      - peer GBS is capable of G.998.1 bonding
+         g9982(2)      - peer GBS is capable of G.998.2 bonding
+         g9983(3)      - peer GBS is capable of G.998.3 bonding
+
+       Note that for ports supporting multiple bonding schemes, the
+       actual administrative scheme is set via the
+       gBondPortConfPeerAdminScheme object.  The current operating
+       bonding scheme is reflected in the gBondPortStatPeerOperScheme
+       object.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 35]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object maps to the TR-159 attribute
+       aGroupPeerBondSchemesSupported."
+     REFERENCE
+       "[TR-159], Section 5.5.1.3"
+     ::= { gBondPortCapEntry 2 }
+
+   gBondPortCapCapacity  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..32)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Number of BCEs that can be aggregated by the local GBS.
+       The number of BCEs currently assigned to a particular G.Bond
+       port (gBondPortStatNumBCEs) is never greater than
+       gBondPortCapCapacity.
+
+       This object maps to the TR-159 attribute aGroupCapacity."
+     REFERENCE
+       "[TR-159], Section 5.5.1.12"
+     ::= { gBondPortCapEntry 3 }
+
+   gBondPortCapPeerCapacity  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0|1..32)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Number of BCEs that can be aggregated by the peer GBS port.
+       A value of 0 is returned when peer Bonding capacity is unknown
+       (peer cannot be reached).
+
+       This object maps to the TR-159 attribute aGroupPeerCapacity."
+     REFERENCE
+       "[TR-159], Section 5.5.1.13"
+     ::= { gBondPortCapEntry 4 }
+
+
+   gBondPortStatTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table provides overall status information of G.Bond
+       ports, complementing the generic status information from the
+       ifTable of the IF-MIB.  Additional status information about
+       connected BCEs is available from the relevant line MIBs.
+
+       This table contains live data from the equipment.  As such,
+       it is NOT persistent."
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 36]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     ::= { gBondPort 3 }
+
+   gBondPortStatEntry OBJECT-TYPE
+     SYNTAX      GBondPortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port Status table.
+       Each entry represents a G.Bond port indexed by the ifIndex.
+       Note that a G.Bond GBS port runs on top of a single
+       or multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { gBondPortStatTable 1 }
+
+   GBondPortStatEntry ::=
+     SEQUENCE {
+       gBondPortStatOperScheme               IANAgBondScheme,
+       gBondPortStatPeerOperScheme           IANAgBondScheme,
+       gBondPortStatUpDataRate               Gauge32,
+       gBondPortStatDnDataRate               Gauge32,
+       gBondPortStatFltStatus                BITS,
+       gBondPortStatSide                     INTEGER,
+       gBondPortStatNumBCEs                  Unsigned32
+     }
+
+   gBondPortStatOperScheme  OBJECT-TYPE
+     SYNTAX      IANAgBondScheme
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Current operating bonding scheme of a G.Bond port.
+       The possible values are:
+         none(0)       - bonding bypass on a single-BCE G.998.2 GBS
+         g9981(1)      - G.998.1 bonding
+         g9982(2)      - G.998.2 bonding
+         g9983(3)      - G.998.3 bonding
+
+       This object maps to the TR-159 attribute
+       aGroupOperBondScheme."
+     REFERENCE
+       "[TR-159], Section 5.5.1.4"
+     ::= { gBondPortStatEntry 1 }
+
+   gBondPortStatPeerOperScheme  OBJECT-TYPE
+     SYNTAX      IANAgBondScheme
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 37]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     DESCRIPTION
+       "Current operating bonding scheme of a G.Bond port link partner.
+       The possible values are:
+         unknown(0)    - peer cannot be reached due to the link state or
+                         bonding bypass on a single-BCE G.998.2 GBS
+         g9981(1)      - G.998.1 bonding
+         g9982(2)      - G.998.2 bonding
+         g9983(3)      - G.998.3 bonding
+
+       This object maps to the TR-159 attribute
+       aGroupPeerOperBondScheme."
+     REFERENCE
+       "[TR-159], Section 5.5.1.5"
+     ::= { gBondPortStatEntry 2 }
+
+   gBondPortStatUpDataRate  OBJECT-TYPE
+     SYNTAX      Gauge32
+     UNITS       "bps"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A current G.Bond port operational data rate in the upstream
+       direction, in bps.
+       This object represents an estimation of the sum of individual
+       BCE upstream data rates, modified to compensate for
+       fragmentation and encapsulation overhead (e.g., for an
+       Ethernet service, the target data rate of 10 Mbps SHALL allow
+       lossless transmission of full-duplex 10-Mbps Ethernet frame
+       stream with minimal inter-frame gap).
+
+       Note that for symmetrical interfaces, gBondPortStatUpDataRate ==
+       gBondPortStatDnDataRate == ifSpeed.
+
+       This object maps to the TR-159 attribute aGroupUpRate."
+     REFERENCE
+       "[TR-159], Section 5.5.1.15"
+     ::= { gBondPortStatEntry 3 }
+
+   gBondPortStatDnDataRate  OBJECT-TYPE
+     SYNTAX      Gauge32
+     UNITS       "bps"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A current G.Bond port operational data rate in the downstream
+       direction, in bps.
+       This object represents an estimation of the sum of individual
+       BCE downstream data rates, modified to compensate for
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 38]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       fragmentation and encapsulation overhead (e.g., for an
+       Ethernet service, the target data rate of 10 Mbps SHALL allow
+       lossless transmission of full-duplex 10-Mbps Ethernet frame
+       stream with minimal inter-frame gap).
+
+       Note that for symmetrical interfaces, gBondPortStatUpDataRate ==
+       gBondPortStatDnDataRate == ifSpeed.
+
+       This object maps to the TR-159 attribute aGroupDownRate."
+     REFERENCE
+       "[TR-159], Section 5.5.1.16"
+     ::= { gBondPortStatEntry 4 }
+
+
+   gBondPortStatFltStatus  OBJECT-TYPE
+     SYNTAX      BITS {
+       noPeer(0),
+       peerPowerLoss(1),
+       peerBondSchemeMismatch(2),
+       bceSubTypeMismatch(3),
+       lowRate(4),
+       init(5),
+       ready(6)
+     }
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "G.Bond (GBS) port fault status.  This is a bitmap of possible
+       conditions.  The various bit positions are:
+         noPeer                 - Peer GBS cannot be reached (e.g.,
+                                  no BCEs attached, all BCEs are
+                                  'down', etc.).
+         peerPowerLoss          - Peer GBS has indicated impending unit
+                                  failure due to loss of local power
+                                  ('Dying Gasp').
+         peerBondSchemeMismatch - Operating bonding scheme of a peer
+                                  GBS is different from the local one.
+         bceSubTypeMismatch     - Local BCEs in the aggregation group
+                                  are not of the same sub-type, e.g.,
+                                  some BCEs in the local device are -O
+                                  while others are -R subtype.
+         lowRate                - gBondUpRate/gBondDnRate of the port
+                                  has reached or dropped below
+                                  gBondPortConfThreshLowUpRate/
+                                  gBondPortConfThreshLowDnRate.
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 39]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+         init                   - The link is initializing, as a result
+                                  of ifAdminStatus being set to 'up'
+                                  for a particular BCE or a GBS
+                                  to which the BCE is connected.
+         ready                  - At least one BCE in the aggregation
+                                  group is detecting handshake tones.
+
+       This object is intended to supplement the ifOperStatus object
+       in the IF-MIB.
+
+       This object maps to the TR-159 attribute aGroupStatus."
+     REFERENCE
+       "[TR-159], Section 5.5.1.9; RFC 2863, IF-MIB, ifOperStatus"
+     ::= { gBondPortStatEntry 5 }
+
+   gBondPortStatSide  OBJECT-TYPE
+     SYNTAX      INTEGER {
+       subscriber(1),
+       office(2),
+       unknown(3)
+     }
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "G.Bond port mode of operation (subtype).
+       The value of 'subscriber' indicates that the port is
+       designated as '-R' subtype (all BCEs assigned to this port are of
+       subtype '-R').
+       The value of 'office' indicates that the port is designated
+       as '-O' subtype (all BCEs assigned to this port are of
+       subtype '-O').
+       The value of 'unknown' indicates that the port has no assigned
+       BCEs yet or that the assigned BCEs are not of the same side
+       (subTypeBCEMismatch).
+
+       This object maps to the TR-159 attribute aGroupEnd."
+     REFERENCE
+       "[TR-159], Section 5.5.1.11"
+     ::= { gBondPortStatEntry 6 }
+
+   gBondPortStatNumBCEs  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..32)
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Number of BCEs that are currently aggregated by the local GBS
+       (assigned to the G.Bond port using the ifStackTable).
+       This number is never greater than gBondPortCapCapacity.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 40]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object SHALL be automatically incremented or decremented
+       when a BCE is added or deleted to/from the G.Bond port using
+       the ifStackTable.
+
+       This object maps to the TR-159 attribute aGroupNumChannels."
+     REFERENCE
+       "[TR-159], Section 5.5.1.14"
+     ::= { gBondPortStatEntry 7 }
+
+
+   -- Performance Monitoring group
+
+   gBondPortPM   OBJECT IDENTIFIER ::= { gBondPort 4 }
+
+   gBondPortPmCurTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains current Performance Monitoring (PM)
+       information for a GBS port.  This table contains live data from
+       the equipment and as such is NOT persistent."
+     ::= { gBondPortPM 1 }
+
+   gBondPortPmCurEntry OBJECT-TYPE
+     SYNTAX      GBondPortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port PM table.
+       Each entry represents a G.Bond port indexed by the ifIndex.
+       Note that a G.Bond GBS port runs on top of a single
+       or multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { gBondPortPmCurTable 1 }
+
+   GBondPortPmCurEntry ::=
+     SEQUENCE {
+       gBondPortPmCurES                      HCPerfTotalCount,
+       gBondPortPmCurSES                     HCPerfTotalCount,
+       gBondPortPmCurUAS                     HCPerfTotalCount,
+       gBondPortPmCur15MinValidIntervals     HCPerfValidIntervals,
+       gBondPortPmCur15MinInvalidIntervals   HCPerfInvalidIntervals,
+       gBondPortPmCur15MinTimeElapsed        HCPerfTimeElapsed,
+       gBondPortPmCur15MinES                 HCPerfCurrentCount,
+       gBondPortPmCur15MinSES                HCPerfCurrentCount,
+       gBondPortPmCur15MinUAS                HCPerfCurrentCount,
+       gBondPortPmCur1DayValidIntervals      Unsigned32,
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 41]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       gBondPortPmCur1DayInvalidIntervals    Unsigned32,
+       gBondPortPmCur1DayTimeElapsed         HCPerfTimeElapsed,
+       gBondPortPmCur1DayES                  HCPerfCurrentCount,
+       gBondPortPmCur1DaySES                 HCPerfCurrentCount,
+       gBondPortPmCur1DayUAS                 HCPerfCurrentCount
+     }
+
+   gBondPortPmCurES  OBJECT-TYPE
+     SYNTAX      HCPerfTotalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Errored Seconds (ES) on the GBS since the BTU was
+       last restarted.
+
+       An Errored Second for a G.998.x interface is defined as a count
+       of 1-second intervals during which one or more GBS errors are
+       declared.  The errors are specific for each bonding scheme, e.g.,
+         - lost cells for the ATM bonding
+         - lost or discarded (due to an error or a buffer overflow)
+           fragments for the Ethernet bonding
+         - CRC-4, CRC-6, or CRC-8 errors for the TDIM bonding
+       This object is inhibited during Unavailable Seconds (UAS).
+
+       This object maps to the TR-159 attribute aGroupPerfES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.29"
+     ::= { gBondPortPmCurEntry 1 }
+
+   gBondPortPmCurSES  OBJECT-TYPE
+     SYNTAX      HCPerfTotalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Severely Errored Seconds (SES) on the GBS
+       since the BTU was last restarted.
+
+       A Severely Errored Second for a G.998.x interface is defined as
+       a count of 1-second intervals during which GBS errors cause at
+       least 1% traffic loss of the nominal bonded link rate or at
+       least 12 ms for the TDM traffic.  The exact definition is
+       specific for each bonding scheme, e.g.,
+         - 234 lost cells for the ATM bonding with 10-Mbps nominal link
+           rate
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 42]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+         - 60 lost/discarded fragments for the Ethernet bonding with
+           10-Mbps nominal link rate and fixed 192-byte-long fragment
+           size
+         - 6 or more CRC-4 errors, one or more CRC-6 errors, or one or
+           more CRC-8 errors for the TDM bonding
+       This object is inhibited during Unavailable Seconds (UAS).
+
+       This object maps to the TR-159 attribute aGroupPerfSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.30"
+     ::= { gBondPortPmCurEntry 2 }
+
+   gBondPortPmCurUAS  OBJECT-TYPE
+     SYNTAX      HCPerfTotalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Unavailable Seconds (UAS) on the GBS since the BTU
+       was last restarted.
+
+       An Unavailable Second for a G.998.x interface is defined as a
+       count of 1-second intervals during which the bonded link is
+       unavailable.  The G.998.x link becomes unavailable at the onset
+       of 10 contiguous SESs.  The 10 SESs are included in the
+       unavailable time.  Once unavailable, the G.998.x line becomes
+       available at the onset of 10 contiguous seconds with no SESs.
+       The 10 seconds with no SESs are excluded from the unavailable
+       time.
+
+       This object maps to the TR-159 attribute aGroupPerfUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.31"
+     ::= { gBondPortPmCurEntry 3 }
+
+   gBondPortPmCur15MinValidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfValidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of 15-minute intervals for which data was collected.
+       The value of this object will be 96 or the maximum number of
+       15-minute history intervals collected by the implementation,
+       unless the measurement was (re)started recently, in which case
+       the value will be the number of complete 15-minute intervals
+       for which there are at least some data.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 43]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinValidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.32"
+     ::= { gBondPortPmCurEntry 4 }
+
+   gBondPortPmCur15MinInvalidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfInvalidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of 15-minute intervals for which data was not always
+       available.  The value will typically be zero, except in cases
+       where the data for some intervals are not available.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinInvalidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.33"
+     ::= { gBondPortPmCurEntry 5 }
+
+   gBondPortPmCur15MinTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of seconds that have elapsed since the beginning of the
+       current 15-minute performance interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfCurr15MinTimeElapsed."
+     REFERENCE
+       "[TR-159], Section 5.5.1.34"
+     ::= { gBondPortPmCurEntry 6 }
+
+   gBondPortPmCur15MinES  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Errored Seconds (ES) on the GBS in the current
+       15-minute performance interval.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 44]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object maps to the TR-159 attribute aGroupPerfCurr15MinES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.35"
+     ::= { gBondPortPmCurEntry 7 }
+
+   gBondPortPmCur15MinSES  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Severely Errored Seconds (SES) on the GBS in the
+       current 15-minute performance interval.
+
+       This object maps to the TR-159 attribute aGroupPerfCurr15MinSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.36"
+     ::= { gBondPortPmCurEntry 8 }
+
+   gBondPortPmCur15MinUAS  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Unavailable Seconds (UAS) on the GBS in the current
+       15-minute performance interval.
+
+       This object maps to the TR-159 attribute aGroupPerfCurr15MinUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.37"
+     ::= { gBondPortPmCurEntry 9 }
+
+   gBondPortPmCur1DayValidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of 1-day intervals for which data was collected.
+       The value of this object will be 7 or the maximum number of
+       1-day history intervals collected by the implementation, unless
+       the measurement was (re)started recently, in which case the
+       value will be the number of complete 1-day intervals for which
+       there are at least some data.
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 45]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayValidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.45"
+     ::= { gBondPortPmCurEntry 10 }
+
+   gBondPortPmCur1DayInvalidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of 1-day intervals for which data was not always
+       available.  The value will typically be zero, except in cases
+       where the data for some intervals are not available.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayInvalidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.46"
+     ::= { gBondPortPmCurEntry 11 }
+
+   gBondPortPmCur1DayTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of seconds that have elapsed since the beginning of
+       the current 1-day performance interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfCurr1DayTimeElapsed."
+     REFERENCE
+       "[TR-159], Section 5.5.1.47"
+     ::= { gBondPortPmCurEntry 12 }
+
+   gBondPortPmCur1DayES  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Errored Seconds (ES) on the GBS in the current 1-day
+       performance interval.
+
+       This object maps to the TR-159 attribute aGroupPerfCurr1DayES."
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 46]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.1.48"
+     ::= { gBondPortPmCurEntry 13 }
+
+   gBondPortPmCur1DaySES  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Severely Errored Seconds (SES) on the GBS in the
+       current 1-day performance interval.
+
+       This object maps to the TR-159 attribute aGroupPerfCurr1DaySES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.49"
+     ::= { gBondPortPmCurEntry 14 }
+
+   gBondPortPmCur1DayUAS  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Unavailable Seconds (UAS) on the GBS in the current
+       1-day performance interval.
+
+       This object maps to the TR-159 attribute aGroupPerfCurr1DayUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.50"
+     ::= { gBondPortPmCurEntry 15 }
+
+   -- PM history: 15-min buckets
+
+   gBondPortPm15MinTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortPm15MinEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 15-minute buckets of Performance
+       Monitoring information for a GBS port (a row for each 15-minute
+       interval, up to 96 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { gBondPortPM 2 }
+
+   gBondPortPm15MinEntry OBJECT-TYPE
+     SYNTAX      GBondPortPm15MinEntry
+     MAX-ACCESS  not-accessible
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 47]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port historical 15-minute PM table.
+       Each entry represents Performance Monitoring data for a GBS port,
+       indexed by the ifIndex, collected during a particular 15-minute
+       interval, indexed by the gBondPortPm15MinIntervalIndex."
+     INDEX  { ifIndex, gBondPortPm15MinIntervalIndex }
+     ::= { gBondPortPm15MinTable 1 }
+
+   GBondPortPm15MinEntry ::=
+     SEQUENCE {
+       gBondPortPm15MinIntervalIndex         Unsigned32,
+       gBondPortPm15MinIntervalMoniTime      HCPerfTimeElapsed,
+       gBondPortPm15MinIntervalES            HCPerfIntervalCount,
+       gBondPortPm15MinIntervalSES           HCPerfIntervalCount,
+       gBondPortPm15MinIntervalUAS           HCPerfIntervalCount,
+       gBondPortPm15MinIntervalValid         TruthValue
+     }
+
+   gBondPortPm15MinIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..96)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance data interval number.  1 is the most recent
+       previous interval; interval 96 is 24 hours ago.
+       Intervals 2..96 are OPTIONAL.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinIntervalNumber."
+     REFERENCE
+       "[TR-159], Section 5.5.1.57"
+     ::= { gBondPortPm15MinEntry 1 }
+
+   gBondPortPm15MinIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of seconds over which the performance data was actually
+       monitored.  This value will be the same as the interval duration
+       (900 seconds), except in a situation where performance data
+       could not be collected for any reason."
+     ::= { gBondPortPm15MinEntry 2 }
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 48]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   gBondPortPm15MinIntervalES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Errored Seconds (ES) on the GBS in the 15-minute
+       performance history interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinIntervalES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.59"
+     ::= { gBondPortPm15MinEntry 3 }
+
+   gBondPortPm15MinIntervalSES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Severely Errored Seconds (SES) on the GBS in the
+       15-minute performance history interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinIntervalSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.60"
+     ::= { gBondPortPm15MinEntry 4 }
+
+   gBondPortPm15MinIntervalUAS  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Unavailable Seconds (UAS) on the GBS in the current
+       15-minute performance interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinIntervalUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.61"
+     ::= { gBondPortPm15MinEntry 5 }
+
+   gBondPortPm15MinIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 49]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU-C MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf15MinIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.58"
+     ::= { gBondPortPm15MinEntry 6 }
+
+   -- PM history: 1-day buckets
+
+   gBondPortPm1DayTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 1-day buckets of Performance
+       Monitoring information for a GBS port (a row for each 1-day
+       interval, up to 7 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { gBondPortPM 3 }
+
+   gBondPortPm1DayEntry OBJECT-TYPE
+     SYNTAX      GBondPortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond Port historical 1-day PM table.
+       Each entry represents Performance Monitoring data for a GBS port,
+       indexed by the ifIndex, collected during a particular 1-day
+       interval, indexed by the gBondPortPm1DayIntervalIndex."
+     INDEX  { ifIndex, gBondPortPm1DayIntervalIndex }
+     ::= { gBondPortPm1DayTable 1 }
+
+   GBondPortPm1DayEntry ::=
+     SEQUENCE {
+       gBondPortPm1DayIntervalIndex          Unsigned32,
+       gBondPortPm1DayIntervalMoniTime       HCPerfTimeElapsed,
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 50]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       gBondPortPm1DayIntervalES             HCPerfIntervalCount,
+       gBondPortPm1DayIntervalSES            HCPerfIntervalCount,
+       gBondPortPm1DayIntervalUAS            HCPerfIntervalCount,
+       gBondPortPm1DayIntervalValid          TruthValue
+     }
+
+   gBondPortPm1DayIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..7)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance data interval number.  1 is the most recent
+       previous interval; interval 7 is 7 days ago.
+       Intervals 2..7 are OPTIONAL.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalNumber."
+     REFERENCE
+       "[TR-159], Section 5.5.1.62"
+     ::= { gBondPortPm1DayEntry 1 }
+
+   gBondPortPm1DayIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of seconds over which the performance data was actually
+       monitored.  This value will be the same as the interval duration
+       (86400 seconds), except in a situation where performance data
+       could not be collected for any reason.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalMoniSecs."
+     REFERENCE
+       "[TR-159], Section 5.5.1.64"
+     ::= { gBondPortPm1DayEntry 2 }
+
+   gBondPortPm1DayIntervalES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Errored Seconds (ES) on the GBS in the 1-day
+       performance history interval.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 51]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.65"
+     ::= { gBondPortPm1DayEntry 3 }
+
+   gBondPortPm1DayIntervalSES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Severely Errored Seconds (SES) on the GBS in the
+       1-day performance history interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.66"
+     ::= { gBondPortPm1DayEntry 4 }
+
+   gBondPortPm1DayIntervalUAS  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of Unavailable Seconds (UAS) on the GBS in the current
+       1-day performance interval.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.67"
+     ::= { gBondPortPm1DayEntry 5 }
+
+   gBondPortPm1DayIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU-C MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 52]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object maps to the TR-159 attribute
+       aGroupPerf1DayIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.63"
+     ::= { gBondPortPm1DayEntry 6 }
+
+
+   -- Performance Monitoring TCA Configuration profile
+
+   gBondPortPmTcaProfileTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondPortPmTcaProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table supports definitions of Performance Monitoring (PM)
+       Threshold Crossing Alert (TCA) configuration profiles for GBS
+       ports.
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { gBondPortPM 4 }
+
+   gBondPortPmTcaProfileEntry OBJECT-TYPE
+     SYNTAX      GBondPortPmTcaProfileEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the GBS PM TCA Configuration table.
+       Each entry corresponds to a single TCA configuration profile.
+       Each profile contains a set of parameters for setting alarm
+       thresholds for various performance attributes monitored at GBS
+       ports.  Profiles may be created/deleted using the row
+       creation/deletion mechanism via
+       gBondPortPmTcaProfileRowStatus.  If an active entry is
+       referenced via gBondPortConfPmTcaConfProfile, the entry MUST
+       remain active until all references are removed.
+       A default profile with an index of 'DEFVAL' will always exist,
+       and its parameters will be set to vendor-specific values
+       unless otherwise specified in this document."
+     INDEX  { gBondPortPmTcaProfileName }
+     ::= { gBondPortPmTcaProfileTable 1 }
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 53]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   GBondPortPmTcaProfileEntry ::=
+     SEQUENCE {
+       gBondPortPmTcaProfileName           SnmpAdminString,
+       gBondPortPmTcaProfileThresh15MinES  HCPerfIntervalThreshold,
+       gBondPortPmTcaProfileThresh15MinSES HCPerfIntervalThreshold,
+       gBondPortPmTcaProfileThresh15MinUAS HCPerfIntervalThreshold,
+       gBondPortPmTcaProfileThresh1DayES   GBondPm1DayIntervalThreshold,
+       gBondPortPmTcaProfileThresh1DaySES  GBondPm1DayIntervalThreshold,
+       gBondPortPmTcaProfileThresh1DayUAS  GBondPm1DayIntervalThreshold,
+       gBondPortPmTcaProfileRowStatus      RowStatus
+     }
+
+   gBondPortPmTcaProfileName  OBJECT-TYPE
+     SYNTAX      SnmpAdminString (SIZE (1..32))
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This object is a unique index (name) associated with this
+       GBS PM TCA profile."
+     ::= { gBondPortPmTcaProfileEntry 1 }
+
+   gBondPortPmTcaProfileThresh15MinES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "A desired threshold for the number of Errored Seconds (ES)
+       within any given 15-minute performance data collection interval.
+       If the number of ESs in a particular 15-minute collection
+       interval reaches or exceeds this value, a
+       gBondPmTca15MinESCrossing notification MAY be generated if
+       enabled by gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca15MinESCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold15MinES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.39"
+     ::= { gBondPortPmTcaProfileEntry 2 }
+
+   gBondPortPmTcaProfileThresh15MinSES  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 54]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     DESCRIPTION
+       "A desired threshold for the number of Severely Errored Seconds
+       (SES) within any given 15-minute performance data collection
+       interval.
+       If the number of SESs in a particular 15-minute collection
+       interval reaches or exceeds this value, a
+       gBondPmTca15MinSESCrossing notification MAY be generated if
+       enabled by gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca15MinSESCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold15MinSES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.40"
+     ::= { gBondPortPmTcaProfileEntry 3 }
+
+   gBondPortPmTcaProfileThresh15MinUAS  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "A desired threshold for the number of Unavailable Seconds (UAS)
+       within any given 15-minute performance data collection interval.
+       If the number of UASs in a particular 15-minute collection
+       interval reaches or exceeds this value, a
+       gBondPmTca15MinUASCrossing notification MAY be generated if
+       enabled by gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca15MinUASCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold15MinUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.41"
+     ::= { gBondPortPmTcaProfileEntry 4 }
+
+   gBondPortPmTcaProfileThresh1DayES  OBJECT-TYPE
+     SYNTAX      GBondPm1DayIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "A desired threshold for the number of Errored Seconds (ES)
+       within any given 1-day performance data collection interval.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 55]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       If the number of ESs in a particular 1-day collection interval
+       reaches or exceeds this value, a gBondPmTca1DayESCrossing
+       notification MAY be generated if enabled by
+       gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca1DayESCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold1DayES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.51"
+     ::= { gBondPortPmTcaProfileEntry 5 }
+
+   gBondPortPmTcaProfileThresh1DaySES  OBJECT-TYPE
+     SYNTAX      GBondPm1DayIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "A desired threshold for the number of Severely Errored Seconds
+       (SES) within any given 1-day performance data collection
+       interval.
+       If the number of SESs in a particular 1-day collection interval
+       reaches or exceeds this value, a gBondPmTca1DaySESCrossing
+       notification MAY be generated if enabled by
+       gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca1DaySESCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold1DaySES."
+     REFERENCE
+       "[TR-159], Section 5.5.1.52"
+     ::= { gBondPortPmTcaProfileEntry 6 }
+
+   gBondPortPmTcaProfileThresh1DayUAS  OBJECT-TYPE
+     SYNTAX      GBondPm1DayIntervalThreshold
+     UNITS       "seconds"
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "A desired threshold for the number of Unavailable Seconds (UAS)
+       within any given 1-day performance data collection interval.
+       If the number of UASs in a particular 1-day collection interval
+       reaches or exceeds this value, a gBondPmTca1DayUASCrossing
+       notification MAY be generated if enabled by
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 56]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       gBondPortConfPmTcaEnable.
+       At most one notification can be sent per interval.
+       Setting this attribute to zero (default) effectively disables
+       the gBondPmTca1DayUASCrossing notification.
+
+       This object maps to the TR-159 attribute
+       aGroupPerfThreshold1DayUAS."
+     REFERENCE
+       "[TR-159], Section 5.5.1.53"
+     ::= { gBondPortPmTcaProfileEntry 7 }
+
+   gBondPortPmTcaProfileRowStatus  OBJECT-TYPE
+     SYNTAX      RowStatus
+     MAX-ACCESS  read-create
+     STATUS      current
+     DESCRIPTION
+       "This object controls the creation, modification, or deletion
+       of the associated entry in the gBondPortPmTcaProfileTable
+       per the semantics of RowStatus.
+
+       If an 'active' entry is referenced via
+       gBondPortConfPmTcaConfProfile instance(s), the entry MUST
+       remain 'active'.
+
+       An 'active' entry SHALL NOT be modified.  In order to modify an
+       existing entry, it MUST be taken out of service (by setting
+       this object to 'notInService'), modified, and set to 'active'
+       again."
+     ::= { gBondPortPmTcaProfileEntry 8 }
+
+
+   -- The BCE group
+
+   gBondBceConfTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF GBondBceConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for configuration of G.Bond common aspects for the
+       Bonding Channel Entity (BCE) ports (modems/channels).
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { gBondBce 1 }
+
+   gBondBceConfEntry OBJECT-TYPE
+     SYNTAX      GBondBceConfEntry
+     MAX-ACCESS  not-accessible
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 57]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond BCE Configuration table.
+       Each entry represents common aspects of a G.Bond BCE port
+       indexed by the ifIndex.  Note that a G.Bond BCE port can be
+       stacked below a single GBS port, also indexed by the ifIndex,
+       possibly together with other BCE ports if bonding is enabled."
+     INDEX  { ifIndex }
+     ::= { gBondBceConfTable 1 }
+
+   GBondBceConfEntry ::=
+     SEQUENCE {
+       gBondBceConfRemoteDiscoveryCode    PhysAddress
+     }
+
+   gBondBceConfRemoteDiscoveryCode  OBJECT-TYPE
+     SYNTAX      PhysAddress (SIZE (0|6))
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "A remote discovery code of the BCE port at the CO.
+       A 6-octet-long discovery code of the peer GBS connected via
+       the BCE.
+       Reading this object results in a Discovery Get operation.
+       Setting this object to all zeroes results in a Discovery
+       Clear_if_Same operation (the value of gBondPortConfDiscoveryCode
+       at the peer GBS SHALL be the same as gBondPortConfDiscoveryCode
+       of the local GBS associated with the BCE for the operation to
+       succeed).
+       Writing a non-zero value to this object results in a
+       Discovery Set_if_Clear operation.
+       A zero-length octet string SHALL be returned on an attempt to
+       read this object when bonding is not enabled.
+
+       This object is irrelevant in BCE-R port subtypes (CPE side):
+       in this case, a zero-length octet string SHALL be returned on
+       an attempt to read this object.  An attempt to change this
+       object MUST be rejected (in the case of SNMP, with the error
+       inconsistentValue).
+
+       Discovery MUST be performed when the link is 'down'.
+       Attempts to change this object MUST be rejected (in the case of
+       SNMP, with the error inconsistentValue), If the link is 'up' or
+       initializing.
+
+       This object maps to the TR-159 attribute
+       aLineRemoteDiscoveryCode."
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 58]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.6.7"
+     ::= { gBondBceConfEntry 1 }
+
+  --
+  -- Conformance Statements
+  --
+
+   gBondGroups      OBJECT IDENTIFIER ::= { gBondConformance 1 }
+
+   gBondCompliances OBJECT IDENTIFIER ::= { gBondConformance 2 }
+
+   -- Object Groups
+
+   gBondBasicGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortStatOperScheme,
+       gBondPortStatUpDataRate,
+       gBondPortStatDnDataRate,
+       gBondPortConfTargetUpDataRate,
+       gBondPortConfTargetDnDataRate,
+       gBondPortCapSchemesSupported,
+       gBondPortCapCapacity,
+       gBondPortStatNumBCEs,
+       gBondPortStatSide,
+       gBondPortStatFltStatus
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects representing management information
+       common to all types of G.Bond ports."
+     ::= { gBondGroups 1 }
+
+   gBondDiscoveryGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortStatPeerOperScheme,
+       gBondPortCapPeerSchemesSupported,
+       gBondPortCapPeerCapacity,
+       gBondPortConfDiscoveryCode,
+       gBondBceConfRemoteDiscoveryCode
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL G.Bond discovery
+       in G.Bond ports."
+     ::= { gBondGroups 2 }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 59]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   gBondMultiSchemeGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortConfAdminScheme,
+       gBondPortConfPeerAdminScheme
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects providing OPTIONAL management
+       information for G.Bond ports supporting multiple bonding
+       schemes."
+     ::= { gBondGroups 3 }
+
+   gBondTcaConfGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortConfThreshLowUpRate,
+       gBondPortConfThreshLowDnRate,
+       gBondPortConfLowRateCrossingEnable
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects required for configuration of alarm
+       thresholds and notifications in G.Bond ports."
+     ::= { gBondGroups 4 }
+
+   gBondTcaNotificationGroup NOTIFICATION-GROUP
+     NOTIFICATIONS {
+       gBondLowUpRateCrossing,
+       gBondLowDnRateCrossing
+     }
+     STATUS      current
+     DESCRIPTION
+       "This group supports notifications of significant conditions
+       (non-PM threshold crossing alerts) associated with G.Bond ports."
+     ::= { gBondGroups 5 }
+
+   gBondPmCurGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortPmCurES,
+       gBondPortPmCurSES,
+       gBondPortPmCurUAS,
+       gBondPortPmCur15MinValidIntervals,
+       gBondPortPmCur15MinInvalidIntervals,
+       gBondPortPmCur15MinTimeElapsed,
+       gBondPortPmCur15MinES,
+       gBondPortPmCur15MinSES,
+       gBondPortPmCur15MinUAS,
+       gBondPortPmCur1DayValidIntervals,
+       gBondPortPmCur1DayInvalidIntervals,
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 60]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       gBondPortPmCur1DayTimeElapsed,
+       gBondPortPmCur1DayES,
+       gBondPortPmCur1DaySES,
+       gBondPortPmCur1DayUAS
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL current Performance
+       Monitoring information for G.Bond ports."
+     ::= { gBondGroups 6 }
+
+   gBondPm15MinGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortPm15MinIntervalMoniTime,
+       gBondPortPm15MinIntervalES,
+       gBondPortPm15MinIntervalSES,
+       gBondPortPm15MinIntervalUAS,
+       gBondPortPm15MinIntervalValid
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond ports, during
+       previous 15-minute intervals."
+     ::= { gBondGroups 7 }
+
+   gBondPm1DayGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortPm1DayIntervalMoniTime,
+       gBondPortPm1DayIntervalES,
+       gBondPortPm1DayIntervalSES,
+       gBondPortPm1DayIntervalUAS,
+       gBondPortPm1DayIntervalValid
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond ports, during
+       previous 1-day intervals."
+     ::= { gBondGroups 8 }
+
+   gBondPmTcaConfGroup OBJECT-GROUP
+     OBJECTS {
+       gBondPortConfPmTcaConfProfile,
+       gBondPortConfPmTcaEnable,
+       gBondPortPmTcaProfileThresh15MinES,
+       gBondPortPmTcaProfileThresh15MinSES,
+       gBondPortPmTcaProfileThresh15MinUAS,
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 61]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+       gBondPortPmTcaProfileThresh1DayES,
+       gBondPortPmTcaProfileThresh1DaySES,
+       gBondPortPmTcaProfileThresh1DayUAS,
+       gBondPortPmTcaProfileRowStatus
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects required for configuration of
+       Performance Monitoring Threshold Crossing Alert notifications
+       in G.Bond ports."
+     ::= { gBondGroups 9 }
+
+   gBondPmTcaNotificationGroup NOTIFICATION-GROUP
+     NOTIFICATIONS {
+       gBondPmTca15MinESCrossing,
+       gBondPmTca15MinSESCrossing,
+       gBondPmTca15MinUASCrossing,
+       gBondPmTca1DayESCrossing,
+       gBondPmTca1DaySESCrossing,
+       gBondPmTca1DayUASCrossing
+     }
+     STATUS      current
+     DESCRIPTION
+       "This group supports notifications of Performance Monitoring
+       Threshold Crossing Alerts associated with G.Bond ports."
+     ::= { gBondGroups 10 }
+
+  -- Compliance Statements
+
+   gBondCompliance MODULE-COMPLIANCE
+     STATUS      current
+     DESCRIPTION
+       "The compliance statement for G.Bond interfaces.
+       Compliance with the following external compliance statements
+       is REQUIRED:
+
+       MIB Module             Compliance Statement
+       ----------             --------------------
+       IF-MIB                 ifCompliance3
+
+       Compliance with the following external compliance statements
+       is OPTIONAL for implementations supporting bonding with
+       flexible cross-connect between the GBS and BCE ports:
+
+       MIB Module             Compliance Statement
+       ----------             --------------------
+       IF-INVERTED-STACK-MIB  ifInvCompliance
+       IF-CAP-STACK-MIB       ifCapStackCompliance"
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 62]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     MODULE  -- this module
+       MANDATORY-GROUPS {
+         gBondBasicGroup,
+         gBondTcaConfGroup,
+         gBondTcaNotificationGroup
+       }
+
+       GROUP       gBondDiscoveryGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting the G.Bond Discovery function."
+
+       GROUP       gBondMultiSchemeGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting multiple bonding schemes."
+
+       GROUP       gBondPmCurGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting Performance Monitoring."
+
+       GROUP       gBondPm15MinGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting 15-minute historical Performance Monitoring."
+
+       GROUP       gBondPm1DayGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting 1-day historical Performance Monitoring."
+
+       GROUP       gBondPmTcaConfGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting Performance Monitoring Threshold Crossing Alert
+         notifications."
+
+       GROUP       gBondPmTcaNotificationGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting Performance Monitoring Threshold Crossing Alert
+         notifications."
+
+       OBJECT      gBondPortCapSchemesSupported
+       SYNTAX      IANAgBondSchemeList
+       DESCRIPTION
+         "Support for all bonding scheme types is not required.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 63]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+         However, at least one value SHALL be supported."
+
+       OBJECT      gBondPortCapPeerSchemesSupported
+       SYNTAX      IANAgBondSchemeList
+       DESCRIPTION
+         "Support for all bonding scheme types is not required.
+         However, at least one value SHALL be supported."
+
+     ::= { gBondCompliances 1 }
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 64]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+7.  IANA-Maintained G.Bond TC Definitions
+
+   The IANA-GBOND-TC-MIB module IMPORTS objects from SNMPv2-SMI
+   [RFC2578] and SNMPv2-TC [RFC2579].
+
+IANA-GBOND-TC-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+    MODULE-IDENTITY,
+    mib-2
+      FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION
+      FROM SNMPv2-TC
+    ;
+------------------------------------------------------------------------
+  ianaGBondTcMIB MODULE-IDENTITY
+    LAST-UPDATED "201302200000Z"  -- 20 February 2013
+    ORGANIZATION "IANA"
+    CONTACT-INFO "        Internet Assigned Numbers Authority
+
+                  Postal: ICANN
+                          12025 Waterfront Drive, Suite 300
+                          Los Angeles, CA 90094-2536
+
+                     Tel: +1-310-301-5800
+                   EMail: iana@iana.org"
+
+    DESCRIPTION
+      "This MIB module defines IANAgBondScheme and IANAgBondSchemeList
+      TEXTUAL-CONVENTIONs, specifying enumerated values of the
+      gBondPortConfAdminScheme, gBondPortConfPeerAdminScheme,
+      gBondPortStatOperScheme, gBondPortStatPeerOperScheme,
+      gBondPortCapSchemesSupported, and gBondPortCapPeerSchemesSupported
+      objects, respectively, as defined in the GBOND-MIB.
+
+      It is intended that each new bonding scheme defined by the
+      ITU-T Q4/SG15 working group and approved for publication in a
+      revision of the ITU-T G.998 specification will be added to this
+      MIB module, provided that it is suitable for being managed by the
+      base objects in the GBOND-MIB.  An Expert Review, as defined in
+      RFC 5226, is REQUIRED for such additions.
+
+      The following references are used throughout this MIB module:
+
+      [G.998.1] refers to:
+        ITU-T Recommendation G.998.1: 'ATM-based multi-pair bonding',
+        January 2005.
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 65]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+      [G.998.2] refers to:
+        ITU-T Recommendation G.998.2: 'Ethernet-based multi-pair
+        bonding', January 2005.
+
+      [G.998.3] refers to:
+        ITU-T Recommendation G.998.3: 'Multi-pair bonding using
+        time-division inverse multiplexing', January 2005.
+
+      Naming Conventions:
+        BCE   - Bonding Channel Entity
+        GBS   - Generic Bonding Sub-layer
+
+      These references should be updated as appropriate when a new
+      bonding scheme is added to this MIB module.
+
+      Copyright (c) 2013 IETF Trust and the persons identified as
+      authors of the code.  All rights reserved.
+
+      Redistribution and use in source and binary forms, with or without
+      modification, is permitted pursuant to, and subject to the license
+      terms contained in, the Simplified BSD License set forth in
+      Section 4.c of the IETF Trust's Legal Provisions Relating to IETF
+      Documents (http://trustee.ietf.org/license-info)."
+
+    REVISION    "201302200000Z"  -- 20 February 2013
+    DESCRIPTION "Initial version, published as RFC 6765."
+
+    ::= { mib-2 215 }
+
+   -- Textual Conventions
+
+   IANAgBondSchemeList ::= TEXTUAL-CONVENTION
+     STATUS      current
+     DESCRIPTION
+       "This textual convention defines a bitmap of possible ITU-T
+       G.998 (G.Bond) bonding schemes.  Currently, the following values
+       are defined for the corresponding bonding schemes:
+         g9981(1) - G.998.1 (G.Bond/ATM; see the G9981-MIB)
+         g9982(2) - G.998.2 (G.Bond/Ethernet; see the G9982-MIB)
+         g9983(3) - G.998.3 (G.Bond/TDIM; see the G9983-MIB)
+       An additional value of none(0) can be returned as a result
+       of a GET operation when a value of the object cannot be
+       determined (for example, a peer GBS cannot be reached), the port
+       does not support any kind of bonding, or when a single-BCE
+       G.998.2 GBS supports bonding (frame fragmentation/reassembly)
+       bypass."
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 66]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+     SYNTAX      BITS {
+       none(0),
+       g9981(1),
+       g9982(2),
+       g9983(3)
+     }
+
+   IANAgBondScheme ::= TEXTUAL-CONVENTION
+     STATUS      current
+     DESCRIPTION
+       "This textual convention defines ITU-T G.998 bonding scheme
+       values.  Possible values are:
+         none(0)    - no bonding (e.g., on a single-BCE G.998.2 GBS)
+                      or unknown
+         g9981(1)   - G.998.1 (G.Bond/ATM)
+         g9982(2)   - G.998.2 (G.Bond/Ethernet)
+         g9983(3)   - G.998.3 (G.Bond/TDIM)"
+     SYNTAX      INTEGER {
+       none(0),
+       g9981(1),
+       g9982(2),
+       g9983(3)
+     }
+
+END
+
+8.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  Changing of the gBondPortConfAdminScheme object may lead to a
+      potential locking of the link, if the peer device does not support
+      the desired bonding scheme.
+
+   o  Changing of the gBondPortConfDiscoveryCode object, before the
+      discovery operation, may lead to a wrongful discovery -- for
+      example, when two CO ports are connected to the same multi-channel
+      RT port, while both CO ports have the same discovery register
+      value.
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 67]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   o  Changing of the target upstream/downstream data rate via
+      gBondPortConfTargetUpDataRate/gBondPortConfTargetDnDataRate may
+      lead to anything from degradation of link quality and data rate to
+      a complete link initialization failure, as the ability of a G.Bond
+      port to support a particular configuration depends on the copper
+      environment.
+
+   o  Activation of a specific line/channel may cause a severe
+      degradation of service for another G.Bond port, whose channel(s)
+      may be affected by the cross-talk from the newly activated
+      channel.
+
+   o  Removal of a channel from an operationally 'up' G.Bond port,
+      aggregating several channels, may cause degradation of the port's
+      data rate.
+
+   Some of the readable objects in this MIB module (i.e., those with
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments since, collectively, they
+   provide information about the performance of network interfaces and
+   can reveal some aspects of their configuration.
+
+   In particular, since a bonded xDSL port can be comprised of multiple
+   Unshielded Twisted Pair (UTP) voice-grade copper, located in the same
+   bundle with other pairs belonging to another operator/customer, it is
+   theoretically possible to eavesdrop on a G.Bond transmission, simply
+   by "listening" to cross-talk from the bonded pairs, especially if the
+   operating parameters of the G.Bond link in question are known.
+
+   It is thus important to control even GET and/or NOTIFY access to
+   these objects and possibly to even encrypt the values of these
+   objects when sending them over the network via SNMP.  These are the
+   tables and objects and their sensitivity/vulnerability:
+
+   o  gBondPortStatTable - objects in this table provide status
+      information for the G.Bond port, which may aid in identification
+      of the pairs belonging to the bonded port and eavesdropping on the
+      traffic over that port.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 68]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  IANA Considerations
+
+   Three new values of IANAifType -- g9981(263), g9982(264), and
+   g9983(265) -- have been allocated by IANA <http://www.iana.org/> in
+   the IANAifType-MIB module [IANAifType-MIB].
+
+   An object identifier for gBondMIB MODULE-IDENTITY has been allocated
+   by IANA in the MIB-2 transmission sub-tree (211).
+
+   This document defines the first version of the IANA-maintained IANA-
+   GBOND-TC-MIB module.  It is intended that each new G.998 bonding
+   scheme defined by the ITU-T Q4/SG15 working group and approved for
+   publication in a revision of ITU-T G.998.x will be added to the IANA-
+   maintained MIB module, provided that it is suitable for being managed
+   by the base objects in the GBOND-MIB module.  An object identifier
+   for ianaGBondTcMIB MODULE-IDENTITY has been allocated by IANA in the
+   MIB-2 transmission sub-tree (215).
+
+   For each new bonding scheme added, a short description of the bonding
+   protocol and, wherever possible, a reference to a publicly available
+   specification SHOULD be specified.  An Expert Review, as defined in
+   [RFC5226], is REQUIRED for each modification.
+
+10.  Acknowledgments
+
+   This document was produced by the [ADSLMIB] working group.
+
+   Special thanks to Dan Romascanu for his meticulous review of this
+   text.
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 69]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3411]  Harrington, D., Presuhn, R., and B. Wijnen, "An
+              Architecture for Describing Simple Network Management
+              Protocol (SNMP) Management Frameworks", STD 62, RFC 3411,
+              December 2002.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3705]  Ray, B. and R. Abbi, "High Capacity Textual Conventions
+              for MIB Modules Using Performance History Based on 15
+              Minute Intervals", RFC 3705, February 2004.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)",
+              RFC 5591, June 2009.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 70]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+   [TR-159]   Beili, E. and M. Morgenstern, "Management Framework for
+              xDSL Bonding", Broadband Forum Technical Report TR-159,
+              December 2008, <http://www.broadband-forum.org/technical/
+              download/TR-159.pdf>.
+
+11.2.  Informative References
+
+   [802.3]    IEEE, "IEEE Standard for Information technology -
+              Telecommunications and information exchange between
+              systems - Local and metropolitan area networks - Specific
+              requirements - Part 3: Carrier Sense Multiple Access with
+              Collision Detection (CSMA/CD) Access Method and Physical
+              Layer Specifications", IEEE Std 802.3-2005, December 2005.
+
+   [ADSLMIB]  IETF, "ADSL MIB (adslmib) Charter",
+              <http://datatracker.ietf.org/wg/adslmib/charter/>.
+
+   [AF-PHY-0086]
+              ATM Forum, "Inverse Multiplexing for ATM (IMA)
+              Specification Version 1.1", ATM Forum specification af-
+              phy-0086.001, March 1999, <http://www.broadband-forum.org/
+              ftp/pub/approved-specs/af-phy-0086.001.pdf>.
+
+   [G.994.1]  ITU-T, "Handshake procedures for digital subscriber line
+              (DSL) transceivers", ITU-T Recommendation G.994.1,
+              June 2012, <http://www.itu.int/rec/T-REC-G.994.1/en>.
+
+   [G.998.1]  ITU-T, "ATM-based multi-pair bonding", ITU-T
+              Recommendation G.998.1, January 2005,
+              <http://www.itu.int/rec/T-REC-G.998.1/en>.
+
+   [G.998.2]  ITU-T, "Ethernet-based multi-pair bonding", ITU-T
+              Recommendation G.998.2, January 2005,
+              <http://www.itu.int/rec/T-REC-G.998.2/en>.
+
+   [G.998.3]  ITU-T, "Multi-pair bonding using time-division inverse
+              multiplexing", ITU-T Recommendation G.998.3, January 2005,
+              <http://www.itu.int/rec/T-REC-G.998.3/en>.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 71]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   [IANAifType-MIB]
+              Internet Assigned Numbers Authority (IANA), "IANAifType
+              Textual Convention definition",
+              <http://www.iana.org/assignments/ianaiftype-mib>.
+
+   [RFC2790]  Waldbusser, S. and P. Grillo, "Host Resources MIB",
+              RFC 2790, March 2000.
+
+   [RFC2864]  McCloghrie, K. and G. Hanson, "The Inverted Stack Table
+              Extension to the Interfaces Group MIB", RFC 2864,
+              June 2000.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3440]  Ly, F. and G. Bathrick, "Definitions of Extension Managed
+              Objects for Asymmetric Digital Subscriber Lines",
+              RFC 3440, December 2002.
+
+   [RFC3593]  Tesink, K., "Textual Conventions for MIB Modules Using
+              Performance History Based on 15 Minute Intervals",
+              RFC 3593, September 2003.
+
+   [RFC3728]  Ray, B. and R. Abbi, "Definitions of Managed Objects for
+              Very High Speed Digital Subscriber Lines (VDSL)",
+              RFC 3728, February 2004.
+
+   [RFC4181]  Heard, C., "Guidelines for Authors and Reviewers of MIB
+              Documents", BCP 111, RFC 4181, September 2005.
+
+   [RFC4319]  Sikes, C., Ray, B., and R. Abbi, "Definitions of Managed
+              Objects for High Bit-Rate DSL - 2nd generation (HDSL2) and
+              Single-Pair High-Speed Digital Subscriber Line (SHDSL)
+              Lines", RFC 4319, December 2005.
+
+   [RFC4706]  Morgenstern, M., Dodge, M., Baillie, S., and U. Bonollo,
+              "Definitions of Managed Objects for Asymmetric Digital
+              Subscriber Line 2 (ADSL2)", RFC 4706, November 2006.
+
+   [RFC5066]  Beili, E., "Ethernet in the First Mile Copper (EFMCu)
+              Interfaces MIB", RFC 5066, November 2007.
+
+   [RFC5650]  Morgenstern, M., Baillie, S., and U. Bonollo, "Definitions
+              of Managed Objects for Very High Speed Digital Subscriber
+              Line 2 (VDSL2)", RFC 5650, September 2009.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 72]
+
+RFC 6765                       G.Bond MIB                  February 2013
+
+
+   [RFC5905]  Mills, D., Martin, J., Burbank, J., and W. Kasch, "Network
+              Time Protocol Version 4: Protocol and Algorithms
+              Specification", RFC 5905, June 2010.
+
+   [RFC6766]  Beili, E., "xDSL Multi-Pair Bonding Using Time-Division
+              Inverse Multiplexing (G.Bond/TDIM) MIB", RFC 6766,
+              February 2013.
+
+   [RFC6767]  Beili, E. and M. Morgenstern, "Ethernet-Based xDSL Multi-
+              Pair Bonding (G.Bond/Ethernet) MIB", RFC 6767,
+              February 2013.
+
+   [RFC6768]  Beili, E., "ATM-Based xDSL Bonded Interfaces MIB",
+              RFC 6768, February 2013.
+
+Authors' Addresses
+
+   Edward Beili
+   Actelis Networks
+   25 Bazel St.
+   Petach-Tikva  49103
+   Israel
+
+   Phone: +972-3-924-3491
+   EMail: edward.beili@actelis.com
+
+
+   Moti Morgenstern
+   ECI Telecom
+   30 Hasivim St.
+   Petach-Tikva  4951169
+   Israel
+
+   Phone: +972-3-926-6258
+   EMail: moti.morgenstern@ecitele.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 73]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6765.txt](<www.ietf.org/rfc/rfc6765.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
