### PR TITLE
Archive rfc6768.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6768.txt
+++ b/www.ietf.org/rfc/rfc6768.txt
@@ -1,0 +1,1907 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          E. Beili
+Request for Comments: 6768                              Actelis Networks
+Category: Standards Track                                  February 2013
+ISSN: 2070-1721
+
+
+                  ATM-Based xDSL Bonded Interfaces MIB
+
+Abstract
+
+   This document defines a Management Information Base (MIB) module for
+   use with network management protocols in TCP/IP-based internets.
+   This document proposes an extension to the GBOND-MIB module with a
+   set of objects for managing ATM-based multi-pair bonded xDSL
+   interfaces, as defined in ITU-T Recommendation G.998.1.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6768.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 1]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The Internet-Standard Management Framework ......................3
+   3. The Broadband Forum Management Framework for xDSL Bonding .......3
+   4. Relationship to Other MIB Modules ...............................3
+      4.1. Relationship to Interfaces Group MIB Module ................3
+      4.2. Relationship to G.Bond MIB Module ..........................3
+      4.3. Relationship to ATM MIB Module .............................4
+   5. MIB Structure ...................................................4
+      5.1. Overview ...................................................4
+      5.2. Performance Monitoring .....................................4
+      5.3. Mapping of Broadband Forum TR-159 Managed Objects ..........5
+   6. G.Bond/ATM MIB Definitions ......................................7
+   7. Security Considerations ........................................31
+   8. IANA Considerations ............................................32
+   9. Acknowledgments ................................................32
+   10. References ....................................................32
+      10.1. Normative References .....................................32
+      10.2. Informative References ...................................33
+
+1.  Introduction
+
+   ATM-Based Multi-Pair Bonding, a.k.a. G.Bond/ATM, is specified in
+   ITU-T Recommendation G.998.1 [G.998.1], which defines a method for
+   bonding (or aggregating) multiple xDSL lines (or individual bearer
+   channels in multiple xDSL lines) into a single bidirectional logical
+   link carrying an ATM stream.
+
+   This specification can be viewed as an evolution of the legacy
+   Inverse Multiplexing for ATM (IMA) technology [AF-PHY-0086], applied
+   to xDSL with variable rates on each line/bearer channel.  As with the
+   other bonding schemes, ATM bonding also allows bonding of up to 32
+   individual sub-layers with variable rates, providing common
+   functionality for the configuration, initialization, operation, and
+   monitoring of the bonded link.
+
+   The MIB module defined in this document defines a set of managed
+   objects for the management of G.998.1 bonded interfaces, extending
+   the common objects specified in the GBOND-MIB module [RFC6765].
+
+
+
+
+
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 2]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14, RFC 2119 [RFC2119].
+
+3.  The Broadband Forum Management Framework for xDSL Bonding
+
+   This document makes use of the Broadband Forum technical report
+   "Management Framework for xDSL Bonding" [TR-159], defining a
+   management model and a hierarchy of management objects for the bonded
+   xDSL interfaces.
+
+4.  Relationship to Other MIB Modules
+
+   This section outlines the relationship of the MIB modules defined in
+   this document with other MIB modules described in the relevant RFCs.
+   Specifically, the following MIB modules are discussed: the Interfaces
+   Group MIB (IF-MIB) and the G.Bond MIB (GBOND-MIB).
+
+4.1.  Relationship to Interfaces Group MIB Module
+
+   A G.Bond/ATM port is a private case of a bonded multi-pair xDSL
+   interface and as such is managed using generic interface management
+   objects defined in the IF-MIB [RFC2863].  In particular, an interface
+   index (ifIndex) is used to index instances of G.Bond/ATM ports, as
+   well as xDSL lines/channels, in a managed system.
+
+4.2.  Relationship to G.Bond MIB Module
+
+   The GBOND-MIB module [RFC6765] defines management objects common for
+   all bonded multi-pair xDSL interfaces.  In particular, it describes
+   the bonding management, bonded port and channel configuration,
+   initialization sequence, etc.
+
+
+
+Beili                        Standards Track                    [Page 3]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   Both the GBOND-MIB and G9981-MIB modules are REQUIRED to manage a
+   G.Bond/ATM port.
+
+4.3.  Relationship to ATM MIB Module
+
+   The ATM-MIB [RFC2515] module defines management objects for an ATM
+   interface.
+
+   The ATM-MIB module can be used to manage the ATM aspects of a G.Bond/
+   ATM port.
+
+5.  MIB Structure
+
+5.1.  Overview
+
+   All management objects defined in the G9981-MIB module are contained
+   in a single group g9981Port.  This group is further split into 4
+   sub-groups, structured as recommended by RFC 4181 [RFC4181]:
+
+   o  g9981PortNotifications - containing notifications (Up/Downstream
+      Differential Delay Tolerance Exceeded).
+
+   o  g9981PortConfTable - containing objects for configuration of a
+      G.Bond/ATM port.
+
+   o  g9981PortStatusTable - containing objects providing overall status
+      information of a G.Bond/ATM port, complementing the generic status
+      information from the ifTable of the IF-MIB and the gBondFltStatus
+      of the GBOND-MIB.
+
+   o  g9981PM - containing objects providing historical Performance
+      Monitoring (PM) information of a G.Bond/ATM port, complementing
+      the PM information from the gBondPortPM of the GBOND-MIB.
+
+   Note that the rest of the objects for the Generic Bonding Sub-layer
+   (GBS) port configuration, capabilities, status, notifications, and
+   Performance Monitoring are located in the GBOND-MIB module.
+
+5.2.  Performance Monitoring
+
+   The OPTIONAL Performance Monitoring counters, thresholds, and history
+   buckets (interval-counters) are implemented using the textual
+   conventions defined in the HC-PerfHist-TC-MIB [RFC3705].  The
+   HC-PerfHist-TC-MIB defines 64-bit versions of the textual conventions
+   found in the PerfHist-TC-MIB [RFC3593].
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 4]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   The agent SHOULD align the beginning of each interval to a fifteen-
+   minute boundary of a wall clock.  Likewise, the beginning of each
+   one-day interval SHOULD be aligned with the start of a day.
+
+   Counters are not reset when a GBS is re-initialized, but rather only
+   when the agent is reset or re-initialized.
+
+   Note that the accumulation of certain performance events for a
+   monitored entity is inhibited (counting stops) during periods of
+   service unavailability on that entity.  The DESCRIPTION clause of
+   Performance Monitoring counters in this MIB module specifies which of
+   the counters are inhibited during periods of service unavailability.
+
+5.3.  Mapping of Broadband Forum TR-159 Managed Objects
+
+   This section contains the mapping between relevant managed objects
+   (attributes) defined in [TR-159] and the managed objects defined in
+   this document.
+
+   +-----------------------------+-------------------------------------+
+   | TR-159 Managed Object       | Corresponding SNMP Object           |
+   +-----------------------------+-------------------------------------+
+   | oBondATM - Basic Package    |                                     |
+   | (Mandatory)                 |                                     |
+   +-----------------------------+-------------------------------------+
+   | aIMARxLostCells             | g9981PortStatRxLostCells            |
+   +-----------------------------+-------------------------------------+
+   | aIMAPeerRxLostCells         | g9981PortStatTxLostCells            |
+   +-----------------------------+-------------------------------------+
+   | aIMAMaxUpDiffDelay          | g9981PortStatMaxUpDiffDelay         |
+   +-----------------------------+-------------------------------------+
+   | aIMAMaxDownDiffDelay        | g9981PortStatMaxDnDiffDelay         |
+   +-----------------------------+-------------------------------------+
+   | aIMAUpDiffDelayTolerance    | g9981PortConfUpDiffDelayTolerance   |
+   +-----------------------------+-------------------------------------+
+   | aIMADownDiffDelayTolerance  | g9981PortConfDnDiffDelayTolerance   |
+   +-----------------------------+-------------------------------------+
+   | aIMADiffDelayToleranceExcee | g9981PortConfDiffDelayToleranceExce |
+   | dedEnable                   | ededEnable                          |
+   +-----------------------------+-------------------------------------+
+   | nIMAUpDiffDelayToleranceExc | g9981UpDiffDelayToleranceExceeded   |
+   | eeded                       |                                     |
+   +-----------------------------+-------------------------------------+
+   | nIMADownDiffDelayToleranceE | g9981DnDiffDelayToleranceExceeded   |
+   | xceeded                     |                                     |
+   +-----------------------------+-------------------------------------+
+
+                Table 1: Mapping of TR-159 Managed Objects
+
+
+
+Beili                        Standards Track                    [Page 5]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   Note that some of the mapping between the objects defined in TR-159
+   and the ones defined in this MIB module is not one-to-one; for
+   example, while TR-159 PM attributes aGroupPerf* map to the
+   corresponding gBondPortPm* objects of the GBOND-MIB module, there are
+   no dedicated PM attributes for the g9981PortPm* objects introduced in
+   this MIB module.  However, since their definition is identical to the
+   definition of gBondPortPm* objects of the GBOND-MIB module, we can
+   map g9981PortPm* to the relevant aGroupPerf* attributes of TR-159 and
+   use the term 'partial mapping' to denote the fact that this mapping
+   is not one-to-one.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 6]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+6.  G.Bond/ATM MIB Definitions
+
+   The G9981-MIB module IMPORTS objects from SNMPv2-SMI [RFC2578],
+   SNMPv2-TC [RFC2579], SNMPv2-CONF [RFC2580], IF-MIB [RFC2863], and
+   HC-PerfHist-TC-MIB [RFC3705].  The module has been structured as
+   recommended by [RFC4181].
+
+G9981-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    NOTIFICATION-TYPE,
+    mib-2,
+    Unsigned32,
+    Counter32
+      FROM SNMPv2-SMI           -- RFC 2578
+    TEXTUAL-CONVENTION,
+    TruthValue
+      FROM SNMPv2-TC            -- RFC 2579
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP,
+    NOTIFICATION-GROUP
+      FROM SNMPv2-CONF          -- RFC 2580
+    ifIndex
+      FROM IF-MIB               -- RFC 2863
+    HCPerfCurrentCount,
+    HCPerfIntervalCount,
+    HCPerfValidIntervals,
+    HCPerfInvalidIntervals,
+    HCPerfTimeElapsed
+      FROM  HC-PerfHist-TC-MIB  -- RFC 3705
+    ;
+------------------------------------------------------------------------
+  g9981MIB MODULE-IDENTITY
+    LAST-UPDATED "201302200000Z"  -- 20 February 2013
+    ORGANIZATION "IETF ADSL MIB Working Group"
+    CONTACT-INFO
+      "WG charter:
+        http://datatracker.ietf.org/wg/adslmib/charter/
+
+      Mailing Lists:
+        General Discussion: adslmib@ietf.org
+        To Subscribe: adslmib-request@ietf.org
+        In Body: subscribe your_email_address
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 7]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+       Chair: Menachem Dodge
+      Postal: ECI Telecom, Ltd.
+              30 Hasivim St.,
+              Petach-Tikva 4951169
+              Israel
+       Phone: +972-3-926-8421
+       EMail: menachemdodge1@gmail.com
+
+      Editor: Edward Beili
+      Postal: Actelis Networks, Inc.
+              25 Bazel St., P.O.B. 10173
+              Petach-Tikva 49103
+              Israel
+       Phone: +972-3-924-3491
+       EMail: edward.beili@actelis.com"
+
+    DESCRIPTION
+      "The objects in this MIB module are used to manage the
+      multi-pair bonded xDSL interfaces using ATM inverse
+      multiplexing, as defined in ITU-T Recommendation G.998.1
+      (G.Bond/ATM).
+
+      This MIB module MUST be used in conjunction with the GBOND-MIB
+      module, common to all G.Bond technologies.
+
+      The following references are used throughout this MIB module:
+
+      [G.998.1] refers to:
+        ITU-T Recommendation G.998.1: 'ATM-based multi-pair bonding',
+        January 2005.
+
+      [TR-159] refers to:
+        Broadband Forum Technical Report: 'Management Framework for
+        xDSL Bonding', December 2008.
+
+      Naming Conventions:
+        ATM   - Asynchronous Transfer Mode
+        BCE   - Bonding Channel Entity
+        BTU   - Bonding Terminating Unit
+        CO    - Central Office
+        CPE   - Customer Premises Equipment
+        GBS   - Generic Bonding Sub-layer
+        GBS-C - Generic Bonding Sub-layer, CO side
+        GBS-R - Generic Bonding Sub-layer, RT (or CPE) side
+        PM    - Performance Monitoring
+        RT    - Remote Terminal
+
+
+
+
+
+Beili                        Standards Track                    [Page 8]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+        SNR   - Signal to Noise Ratio
+        SES   - Severely Errored Seconds
+        UAS   - Unavailable Seconds
+
+     Copyright (c) 2013 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, is permitted pursuant to, and subject to the license
+     terms contained in, the Simplified BSD License set forth in Section
+     4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info)."
+
+    REVISION    "201302200000Z"  -- 20 February 2013
+    DESCRIPTION "Initial version, published as RFC 6768."
+
+    ::= { mib-2 208 }
+
+   -- Sections of the module
+   -- Structured as recommended by RFC 4181, Appendix D
+
+   g9981Objects     OBJECT IDENTIFIER ::= { g9981MIB 1 }
+
+   g9981Conformance OBJECT IDENTIFIER ::= { g9981MIB 2 }
+
+   -- Groups in the module
+
+   g9981Port        OBJECT IDENTIFIER ::= { g9981Objects 1 }
+
+   -- Textual Conventions
+
+   MilliSeconds ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "d"
+     STATUS      current
+     DESCRIPTION
+       "Represents time unit value in milliseconds."
+     SYNTAX      Unsigned32
+
+   -- Port Notifications group
+
+   g9981PortNotifications OBJECT IDENTIFIER
+     ::= { g9981Port 0 }
+
+
+
+
+
+
+
+
+
+Beili                        Standards Track                    [Page 9]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   g9981UpDiffDelayToleranceExceeded NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       g9981PortConfUpDiffDelayTolerance,
+       g9981PortStatMaxUpDiffDelay
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the maximum upstream
+       differential delay has exceeded the max upstream differential
+       delay threshold, specified by
+       g9981PortConfUpDiffDelayTolerance.
+
+       This notification MAY be sent for the GBS-C ports while the
+       port is 'up', on the crossing event in both directions: from
+       normal (diff. delay is above the threshold) to low (diff.
+       delay equals the threshold or is below it) and from low to
+       normal.  This notification is not applicable to the GBS-R
+       ports.
+
+       Generation of this notification is controlled by the
+       g9981PortConfDiffDelayToleranceExceededEnable attribute.
+
+       This object maps to the TR-159 notification
+       nIMAUpDiffDelayToleranceExceeded."
+     REFERENCE
+       "[TR-159], Section 5.5.2.8"
+     ::= { g9981PortNotifications 1 }
+
+   g9981DnDiffDelayToleranceExceeded NOTIFICATION-TYPE
+     OBJECTS {
+       -- ifIndex is not needed here, since we are under specific GBS
+       g9981PortConfDnDiffDelayTolerance,
+       g9981PortStatMaxDnDiffDelay
+     }
+     STATUS      current
+     DESCRIPTION
+       "This notification indicates that the maximum downstream
+       differential delay has exceeded the max downstream
+       differential delay threshold, specified by
+       g9981PortConfDnDiffDelayTolerance.
+
+       This notification MAY be sent for the GBS-C ports while the
+       port is 'up', on the crossing event in both directions: from
+       normal (diff. delay is above the threshold) to low (diff.
+       delay equals the threshold or is below it) and from low to
+       normal.  This notification is not applicable to the GBS-R
+       ports.
+
+
+
+Beili                        Standards Track                   [Page 10]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+       Generation of this notification is controlled by the
+       g9981PortConfDiffDelayToleranceExceededEnable attribute.
+
+       This object maps to the TR-159 notification
+       nIMADownDiffDelayToleranceExceeded."
+     REFERENCE
+       "[TR-159], Section 5.5.2.9"
+     ::= { g9981PortNotifications 2 }
+
+   -- G.Bond/ATM Port group
+
+   g9981PortConfTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9981PortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for configuration of G.Bond/ATM ports.  Entries in
+       this table MUST be maintained in a persistent manner."
+     ::= { g9981Port 1 }
+
+   g9981PortConfEntry OBJECT-TYPE
+     SYNTAX      G9981PortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/ATM Port Configuration table.
+       Each entry represents a G.Bond/ATM port indexed by the
+       ifIndex.  Additional configuration parameters are available
+       via the gBondPortConfEntry of the GBOND-MIB.
+       Note that a G.Bond/ATM port runs on top of a single or
+       multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9981PortConfTable 1 }
+
+   G9981PortConfEntry ::=
+     SEQUENCE {
+       g9981PortConfUpDiffDelayTolerance             MilliSeconds,
+       g9981PortConfDnDiffDelayTolerance             MilliSeconds,
+       g9981PortConfDiffDelayToleranceExceededEnable TruthValue
+     }
+
+   g9981PortConfUpDiffDelayTolerance  OBJECT-TYPE
+     SYNTAX      MilliSeconds (0..2047)
+     UNITS       "milliseconds"
+     MAX-ACCESS  read-write
+     STATUS      current
+
+
+
+
+
+Beili                        Standards Track                   [Page 11]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     DESCRIPTION
+       "A maximum tolerated upstream differential delay (among
+       the member BCEs) of a G.Bond/ATM port, expressed in ms.
+
+       This object is read-write for the GBS-C ports.
+       It is irrelevant for the GBS-R ports -- an attempt to read or
+       change this object MUST be rejected (in the case of SNMP, with
+       the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aIMAUpDiffDelayTolerance."
+     REFERENCE
+       "[TR-159], Section 5.5.2.5; [G.998.1], Section 11.4.1 (6)"
+     ::= { g9981PortConfEntry 1 }
+
+   g9981PortConfDnDiffDelayTolerance  OBJECT-TYPE
+     SYNTAX      MilliSeconds (0..2047)
+     UNITS       "milliseconds"
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "A maximum tolerated downstream differential delay (among
+       the member BCEs) of a G.Bond/ATM port, expressed in ms.
+
+       This object is read-write for the GBS-C ports.
+       It is irrelevant for the GBS-R ports -- an attempt to read or
+       change this object MUST be rejected (in the case of SNMP, with
+       the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aIMADownDiffDelayTolerance."
+     REFERENCE
+       "[TR-159], Section 5.5.2.6; [G.998.1], Section 11.4.1 (6)"
+     ::= { g9981PortConfEntry 2 }
+
+   g9981PortConfDiffDelayToleranceExceededEnable  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "Indicates whether g9981UpDiffDelayToleranceExceeded and
+       g9981DnDiffDelayToleranceExceeded notifications should
+       be generated for G.Bond/ATM port.
+
+       A value of true(1) indicates that the notifications are enabled.
+       A value of false(2) indicates that the notifications are
+       disabled.
+
+
+
+
+Beili                        Standards Track                   [Page 12]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+       This object is read-write for the GBS-C.
+       It is irrelevant for the GBS-R ports -- an attempt to read or
+       change this object MUST be rejected (in the case of SNMP, with
+       the error inconsistentValue).
+
+       This object maps to the TR-159 attribute
+       aIMADiffDelayToleranceExceededEnable."
+     REFERENCE
+       "[TR-159], Section 5.5.5.7"
+     ::= { g9981PortConfEntry 3 }
+
+
+   g9981PortStatTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9981PortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table provides overall status information of G.Bond/ATM
+       ports, complementing the generic status information from the
+       ifTable of the IF-MIB and the gBondFltStatus of the GBOND-MIB.
+       Additional status information about connected BCEs is available
+       from the relevant line MIBs.
+
+       This table contains live data from the equipment.  As such, it
+       is NOT persistent."
+     ::= { g9981Port 2 }
+
+   g9981PortStatEntry OBJECT-TYPE
+     SYNTAX      G9981PortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/ATM Port Status table.
+       Each entry represents a G.Bond/ATM port indexed by the
+       ifIndex.
+       Note that a GBS port runs on top of a single or multiple BCE
+       port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9981PortStatTable 1 }
+
+   G9981PortStatEntry ::=
+     SEQUENCE {
+       g9981PortStatRxLostCells      Counter32,
+       g9981PortStatTxLostCells      Counter32,
+       g9981PortStatMaxUpDiffDelay   Unsigned32,
+       g9981PortStatMaxDnDiffDelay   Unsigned32
+     }
+
+
+
+
+Beili                        Standards Track                   [Page 13]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   g9981PortStatRxLostCells  OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "The number of lost ATM cells detected by the G.Bond/ATM port
+       in the receive direction (e.g., upstream direction for
+       a GBS-C port).
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aIMARxLostCells."
+     REFERENCE
+       "[TR-159], Section 5.5.2.1; [G.998.1], Section 11.4.2 (4)"
+     ::= { g9981PortStatEntry 1 }
+
+   g9981PortStatTxLostCells  OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "The number of lost ATM cells detected by the peer G.Bond/ATM
+       port in the receive direction, i.e., downstream direction for a
+       GBS-C port.
+
+       This object is irrelevant for the GBS-R ports -- an attempt to
+       read it MUST be rejected (in the case of SNMP, with the error
+       inconsistentValue).
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aIMAPeerRxLostCells."
+     REFERENCE
+       "[TR-159], Section 5.5.2.2; [G.998.1], Section 11.4.2 (4)"
+     ::= { g9981PortStatEntry 2 }
+
+   g9981PortStatMaxUpDiffDelay  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+
+
+
+Beili                        Standards Track                   [Page 14]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "Current maximum upstream differential delay between all
+       operational BCEs in the G.Bond/ATM bonding group, measured in
+       units of 0.1 ms.
+
+       This object is read-only for the GBS-C ports.
+       It is irrelevant for the GBS-R ports -- an attempt to read this
+       object MUST be rejected (in the case of SNMP, with the error
+       inconsistentValue).
+
+       This object maps to the TR-159 attribute aIMAMaxUpDiffDelay."
+     REFERENCE
+       "[TR-159], Section 5.5.2.3"
+     ::= { g9981PortStatEntry 3 }
+
+   g9981PortStatMaxDnDiffDelay  OBJECT-TYPE
+     SYNTAX      Unsigned32
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Current maximum downstream differential delay between all
+       operational BCEs in the G.Bond/ATM bonding group, measured in
+       units of 0.1 ms.
+
+       This object is read-only for the GBS-C ports.
+       It is irrelevant for the GBS-R ports -- an attempt to read this
+       object MUST be rejected (in the case of SNMP, with the error
+       inconsistentValue).
+
+       This object maps to the TR-159 attribute aIMAMaxDownDiffDelay."
+     REFERENCE
+       "[TR-159], Section 5.5.2.4"
+     ::= { g9981PortStatEntry 4 }
+
+   -------------------------------
+   -- Performance Monitoring group
+   -------------------------------
+
+   g9981PM   OBJECT IDENTIFIER ::= { g9981Port 3 }
+
+   g9981PortPmCurTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9981PortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+
+
+
+
+
+Beili                        Standards Track                   [Page 15]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     DESCRIPTION
+       "This table contains current Performance Monitoring information
+       for a G.Bond/ATM port.  This table contains live data from the
+       equipment and as such is NOT persistent."
+     ::= { g9981PM 1 }
+
+   g9981PortPmCurEntry OBJECT-TYPE
+     SYNTAX      G9981PortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/ATM Port PM table.
+       Each entry represents a G.Bond/ATM port indexed by the
+       ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9981PortPmCurTable 1 }
+
+   G9981PortPmCurEntry ::=
+     SEQUENCE {
+       g9981PortPmCur15MinValidIntervals   HCPerfValidIntervals,
+       g9981PortPmCur15MinInvalidIntervals HCPerfInvalidIntervals,
+       g9981PortPmCur15MinTimeElapsed      HCPerfTimeElapsed,
+       g9981PortPmCur15MinRxLostCells      HCPerfCurrentCount,
+       g9981PortPmCur15MinTxLostCells      HCPerfCurrentCount,
+       g9981PortPmCur15MinUpDiffDelay      HCPerfCurrentCount,
+       g9981PortPmCur15MinDnDiffDelay      HCPerfCurrentCount,
+       g9981PortPmCur1DayValidIntervals    Unsigned32,
+       g9981PortPmCur1DayInvalidIntervals  Unsigned32,
+       g9981PortPmCur1DayTimeElapsed       HCPerfTimeElapsed,
+       g9981PortPmCur1DayRxLostCells       HCPerfCurrentCount,
+       g9981PortPmCur1DayTxLostCells       HCPerfCurrentCount,
+       g9981PortPmCur1DayUpDiffDelay       HCPerfCurrentCount,
+       g9981PortPmCur1DayDnDiffDelay       HCPerfCurrentCount
+     }
+
+   g9981PortPmCur15MinValidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfValidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 15-minute intervals for which the
+       performance data was collected.  The value of this object will
+       be 96 or the maximum number of 15-minute history intervals
+       collected by the implementation, unless the measurement was
+       (re)started recently, in which case the value will be the
+       number of complete 15-minute intervals for which there are at
+       least some data.
+
+
+
+
+Beili                        Standards Track                   [Page 16]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinValidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.32"
+     ::= { g9981PortPmCurEntry 1 }
+
+   g9981PortPmCur15MinInvalidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfInvalidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 15-minute intervals for which the
+       performance data was not always available.  The value will
+       typically be zero, except in cases where the data for some
+       intervals are not available.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinInvalidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.33"
+     ::= { g9981PortPmCurEntry 2 }
+
+   g9981PortPmCur15MinTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds that have elapsed since the
+       beginning of the current 15-minute performance interval.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerfCurr15MinTimeElapsed."
+     REFERENCE
+       "[TR-159], Section 5.5.1.34"
+     ::= { g9981PortPmCurEntry 3 }
+
+   g9981PortPmCur15MinRxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+
+Beili                        Standards Track                   [Page 17]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by a G.Bond/ATM
+       port (e.g., the GBS-C) in the receive direction, during the
+       current 15-minute performance history interval.
+
+       Note that the total number of lost ATM cells is indicated by the
+       g9981PortStatRxLostCells object.
+
+       This object is inhibited during Severely Errored Seconds (SES)
+       or Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.1"
+     ::= { g9981PortPmCurEntry 4}
+
+   g9981PortPmCur15MinTxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by the peer
+       G.Bond/ATM port (e.g., by the GBS-R for the GBS-C) during the
+       current 15-minute performance history interval.
+
+       Note that the total number of lost ATM cells is indicated by the
+       g9981PortStatTxLostCells object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.2"
+     ::= { g9981PortPmCurEntry 5}
+
+   g9981PortPmCur15MinUpDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum upstream differential
+       delay between all operational BCEs in the GBS-C, measured in
+       units of 0.1 ms, during the current 15-minute performance
+       interval.
+
+       Note that the current max upstream differential delay is
+       indicated by the g9981PortStatMaxUpDiffDelay object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+
+
+
+
+Beili                        Standards Track                   [Page 18]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.2.3"
+     ::= { g9981PortPmCurEntry 6}
+
+   g9981PortPmCur15MinDnDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum downstream
+       differential delay between all operational BCEs in the GBS-C
+       (as perceived by the GBS-R), measured in units of 0.1 ms,
+       during the current 15-minute performance history interval.
+
+       Note that the current max downstream differential delay is
+       indicated by the g9981PortStatMaxDnDiffDelay object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.4"
+     ::= { g9981PortPmCurEntry 7}
+
+   g9981PortPmCur1DayValidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 1-day intervals for which data was
+       collected.  The value of this object will be 7 or the maximum
+       number of 1-day history intervals collected by the
+       implementation, unless the measurement was (re)started recently,
+       in which case the value will be the number of complete 1-day
+       intervals for which there are at least some data.
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available."
+     REFERENCE
+       "[TR-159], Section 5.5.1.45"
+     ::= { g9981PortPmCurEntry 8 }
+
+   g9981PortPmCur1DayInvalidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili                        Standards Track                   [Page 19]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     DESCRIPTION
+       "A read-only number of 1-day intervals for which data was
+       not always available.  The value will typically be zero, except
+       in cases where the data for some intervals are not available."
+     REFERENCE
+       "[TR-159], Section 5.5.1.46"
+     ::= { g9981PortPmCurEntry 9 }
+
+   g9981PortPmCur1DayTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds that have elapsed since the
+       beginning of the current 1-day performance interval."
+     REFERENCE
+       "[TR-159], Section 5.5.1.47"
+     ::= { g9981PortPmCurEntry 10 }
+
+   g9981PortPmCur1DayRxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by the G.Bond/ATM
+       port (e.g., the GBS-C) during the current 1-day performance
+       interval.
+
+       This object is inhibited during Severely Errored Seconds (SES)
+       and Unavailable Seconds (UAS)."
+     ::= { g9981PortPmCurEntry 11 }
+
+   g9981PortPmCur1DayTxLostCells OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by the peer
+       G.Bond/ATM port (e.g., by the GBS-R for the GBS-C) during the
+       current 1-day performance history interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPmCurEntry 12 }
+
+
+
+
+
+Beili                        Standards Track                   [Page 20]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   g9981PortPmCur1DayUpDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum upstream differential
+       delay between all operational BCEs in the GBS-C, measured in
+       units of 0.1 ms, during the current 1-day performance
+       interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPmCurEntry 13 }
+
+   g9981PortPmCur1DayDnDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum downstream
+       differential delay between all operational BCEs in the GBS-C,
+       measured in units of 0.1 ms, during the current 1-day
+       performance interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPmCurEntry 14 }
+
+   -- Port PM history: 15-min buckets
+
+   g9981PortPm15MinTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9981PortPm15MinEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 15-minute buckets of Performance
+       Monitoring information for a G.Bond/ATM port (a row for each
+       15-minute interval, up to 96 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { g9981PM 2 }
+
+   g9981PortPm15MinEntry OBJECT-TYPE
+     SYNTAX      G9981PortPm15MinEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/ATM Port historical 15-minute PM table.
+       Each entry represents Performance Monitoring data for a
+
+
+
+Beili                        Standards Track                   [Page 21]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+       G.Bond/ATM port, indexed by the ifIndex, collected during a
+       particular 15-minute interval, indexed by the
+       g9981PortPm15MinIntervalIndex."
+     INDEX  { ifIndex, g9981PortPm15MinIntervalIndex }
+     ::= { g9981PortPm15MinTable 1 }
+
+   G9981PortPm15MinEntry ::=
+     SEQUENCE {
+       g9981PortPm15MinIntervalIndex       Unsigned32,
+       g9981PortPm15MinIntervalMoniTime    HCPerfTimeElapsed,
+       g9981PortPm15MinIntervalRxLostCells HCPerfIntervalCount,
+       g9981PortPm15MinIntervalTxLostCells HCPerfIntervalCount,
+       g9981PortPm15MinIntervalUpDiffDelay HCPerfIntervalCount,
+       g9981PortPm15MinIntervalDnDiffDelay HCPerfIntervalCount,
+       g9981PortPm15MinIntervalValid       TruthValue
+     }
+
+   g9981PortPm15MinIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..96)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance data interval number.  1 is the most recent previous
+       interval; interval 96 is 24 hours ago.
+       Intervals 2..96 are OPTIONAL.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinIntervalNumber."
+     REFERENCE
+       "[TR-159], Section 5.5.1.57"
+     ::= { g9981PortPm15MinEntry 1 }
+
+   g9981PortPm15MinIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds over which the performance data
+       was actually monitored.  This value will be the same as the
+       interval duration (900 seconds), except in a situation where
+       performance data could not be collected for any reason."
+     ::= { g9981PortPm15MinEntry 2 }
+
+   g9981PortPm15MinIntervalRxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+
+
+
+Beili                        Standards Track                   [Page 22]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by a G.Bond/ATM
+       port (e.g., the GBS-C) in the receive direction, during the
+       15-minute performance history interval.
+
+       Note that the total number of lost ATM cells is indicated by the
+       g9981PortStatRxLostCells object.
+
+       This object is inhibited during Severely Errored Seconds (SES)
+       or Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.1"
+     ::= { g9981PortPm15MinEntry 3 }
+
+   g9981PortPm15MinIntervalTxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of lost ATM cells detected by the peer
+       G.Bond/ATM port (e.g., by the GBS-R for the GBS-C) during the
+       15-minute performance history interval.
+
+       Note that the total number of lost ATM cells is indicated by the
+       g9981PortStatTxLostCells object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.2"
+     ::= { g9981PortPm15MinEntry 4 }
+
+   g9981PortPm15MinIntervalUpDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum upstream differential
+       delay between all operational BCEs in the GBS, measured in
+       units of 0.1 ms, during the 15-minute performance history
+       interval.
+
+       Note that the current max upstream differential delay is
+       indicated by the g9981PortStatMaxUpDiffDelay object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+
+
+
+Beili                        Standards Track                   [Page 23]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.2.3"
+     ::= { g9981PortPm15MinEntry 5 }
+
+   g9981PortPm15MinIntervalDnDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum downstream
+       differential delay between all operational BCEs in the GBS,
+       as perceived by its peer port, measured in units of 0.1 ms,
+       during the 15-minute performance history interval.
+
+       Note that the current max downstream differential delay is
+       indicated by the g9981PortStatMaxDnDiffDelay object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.2.4"
+     ::= { g9981PortPm15MinEntry 6 }
+
+   g9981PortPm15MinIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.58"
+     ::= { g9981PortPm15MinEntry 7 }
+
+
+
+
+
+
+
+Beili                        Standards Track                   [Page 24]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   -- Port PM history: 1-day buckets
+
+   g9981PortPm1DayTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9981PortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 1-day buckets of Performance
+       Monitoring information for a G.Bond/ATM port (a row for each
+       1-day interval, up to 7 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { g9981PM 3 }
+
+   g9981PortPm1DayEntry OBJECT-TYPE
+     SYNTAX      G9981PortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/ATM Port historical 1-day PM table.
+       Each entry represents Performance Monitoring data for such a
+       port, indexed by the ifIndex, collected during a particular
+       1-day interval, indexed by the g9981PortPm1DayIntervalIndex."
+     INDEX  { ifIndex, g9981PortPm1DayIntervalIndex }
+     ::= { g9981PortPm1DayTable 1 }
+
+   G9981PortPm1DayEntry ::=
+     SEQUENCE {
+       g9981PortPm1DayIntervalIndex        Unsigned32,
+       g9981PortPm1DayIntervalMoniTime     HCPerfTimeElapsed,
+       g9981PortPm1DayIntervalRxLostCells  HCPerfIntervalCount,
+       g9981PortPm1DayIntervalTxLostCells  HCPerfIntervalCount,
+       g9981PortPm1DayIntervalUpDiffDelay  HCPerfIntervalCount,
+       g9981PortPm1DayIntervalDnDiffDelay  HCPerfIntervalCount,
+       g9981PortPm1DayIntervalValid        TruthValue
+     }
+
+   g9981PortPm1DayIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..7)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance data interval number.  1 is the most recent previous
+       interval; interval 7 is 24 hours ago.
+       Intervals 2..7 are OPTIONAL.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalNumber."
+
+
+
+
+Beili                        Standards Track                   [Page 25]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.1.62"
+     ::= { g9981PortPm1DayEntry 1 }
+
+   g9981PortPm1DayIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of seconds over which the performance data was actually
+       monitored.  This value will be the same as the interval duration
+       (86400 seconds), except in a situation where performance data
+       could not be collected for any reason.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalMoniSecs."
+     REFERENCE
+       "[TR-159], Section 5.5.1.64"
+     ::= { g9981PortPm1DayEntry 2 }
+
+   g9981PortPm1DayIntervalRxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of lost ATM cells detected by the G.Bond/ATM port
+       (e.g., the GBS-C) during the 1-day performance history interval.
+
+       This object is inhibited during Severely Errored Seconds (SES)
+       and Unavailable Seconds (UAS)."
+     ::= { g9981PortPm1DayEntry 3 }
+
+   g9981PortPm1DayIntervalTxLostCells  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "cells"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A count of lost ATM cells detected by the peer G.Bond/ATM port
+       (e.g., by the GBS-R for the GBS-C) during the 1-day performance
+       history interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPm1DayEntry 4 }
+
+
+
+
+
+Beili                        Standards Track                   [Page 26]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   g9981PortPm1DayIntervalUpDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum upstream differential
+       delay between all operational BCEs in the GBS-C, measured in
+       units of 0.1 ms, during the 1-day performance history interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPm1DayEntry 5 }
+
+   g9981PortPm1DayIntervalDnDiffDelay  OBJECT-TYPE
+     SYNTAX      HCPerfIntervalCount
+     UNITS       "0.1 ms"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only value specifying the maximum downstream
+       differential delay between all operational BCEs in the GBS-C,
+       measured in units of 0.1 ms, during the 1-day performance
+       history interval.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     ::= { g9981PortPm1DayEntry 6 }
+
+   g9981PortPm1DayIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.63"
+     ::= { g9981PortPm1DayEntry 7 }
+
+
+
+Beili                        Standards Track                   [Page 27]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+  --
+  -- Conformance Statements
+  --
+
+   g9981Groups      OBJECT IDENTIFIER
+     ::= { g9981Conformance 1 }
+
+   g9981Compliances OBJECT IDENTIFIER
+     ::= { g9981Conformance 2 }
+
+   -- Object Groups
+
+   g9981BasicGroup OBJECT-GROUP
+     OBJECTS {
+       g9981PortStatRxLostCells,
+       g9981PortStatTxLostCells,
+       g9981PortStatMaxUpDiffDelay,
+       g9981PortStatMaxDnDiffDelay
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects representing management information
+       for a G.Bond/ATM port."
+     ::= { g9981Groups 1 }
+
+   g9981AlarmConfGroup OBJECT-GROUP
+     OBJECTS {
+       g9981PortConfUpDiffDelayTolerance,
+       g9981PortConfDnDiffDelayTolerance,
+       g9981PortConfDiffDelayToleranceExceededEnable
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects required for configuration of alarm
+       thresholds and notifications in G.Bond/ATM ports."
+     ::= { g9981Groups 2 }
+
+   g9981NotificationGroup NOTIFICATION-GROUP
+     NOTIFICATIONS {
+       g9981UpDiffDelayToleranceExceeded,
+       g9981DnDiffDelayToleranceExceeded
+     }
+     STATUS      current
+     DESCRIPTION
+       "This group supports notifications of significant conditions
+       associated with G.Bond/ATM ports."
+     ::= { g9981Groups 3 }
+
+
+
+
+Beili                        Standards Track                   [Page 28]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   g9981PerfCurrGroup OBJECT-GROUP
+     OBJECTS {
+       g9981PortPmCur15MinValidIntervals,
+       g9981PortPmCur15MinInvalidIntervals,
+       g9981PortPmCur15MinTimeElapsed,
+       g9981PortPmCur15MinRxLostCells,
+       g9981PortPmCur15MinTxLostCells,
+       g9981PortPmCur15MinUpDiffDelay,
+       g9981PortPmCur15MinDnDiffDelay,
+       g9981PortPmCur1DayValidIntervals,
+       g9981PortPmCur1DayInvalidIntervals,
+       g9981PortPmCur1DayTimeElapsed,
+       g9981PortPmCur1DayRxLostCells,
+       g9981PortPmCur1DayTxLostCells,
+       g9981PortPmCur1DayUpDiffDelay,
+       g9981PortPmCur1DayDnDiffDelay
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL current Performance
+       Monitoring information for G.Bond/ATM ports."
+     ::= { g9981Groups 4 }
+
+   g9981Perf15MinGroup OBJECT-GROUP
+     OBJECTS {
+       g9981PortPm15MinIntervalMoniTime,
+       g9981PortPm15MinIntervalRxLostCells,
+       g9981PortPm15MinIntervalTxLostCells,
+       g9981PortPm15MinIntervalUpDiffDelay,
+       g9981PortPm15MinIntervalDnDiffDelay,
+       g9981PortPm15MinIntervalValid
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond/ATM ports, during
+       previous 15-minute intervals."
+     ::= { g9981Groups 5 }
+
+   g9981Perf1DayGroup OBJECT-GROUP
+     OBJECTS {
+       g9981PortPm1DayIntervalMoniTime,
+       g9981PortPm1DayIntervalRxLostCells,
+       g9981PortPm1DayIntervalTxLostCells,
+       g9981PortPm1DayIntervalUpDiffDelay,
+       g9981PortPm1DayIntervalDnDiffDelay,
+       g9981PortPm1DayIntervalValid
+     }
+
+
+
+Beili                        Standards Track                   [Page 29]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond/ATM ports, during
+       previous 1-day intervals."
+     ::= { g9981Groups 6 }
+
+
+   -- Compliance Statements
+
+   g9981Compliance MODULE-COMPLIANCE
+     STATUS      current
+     DESCRIPTION
+       "The compliance statement for G.Bond/ATM interfaces.
+       Compliance with the following external compliance statements
+       is REQUIRED:
+
+       MIB Module             Compliance Statement
+       ----------             --------------------
+       IF-MIB                 ifCompliance3
+       GBOND-MIB              gBondCompliance"
+
+     MODULE  -- this module
+       MANDATORY-GROUPS {
+         g9981BasicGroup,
+         g9981AlarmConfGroup,
+         g9981NotificationGroup
+       }
+
+       GROUP       g9981PerfCurrGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting Performance Monitoring."
+
+       GROUP       g9981Perf15MinGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting historical Performance Monitoring."
+
+       GROUP       g9981Perf1DayGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting 1-day historical Performance Monitoring."
+
+     ::= { g9981Compliances 1 }
+END
+
+
+
+
+
+Beili                        Standards Track                   [Page 30]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+7.  Security Considerations
+
+   There are a number of managed objects defined in this MIB module with
+   a MAX-ACCESS clause of read-write.  Such objects may be considered
+   sensitive or vulnerable in some network environments.  The support
+   for SET operations in a non-secure environment without proper
+   protection can have a negative effect on network operations.  These
+   are the tables and objects and their sensitivity/vulnerability:
+
+   o  Changing of g9981PortConfTable configuration parameters MAY lead
+      to a potential Service Level Agreement (SLA) breach, for example,
+      if a traffic delay is increased as a result of the higher delay
+      tolerance (increased g9981PortConfUpDiffDelayTolerance and/or
+      g9981PortConfDnDiffDelayTolerance), or the differential delay
+      tolerance notifications are disabled by manipulating the
+      g9981PortConfDiffDelayToleranceExceededEnable parameter.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments since, collectively, they
+   provide information about the performance of network interfaces and
+   can reveal some aspects of their configuration.
+
+   It is thus important to control even GET and/or NOTIFY access to
+   these objects and possibly to even encrypt the values of these
+   objects when sending them over the network via SNMP.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+
+
+
+
+
+Beili                        Standards Track                   [Page 31]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+8.  IANA Considerations
+
+   IANA has assigned 208 as the object identifier for g9981MIB
+   MODULE-IDENTITY in the MIB-2 transmission sub-tree
+   <http://www.iana.org/>.
+
+9.  Acknowledgments
+
+   This document was produced by the [ADSLMIB] working group.
+
+   Special thanks to Dan Romascanu for his meticulous review of this
+   text.
+
+10.  References
+
+10.1.  Normative References
+
+   [G.998.1]  ITU-T, "ATM-based multi-pair bonding", ITU-T
+              Recommendation G.998.1, January 2005,
+              <http://www.itu.int/rec/T-REC-G.998.1/en>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+
+
+
+
+Beili                        Standards Track                   [Page 32]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   [RFC3705]  Ray, B. and R. Abbi, "High Capacity Textual Conventions
+              for MIB Modules Using Performance History Based on 15
+              Minute Intervals", RFC 3705, February 2004.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)",
+              RFC 5591, June 2009.
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+   [RFC6765]  Beili, E. and M. Morgenstern, "xDSL Multi-Pair Bonding
+              (G.Bond) MIB", RFC 6765, February 2013.
+
+   [TR-159]   Beili, E. and M. Morgenstern, "Management Framework for
+              xDSL Bonding", Broadband Forum Technical Report TR-159,
+              December 2008, <http://www.broadband-forum.org/technical/
+              download/TR-159.pdf>.
+
+10.2.  Informative References
+
+   [ADSLMIB]  IETF, "ADSL MIB (adslmib) Charter",
+              <http://datatracker.ietf.org/wg/adslmib/charter/>.
+
+   [AF-PHY-0086]
+              ATM Forum, "Inverse Multiplexing for ATM (IMA)
+              Specification Version 1.1", ATM Forum specification af-
+              phy-0086.001, March 1999, <http://www.broadband-forum.org/
+              ftp/pub/approved-specs/af-phy-0086.001.pdf>.
+
+   [RFC2515]  Tesink, K., "Definitions of Managed Objects for ATM
+              Management", RFC 2515, February 1999.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+Beili                        Standards Track                   [Page 33]
+
+RFC 6768                     G.Bond/ATM MIB                February 2013
+
+
+   [RFC3593]  Tesink, K., "Textual Conventions for MIB Modules Using
+              Performance History Based on 15 Minute Intervals",
+              RFC 3593, September 2003.
+
+   [RFC4181]  Heard, C., "Guidelines for Authors and Reviewers of MIB
+              Documents", BCP 111, RFC 4181, September 2005.
+
+Author's Address
+
+   Edward Beili
+   Actelis Networks
+   25 Bazel St.
+   Petach-Tikva  49103
+   Israel
+
+   Phone: +972-3-924-3491
+   EMail: edward.beili@actelis.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili                        Standards Track                   [Page 34]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6768.txt](<www.ietf.org/rfc/rfc6768.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
