### PR TITLE
Archive rfc6767.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6767.txt
+++ b/www.ietf.org/rfc/rfc6767.txt
@@ -1,0 +1,2971 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          E. Beili
+Request for Comments: 6767                              Actelis Networks
+Category: Standards Track                                 M. Morgenstern
+ISSN: 2070-1721                                              ECI Telecom
+                                                           February 2013
+
+
+      Ethernet-Based xDSL Multi-Pair Bonding (G.Bond/Ethernet) MIB
+
+Abstract
+
+   This document defines a Management Information Base (MIB) module for
+   use with network management protocols in TCP/IP-based internets.
+   This document defines an extension to the GBOND-MIB module with a set
+   of objects for managing Ethernet-based multi-pair bonded Digital
+   Subscriber Line (xDSL) interfaces, as defined in ITU-T Recommendation
+   G.998.2.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6767.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 1]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The Internet-Standard Management Framework ......................2
+   3. The Broadband Forum Management Framework for xDSL Bonding .......3
+   4. Relationship to Other MIB Modules ...............................3
+      4.1. Relationship to Interfaces Group MIB Module ................3
+      4.2. Relationship to G.Bond MIB Module ..........................3
+           4.2.1. BACP-Based Discovery ................................3
+      4.3. Relationship to EFM Copper MIB Module ......................5
+      4.4. Relationship to IEEE 802.3.1 MIB Modules ...................6
+   5. MIB Structure ...................................................6
+      5.1. Overview ...................................................6
+      5.2. Performance Monitoring .....................................7
+      5.3. Mapping of Broadband Forum TR-159 Managed Objects ..........7
+   6. G.Bond/Ethernet MIB Definitions .................................9
+   7. Security Considerations ........................................49
+   8. IANA Considerations ............................................50
+   9. Acknowledgments ................................................50
+   10. References ....................................................50
+      10.1. Normative References .....................................50
+      10.2. Informative References ...................................52
+
+1.  Introduction
+
+   Ethernet-based xDSL Multi-Pair Bonding, a.k.a. G.Bond/Ethernet, is
+   specified in ITU-T Recommendation G.998.2 [G.998.2], which defines a
+   method for bonding (or aggregating) multiple xDSL lines (or
+   individual bearer channels in multiple xDSL lines) into a single
+   bidirectional logical link carrying Ethernet traffic.
+
+   The MIB module defined in this document provides G.Bond/
+   Ethernet-specific objects for the management of G.998.2 bonded
+   interfaces, extending the common bonding objects specified in the
+   GBOND-MIB module [RFC6765].
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 2]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14, RFC 2119 [RFC2119].
+
+3.  The Broadband Forum Management Framework for xDSL Bonding
+
+   This document makes use of the Broadband Forum technical report
+   "Management Framework for xDSL Bonding" [TR-159], defining a
+   management model and a hierarchy of management objects for the bonded
+   xDSL interfaces.
+
+4.  Relationship to Other MIB Modules
+
+   This section outlines the relationship of the MIB modules defined in
+   this document with other MIB modules described in the relevant RFCs.
+   Specifically, the following MIB modules are discussed: the Interfaces
+   Group MIB (IF-MIB), G.Bond MIB (GBOND-MIB), and Ethernet in the First
+   Mile (EFM) Copper MIB (EFM-CU-MIB).
+
+4.1.  Relationship to Interfaces Group MIB Module
+
+   A G.Bond/Ethernet port is a private case of a bonded multi-pair xDSL
+   interface and as such is managed using generic interface management
+   objects defined in the IF-MIB [RFC2863].  In particular, an interface
+   index (ifIndex) is used to index instances of G.Bond/Ethernet ports,
+   as well as xDSL lines/channels, in a managed system.
+
+4.2.  Relationship to G.Bond MIB Module
+
+   The GBOND-MIB module [RFC6765] defines management objects common for
+   all bonded multi-pair xDSL interfaces.  In particular, it describes
+   the bonding management, bonded port and channel configuration,
+   handshake-based discovery, initialization sequence, etc.
+
+   Both the GBOND-MIB [RFC6765] and G9982-MIB (this document) modules
+   are REQUIRED to manage a G.Bond/Ethernet port.
+
+4.2.1.  BACP-Based Discovery
+
+   All G.998 protocols share a remote Bonding Channel Entity (BCE)
+   discovery, using the [G.994.1] handshake (G.hs).  The GBOND-MIB
+   module provides an example of an automatic BCE connection to the
+   corresponding Generic Bonding Sub-layer (GBS) ports of a generic
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 3]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   G.998 multi-port Central Office (CO) device, using G.hs-based BCE
+   discovery.  Amendment 2 to the ITU-T G.998.2 specification
+   [G.998.2-Amd2] provides an alternative optional Bonding Aggregation
+   Control Protocol (BACP) for in-service discovery, aggregation, and
+   pair management.
+
+   The following pseudocode gives the same example of the discovery and
+   automatic BCE assignment for a multi-GBS G.Bond/Eth CO device, using
+   BACP objects defined in this MIB module, as well as the
+   IF-CAP-STACK-MIB [RFC5066] and IF-MIB modules.  Note that automatic
+   BCE assignment is only shown here for the purposes of the example.
+   Fixed BCE pre-assignment, manual assignment, or auto-assignment using
+   an alternative internal algorithm may be chosen by a particular
+   implementation:
+
+   // Go over all GBS ports in the CO device
+   FOREACH gbs[i] IN CO_device
+   { // Perform discovery and auto-assignment on GBS ports
+     // with room for more channels.
+     IF ( gbs[i].NumBCEs < gbs[i].BondCapacity )
+     { IF ( gbs[i].g9982OperCp == cpBACP )
+       { // Using BACP
+
+         // Get Eligible Group ID and Remote Group ID
+         // from a connected BCE (during BACP
+         // initialization, each BCE is connected to its own GBS)
+         gid = ifStackTable[gbs[i]].bce[0].g9982BceEligibleGroupID;
+         rgid =
+           ifStackTable[gbs[i]].bce[0].g9982BcePeerEligibleGroupID;
+
+         // Go over all disconnected channels, which can
+         // potentially be connected to the GBS
+         FOREACH bce[j] IN ifCapStackTable[gbs[i]] AND
+                      NOT IN ifStackTable[gbs[i]]  // not connected
+         { // Read the Remote Group ID for the selected BCE
+           // and compare it with the Remote Group ID of the connected
+           // BCE.
+           r = bce[j].g9982BcePeerEligibleGroupID;
+           IF ( r == rgid AND gbs[i].NumBCEs < gbs[i].BondCapacity )
+           { // The Remote Terminal device (RT) connected via BCE[j] is
+             // a peer for GBS[i], and there is room for another BCE in
+             // the GBS[i] aggregation group (max. Bonding capacity is
+             // not reached yet).
+             // Connect this BCE to the GBS (via the ifStackTable; the
+             // ifInvStackTable, which is the inverse of the
+             // ifStackTable, is updated automatically; i.e., gbs[i] is
+             // auto-added to ifInvStackTable[bce[j]]).
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 4]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+             ADD bce[j] TO ifStackTable[gbs[i]];
+             gbs[i].NumBCEs = gbs[i].NumBCEs + 1;
+           }
+         }
+         // At this point, we have discovered all local BCEs that
+         // are physically connected to the same RT
+         // and have connected them to GBS[i].  Go to the next GBS.
+         BREAK;
+       }
+       ELSE
+       { // Use default G.hs discovery protocol.
+         ...
+       }
+     }
+   }
+
+   An SNMP agent for a G.Bond device builds the ifCapStackTable and its
+   inverse -- the ifInvCapStackTable -- on device initialization,
+   according to the cross-connect capabilities of the device.  When BACP
+   is used, the g9982BceConfEligibleGroupID object identifying bonding
+   eligibility MUST be automatically updated whenever the
+   ifCapStackTable/ifInvCapStackTable are changed.
+
+4.3.  Relationship to EFM Copper MIB Module
+
+   The EFM-CU-MIB module [RFC5066] defines objects for managing Ethernet
+   in the First Mile Copper (EFMCu) interfaces 10PASS-TS and 2BASE-TL,
+   as defined in IEEE Std 802.3-2005 [802.3].  These interfaces are
+   based on Single-pair High-speed DSL (SHDSL) [G.991.2] and Very high
+   speed DSL (VDSL) [G.993.1] technology, respectively, and can be
+   optionally aggregated (bonded).
+
+   The ITU-T G.998.2 specification extends the IEEE 802.3 Clause 61
+   bonding to work over any xDSL technology, providing the ability to
+   bond individual channels as well as physical lines.  It also allows
+   the use of alternative High-level Data Link Control (HDLC)
+   encapsulation instead of the default 64/65-octet encapsulation and
+   adds a new optional Bonding Aggregation Control Protocol (BACP) for
+   in-service discovery, aggregation, and pair management instead of the
+   default G.hs-based bonding protocol, which cannot be used in-service,
+   while the link is 'up'.
+
+   EFM-CU-MIB can be used to manage all aspects of the EFMCu physical
+   interfaces (PHYs), including complete (within the scope of the 802.3
+   standard) management of the SHDSL/VDSL lines.  The GBOND-MIB and
+   G9982-MIB modules, on the other hand, provide management objects only
+   for the bonding part, leaving the management of the individual xDSL
+   interfaces (lines/channels) to the respective xDSL-LINE-MIB modules.
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 5]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   Therefore, an IEEE 802.3 2BASE-TL/10PASS-TS interface can be managed
+   by either combination of the following MIB modules:
+
+      IF-MIB + IF-CAP-STACK-MIB + EtherLike-MIB + MAU-MIB + EFM-CU-MIB
+
+      IF-MIB + IF-CAP-STACK-MIB + GBOND-MIB + G9982-MIB +
+      HDSL2-SHDSL-LINE-MIB/VDSL-LINE-MIB
+
+   (The EtherLike-MIB, HDSL2-SHDSL-LINE-MIB, and VDSL-LINE-MIB modules
+   are found in [RFC3635], [RFC4319], and [RFC3728], respectively.)
+
+   Note also that while EFM-CU-MIB relies on the ifMauMediaAvailable
+   object from MAU-MIB [RFC4836] for the additional bonded xDSL-specific
+   operational states, GBOND-MIB provides these indications via the
+   gBondPortStatFltStatus object, complementing the ifOperStatus object
+   from the IF-MIB.
+
+   Finally, the EFM-CU-MIB does not include historical Performance
+   Monitoring (PM), while the GBOND-MIB/G9982-MIB/xDSL-LINE-MIB
+   combination provides full PM functionality for a bonded link and
+   individual xDSL lines.
+
+4.4.  Relationship to IEEE 802.3.1 MIB Modules
+
+   The IEEE 802.3 working group chartered a task force [IEEE802.3.1],
+   which continues the development of standard Ethernet-related MIB
+   modules based on the initial work done in the IETF.  Future projects
+   resulting from the work of this task force may include and possibly
+   extend the work done in the IETF.
+
+5.  MIB Structure
+
+5.1.  Overview
+
+   The main management objects defined in the G9982-MIB module are split
+   into 2 groups, structured as recommended by RFC 4181 [RFC4181]:
+
+   o  g9982Port - containing objects for configuration, capabilities,
+      status, and PM of G.Bond/Eth ports.  Note that the rest of the
+      objects for the Generic Bonding Sub-layer (GBS) port
+      configuration, capabilities, status, notifications, and PM are
+      located in the GBOND-MIB module.
+
+   o  g9982Bce - containing objects representing OPTIONAL status
+      information and BACP configuration for each Bonding Channel Entity
+      (BCE).  Note that the rest of the objects for the BCE
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 6]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+      configuration, capabilities, status, and notifications are located
+      in relevant xDSL line MIB modules as well as in the GBOND-MIB
+      module.
+
+5.2.  Performance Monitoring
+
+   The OPTIONAL Performance Monitoring counters, thresholds, and history
+   buckets (interval-counters), similar to those defined in [TR-159],
+   are implemented using the textual conventions defined in the
+   HC-PerfHist-TC-MIB [RFC3705].  The HC-PerfHist-TC-MIB defines 64-bit
+   versions of the textual conventions found in PerfHist-TC-MIB
+   [RFC3593].
+
+   The agent SHOULD align the beginning of each interval to a fifteen-
+   minute boundary of a wall clock.  Likewise, the beginning of each
+   one-day interval SHOULD be aligned with the start of a day.
+
+   Counters are not reset when a GBS is re-initialized, but rather only
+   when the agent is reset or re-initialized.
+
+5.3.  Mapping of Broadband Forum TR-159 Managed Objects
+
+   This section contains the mapping between relevant managed objects
+   (attributes) defined in [TR-159] and the managed objects defined in
+   this document.
+
+   +---------------------------------+---------------------------------+
+   | TR-159 Managed Object           | Corresponding SNMP Object       |
+   +---------------------------------+---------------------------------+
+   | oBondEth - Basic Package        |                                 |
+   | (Mandatory)                     |                                 |
+   +---------------------------------+---------------------------------+
+   | aEthBACPSupported               | g9982PortCapBacpSupported       |
+   +---------------------------------+---------------------------------+
+   | aEthTcAdminType                 | g9982PortConfTcAdminType        |
+   +---------------------------------+---------------------------------+
+   | aEthTcOperType                  | g9982PortStatTcOperType         |
+   +---------------------------------+---------------------------------+
+   | aEthTcTypesSupported            | g9982PortCapTcTypesSupported    |
+   +---------------------------------+---------------------------------+
+   | aEthRxErrors                    | g9982PortStatRxErrors           |
+   +---------------------------------+---------------------------------+
+   | aEthRxSmallFragments            | g9982PortStatRxSmallFragments   |
+   +---------------------------------+---------------------------------+
+   | aEthRxLargeFragments            | g9982PortStatRxLargeFragments   |
+   +---------------------------------+---------------------------------+
+   | aEthRxBadFragments              | g9982PortStatRxBadFragments     |
+   +---------------------------------+---------------------------------+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 7]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   +---------------------------------+---------------------------------+
+   | aEthRxLostFragments             | g9982PortStatRxLostFragments    |
+   +---------------------------------+---------------------------------+
+   | aEthRxLostStarts                | g9982PortStatRxLostStarts       |
+   +---------------------------------+---------------------------------+
+   | aEthRxLostEnds                  | g9982PortStatRxLostEnds         |
+   +---------------------------------+---------------------------------+
+   | aEthRxOverflows                 | g9982PortStatRxOverflows        |
+   +---------------------------------+---------------------------------+
+   | oBondEth - BACP Package         |                                 |
+   | (Optional)                      |                                 |
+   +---------------------------------+---------------------------------+
+   | aEthAdminCP                     | g9982PortConfAdminCp            |
+   +---------------------------------+---------------------------------+
+   | aEthOperCP                      | g9982PortStatOperCp             |
+   +---------------------------------+---------------------------------+
+   | oChannel - BACP Package         |                                 |
+   | (Optional)                      |                                 |
+   | aChannelEligibleGroupID         | g9982BceConfEligibleGroupID     |
+   +---------------------------------+---------------------------------+
+   | aChannelEligibleStreamID        | g9982BceConfPeerEligibleGroupID |
+   +---------------------------------+---------------------------------+
+   | oChannel - PM Package           |                                 |
+   | (Optional)                      |                                 |
+   +---------------------------------+---------------------------------+
+   | aChannelPtmTcRxCodingViolations | g9982BceStatTcInCodingErrors    |
+   +---------------------------------+---------------------------------+
+   | aChannelPtmTcRxCrcErrors        | g9982BceStatTcInCrcErrors       |
+   +---------------------------------+---------------------------------+
+
+                Table 1: Mapping of TR-159 Managed Objects
+
+   Note that some of the mapping between the objects defined in TR-159
+   and the ones defined in this MIB module is not one-to-one; for
+   example, while TR-159 PM attributes aGroupPerf* map to the
+   corresponding gBondPortPm* objects of the GBOND-MIB module, there are
+   no dedicated PM attributes for the g9982PortPm* objects introduced in
+   this MIB module.  However, since their definition is identical to the
+   definition of gBondPortPm* objects of the GBOND-MIB module, we can
+   map g9982PortPm* to the relevant aGroupPerf* attributes of TR-159 and
+   use the term 'partial mapping' to denote the fact that this mapping
+   is not one-to-one.
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 8]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+6.  G.Bond/Ethernet MIB Definitions
+
+   The G9982-MIB module IMPORTS objects from SNMPv2-SMI [RFC2578],
+   SNMPv2-TC [RFC2579], SNMPv2-CONF [RFC2580], IF-MIB [RFC2863], and
+   HC-PerfHist-TC-MIB [RFC3705].  The module has been structured as
+   recommended by [RFC4181].
+
+G9982-MIB DEFINITIONS ::= BEGIN
+
+  IMPORTS
+    MODULE-IDENTITY,
+    OBJECT-TYPE,
+    Counter32,
+    mib-2,
+    Unsigned32
+      FROM SNMPv2-SMI           -- RFC 2578
+    TEXTUAL-CONVENTION,
+    TruthValue,
+    PhysAddress
+      FROM SNMPv2-TC            -- RFC 2579
+    MODULE-COMPLIANCE,
+    OBJECT-GROUP
+      FROM SNMPv2-CONF          -- RFC 2580
+    ifIndex
+      FROM IF-MIB               -- RFC 2863
+    HCPerfCurrentCount,
+    HCPerfValidIntervals,
+    HCPerfInvalidIntervals,
+    HCPerfTimeElapsed
+      FROM  HC-PerfHist-TC-MIB  -- RFC 3705
+    ;
+------------------------------------------------------------------------
+  g9982MIB MODULE-IDENTITY
+    LAST-UPDATED "201302200000Z"  -- 20 February 2013
+    ORGANIZATION "IETF ADSL MIB Working Group"
+    CONTACT-INFO
+      "WG charter:
+        http://datatracker.ietf.org/wg/adslmib/charter/
+
+      Mailing Lists:
+        General Discussion: adslmib@ietf.org
+        To Subscribe: adslmib-request@ietf.org
+        In Body: subscribe your_email_address
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                    [Page 9]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Chair: Menachem Dodge
+      Postal: ECI Telecom, Ltd.
+              30 Hasivim St.
+              Petach-Tikva  4951169
+              Israel
+       Phone: +972-3-926-8421
+       EMail: menachemdodge1@gmail.com
+
+      Editor: Edward Beili
+      Postal: Actelis Networks, Inc.
+              25 Bazel St., P.O.B. 10173
+              Petach-Tikva  49103
+              Israel
+       Phone: +972-3-924-3491
+       EMail: edward.beili@actelis.com
+
+      Editor: Moti Morgenstern
+      Postal: ECI Telecom
+              30 Hasivim St.
+              Petach-Tikva  4951169
+              Israel
+       Phone: +972-3-926-6258
+       EMail: moti.morgenstern@ecitele.com"
+
+    DESCRIPTION
+      "The objects in this MIB module are used to manage the
+      Ethernet-based multi-pair bonded xDSL interfaces, as defined in
+      ITU-T Recommendation G.998.2 (G.Bond/Ethernet).
+
+      This MIB module MUST be used in conjunction with the GBOND-MIB
+      module, common to all G.Bond technologies.
+
+      The following references are used throughout this MIB module:
+
+      [G.998.2] refers to:
+        ITU-T Recommendation G.998.2: 'Ethernet-based multi-pair
+        bonding', January 2005.
+
+      [G.998.2-Amd2] refers to:
+        ITU-T Recommendation G.998.2 Amendment 2, December 2007.
+
+      [802.3] refers to:
+        IEEE Std 802.3-2005: 'IEEE Standard for Information
+        technology - Telecommunications and information exchange
+        between systems - Local and metropolitan area networks -
+        Specific requirements -
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 10]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+        Part 3: Carrier Sense Multiple Access with Collision
+        Detection (CSMA/CD) Access Method and Physical Layer
+        Specifications', December 2005.
+
+      [TR-159] refers to:
+        Broadband Forum Technical Report: 'Management Framework for
+        xDSL Bonding', December 2008.
+
+      Naming Conventions:
+        BACP   - Bonding Aggregation Control Protocol
+        BCE    - Bonding Channel Entity
+        BTU    - Bonding Terminating Unit
+        BTU-C  - Bonding Terminating Unit, CO side
+        BTU-R  - Bonding Terminating Unit, Remote Terminal (CPE) side
+        CO     - Central Office
+        CPE    - Customer Premises Equipment
+        GBS    - Generic Bonding Sub-layer
+        HDLC   - High-level Data Link Control
+        PTM-TC - Packet Transfer Mode Transmission Convergence
+                 (sub-layer)
+        SNR    - Signal to Noise Ratio
+        TC     - Transmission Convergence (sub-layer)
+        UAS    - Unavailable Seconds
+
+     Copyright (c) 2013 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, is permitted pursuant to, and subject to the license
+     terms contained in, the Simplified BSD License set forth in Section
+     4.c of the IETF Trust's Legal Provisions Relating to IETF Documents
+     (http://trustee.ietf.org/license-info)."
+
+    REVISION    "201302200000Z"  -- 20 February 2013
+    DESCRIPTION "Initial version, published as RFC 6767."
+
+    ::= { mib-2 264 }
+
+   -- Sections of the module
+   -- Structured as recommended by RFC 4181, Appendix D
+
+   g9982Objects     OBJECT IDENTIFIER ::= { g9982MIB 1 }
+
+   g9982Conformance OBJECT IDENTIFIER ::= { g9982MIB 2 }
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 11]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   -- Groups in the module
+
+   g9982Port        OBJECT IDENTIFIER ::= { g9982Objects 1 }
+
+   g9982Bce         OBJECT IDENTIFIER ::= { g9982Objects 2 }
+
+   -------------------------------
+   -- Textual Conventions
+   -------------------------------
+
+   G9982PtmTcType ::= TEXTUAL-CONVENTION
+     STATUS       current
+     DESCRIPTION
+       "This textual convention represents possible PTM-TC types in
+       G.Bond/Eth ports.  The following values are defined:
+         tc6465         - 64/65-octet encapsulation, as defined in
+                          [802.3] Clause 61.3.3.
+         tcHDLC         - HDLC encapsulation, as defined in [G.998.2]
+                          Annex B."
+     SYNTAX      INTEGER {
+       tc6465(1),
+       tcHDLC(2)
+     }
+
+   G9982CpType ::= TEXTUAL-CONVENTION
+     STATUS       current
+     DESCRIPTION
+       "This textual convention represents possible control protocol
+       types in G.Bond/Eth ports.  The following values are defined:
+         unknown      - the control protocol cannot be determined.
+         cpHS         - G.hs-based discovery and aggregation,
+                        as specified in [G.998.2].
+         cpBACP       - Bonding Aggregation Control Protocol (BACP) --
+                        a frame-based discovery, aggregation, and link
+                        management protocol, as specified in
+                        [G.998.2-Amd2] Annex C."
+     SYNTAX      INTEGER {
+       unknown(0),
+       cpHS(1),
+       cpBACP(2)
+     }
+
+   -------------------------------
+   -- GBS Notifications group
+   -------------------------------
+
+     -- empty --
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 12]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   -------------------------------
+   -- GBS group
+   -------------------------------
+
+   g9982PortConfTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for configuration of G.Bond/Eth GBS ports.  Entries in
+       this table MUST be maintained in a persistent manner."
+     ::= { g9982Port 1 }
+
+   g9982PortConfEntry OBJECT-TYPE
+     SYNTAX      G9982PortConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth Port Configuration table.
+       Each entry represents a G.Bond Ethernet port indexed by the
+       ifIndex.
+       Note that a G.Bond/Eth GBS port runs on top of a single or
+       multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9982PortConfTable 1 }
+
+   G9982PortConfEntry ::=
+     SEQUENCE {
+       g9982PortConfTcAdminType         G9982PtmTcType,
+       g9982PortConfAdminCp             G9982CpType
+     }
+
+   g9982PortConfTcAdminType  OBJECT-TYPE
+     SYNTAX      G9982PtmTcType
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "Administrative (desired) PTM-TC encapsulation type of a
+       G.Bond/Eth port (GBS).
+       Possible values are:
+         tc6465(1)  - 64/65-octet encapsulation
+         tcHDLC(2)  - HDLC encapsulation
+
+       Attempts to set a port to a non-supported PTM-TC encapsulation
+       type (see g9982PortCapTcTypesSupported) SHALL be rejected
+       (with the error inconsistentValue).
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 13]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Changing g9982PortConfTcAdminType is a traffic-disruptive
+       operation and as such SHALL be done when the link (GBS) is
+       administratively 'down', as indicated by the ifAdminStatus object
+       in the IF-MIB.
+       Attempts to change this object SHALL be rejected (with the error
+       inconsistentValue) if the link is 'up' or initializing.
+
+       This object maps to the TR-159 attribute aEthTcAdminType."
+     REFERENCE
+       "[TR-159], Section 5.5.3.4; RFC 2863, IF-MIB, ifAdminStatus"
+     ::= { g9982PortConfEntry 1 }
+
+   g9982PortConfAdminCp  OBJECT-TYPE
+     SYNTAX      G9982CpType
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "Administrative (desired) bonding control protocol of a
+       G.Bond/Eth port (GBS).  Possible values are:
+         cpHS(1)    - use G.hs-based protocol (default)
+         cpBACP(2)  - use frame-based BACP
+
+       Note that G.hs-based protocol support is mandatory, according to
+       [G.998.2].  Attempts to set a port to a non-supported bonding
+       control protocol (e.g., BACP if the value of
+       g9982PortCapBacpSupported is false) SHALL be rejected
+       (with the error inconsistentValue).
+
+       Changing g9982PortConfAdminCp is a traffic-disruptive
+       operation and as such SHALL be done when the link (GBS) is
+       administratively 'down', as indicated by the ifAdminStatus
+       object in the IF-MIB.
+       Attempts to change this object SHALL be rejected (with the error
+       inconsistentValue) if the link is 'up' or initializing.
+
+       This object maps to the TR-159 attribute aEthAdminCP."
+     REFERENCE
+       "[TR-159], Section 5.5.3.2; RFC 2863, IF-MIB, ifAdminStatus"
+     DEFVAL { cpHS }
+     ::= { g9982PortConfEntry 2 }
+
+
+   g9982PortCapTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortCapEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 14]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "Table for capabilities of G.Bond/Eth ports.  Entries in this
+       table MUST be maintained in a persistent manner."
+     ::= { g9982Port 2 }
+
+   g9982PortCapEntry OBJECT-TYPE
+     SYNTAX      G9982PortCapEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth Port Capability table.
+       Each entry represents a G.Bond port indexed by the ifIndex.
+       Note that a G.Bond GBS port runs on top of a single or
+       multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9982PortCapTable 1 }
+
+   G9982PortCapEntry ::=
+     SEQUENCE {
+       g9982PortCapTcTypesSupported         BITS,
+       g9982PortCapBacpSupported            TruthValue
+     }
+
+   g9982PortCapTcTypesSupported  OBJECT-TYPE
+     SYNTAX      BITS {
+       tc6465(0),
+       tcHDLC(1)
+     }
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "PTM-TC encapsulation types supported by the G.Bond/Eth port.
+       This is a bitmap of possible encapsulation types.  The various
+       bit positions are:
+         tc6465   - GBS is capable of 64/65-octet encapsulation
+         tcHDLC   - GBS is capable of HDLC encapsulation
+
+       A desired encapsulation is determined by
+       g9982PortConfTcAdminType, while g9982PortStatTcOperType
+       reflects the current operating mode.
+
+       This object maps to the TR-159 attribute aEthTcTypesSupported."
+     REFERENCE
+       "[TR-159], Section 5.5.3.6"
+     ::= { g9982PortCapEntry 1 }
+
+   g9982PortCapBacpSupported  OBJECT-TYPE
+     SYNTAX      TruthValue
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 15]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Indicates whether the Bonding Aggregation Control Protocol
+       (BACP) -- the frame-based discovery, aggregation, and link
+       management protocol specified in [G.998.2-Amd2]) is supported
+       by the G.Bond/Ethernet port.
+       A value of true(1) indicates that BACP is supported.
+       A value of false(2) indicates that BACP is unsupported.
+
+       The BACP functionality, if supported, can be enabled or
+       disabled via g9982AdminCP, while g9982OperCP
+       reflects the current BACP operating mode.
+
+       This object maps to the TR-159 attribute aEthBACPSupported."
+     REFERENCE
+       "[TR-159], Section 5.5.3.1; [G.998.2-Amd2], Annex C"
+     ::= { g9982PortCapEntry 2 }
+
+
+   g9982PortStatTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table provides overall status information of G.Bond
+       ports, complementing the generic status information from the
+       ifTable of the IF-MIB.  Additional status information about
+       connected BCEs is available from the relevant line MIBs.
+
+       This table contains live data from the equipment.  As such,
+       it is NOT persistent."
+     ::= { g9982Port 3 }
+
+   g9982PortStatEntry OBJECT-TYPE
+     SYNTAX      G9982PortStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth Port Status table.
+       Each entry represents a G.Bond/Eth port indexed by the
+       ifIndex.
+       Note that a G.Bond GBS port runs on top of a single or
+       multiple BCE port(s), which are also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9982PortStatTable 1 }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 16]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   G9982PortStatEntry ::=
+     SEQUENCE {
+       g9982PortStatTcOperType            G9982PtmTcType,
+       g9982PortStatOperCp                G9982CpType,
+       g9982PortStatRxErrors              Counter32,
+       g9982PortStatRxSmallFragments      Counter32,
+       g9982PortStatRxLargeFragments      Counter32,
+       g9982PortStatRxBadFragments        Counter32,
+       g9982PortStatRxLostFragments       Counter32,
+       g9982PortStatRxLostStarts          Counter32,
+       g9982PortStatRxLostEnds            Counter32,
+       g9982PortStatRxOverflows           Counter32
+     }
+
+   g9982PortStatTcOperType  OBJECT-TYPE
+     SYNTAX      G9982PtmTcType
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Current operational encapsulation type of the G.Bond/Eth
+       port.
+       Possible values are:
+         tc6465(1)   - GBS uses 64/65-octet encapsulation
+         tcHDLC(2)   - GBS uses HDLC encapsulation
+
+       The operational PTM-TC encapsulation type can be configured
+       via g9982PortConfTcAdminType.
+
+       This object maps to the TR-159 attribute aEthTcOperType."
+     REFERENCE
+       "[TR-159], Section 5.5.3.5"
+     ::= { g9982PortStatEntry 1 }
+
+   g9982PortStatOperCp  OBJECT-TYPE
+     SYNTAX      G9982CpType
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "Current operational bonding discovery and aggregation control
+       protocol of the G.Bond/Eth port.
+       Possible values are:
+         unknown(0)  - the protocol cannot be determined, e.g., when
+                       the GBS is 'down'
+         cpHS(1)     - GBS uses G.hs-based protocol
+         cpBACP(2)   - GBS uses frame-based BACP
+
+       The operational discovery and aggregation control protocol can
+       be configured via the g9982PortConfAdminCp variable.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 17]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       This object maps to the TR-159 attribute aEthOperCP."
+     REFERENCE
+       "[TR-159], Section 5.5.3.3"
+     ::= { g9982PortStatEntry 2 }
+
+   g9982PortStatRxErrors OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of Ethernet frame fragments that have been received
+       by the bonding function and discarded due to various errors.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxErrors."
+     REFERENCE
+       "[TR-159], Section 5.5.3.7"
+     ::= { g9982PortStatEntry 3 }
+
+   g9982PortStatRxSmallFragments OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of fragments smaller than minFragmentSize (64 bytes)
+       that have been received by the bonding function and discarded.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxSmallFragments."
+     REFERENCE
+       "[TR-159], Section 5.5.3.8"
+     ::= { g9982PortStatEntry 4 }
+
+   g9982PortStatRxLargeFragments OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 18]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A number of fragments larger than maxFragmentSize (512 bytes)
+       that have been received by the bonding function and discarded.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxLargeFragments."
+     REFERENCE
+       "[TR-159], Section 5.5.3.9"
+     ::= { g9982PortStatEntry 5 }
+
+   g9982PortStatRxBadFragments OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of fragments that do not fit into the sequence
+       expected by the frame assembly function and that have been
+       received and discarded by the bonding function (the frame buffer
+       is flushed to the next valid frame start).
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxBadFragments."
+     REFERENCE
+       "[TR-159], Section 5.5.3.10"
+     ::= { g9982PortStatEntry 6 }
+
+   g9982PortStatRxLostFragments OBJECT-TYPE
+     SYNTAX      Counter32
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of gaps in the sequence of fragments that have
+       been received by the bonding function (the frame buffer is
+       flushed to the next valid frame start, when a fragment or
+       fragments expected by the frame assembly function are not
+       received).
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 19]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxLostFragments."
+     REFERENCE
+       "[TR-159], Section 5.5.3.11"
+     ::= { g9982PortStatEntry 7 }
+
+   g9982PortStatRxLostStarts OBJECT-TYPE
+     SYNTAX      Counter32
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of missing StartOfPacket indicators expected by the
+       frame assembly function.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxLostStarts."
+     REFERENCE
+       "[TR-159], Section 5.5.3.12"
+     ::= { g9982PortStatEntry 8 }
+
+   g9982PortStatRxLostEnds OBJECT-TYPE
+     SYNTAX      Counter32
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of missing EndOfPacket indicators expected by the
+       frame assembly function.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxLostEnds."
+     REFERENCE
+       "[TR-159], Section 5.5.3.13"
+     ::= { g9982PortStatEntry 9 }
+
+   g9982PortStatRxOverflows OBJECT-TYPE
+     SYNTAX      Counter32
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 20]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of fragments, received and discarded by the bonding
+       function, that would have caused the frame assembly buffer to
+       overflow.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute aEthRxOverflows."
+     REFERENCE
+       "[TR-159], Section 5.5.3.14"
+     ::= { g9982PortStatEntry 10 }
+
+   -------------------------------
+   -- GBS Performance Monitoring group
+   -------------------------------
+
+   g9982PM   OBJECT IDENTIFIER ::= { g9982Port 4 }
+
+   g9982PortPmCurTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains current Performance Monitoring information
+       for a G.Bond/Eth port.  This table contains live data from the
+       equipment and as such is NOT persistent."
+     ::= { g9982PM 1 }
+
+   g9982PortPmCurEntry OBJECT-TYPE
+     SYNTAX      G9982PortPmCurEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth Port PM table.
+       Each entry represents a G.Bond/Eth port indexed by the
+       ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9982PortPmCurTable 1 }
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 21]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   G9982PortPmCurEntry ::=
+     SEQUENCE {
+       g9982PortPm15MinValidIntervals      HCPerfValidIntervals,
+       g9982PortPm15MinInvalidIntervals    HCPerfInvalidIntervals,
+       g9982PortPmCur15MinTimeElapsed      HCPerfTimeElapsed,
+       g9982PortPmCur15MinRxErrors         HCPerfCurrentCount,
+       g9982PortPmCur15MinRxSmallFragments HCPerfCurrentCount,
+       g9982PortPmCur15MinRxLargeFragments HCPerfCurrentCount,
+       g9982PortPmCur15MinRxBadFragments   HCPerfCurrentCount,
+       g9982PortPmCur15MinRxLostFragments  HCPerfCurrentCount,
+       g9982PortPmCur15MinRxLostStarts     HCPerfCurrentCount,
+       g9982PortPmCur15MinRxLostEnds       HCPerfCurrentCount,
+       g9982PortPmCur15MinRxOverflows      HCPerfCurrentCount,
+       g9982PortPm1DayValidIntervals       Unsigned32,
+       g9982PortPm1DayInvalidIntervals     Unsigned32,
+       g9982PortPmCur1DayTimeElapsed       HCPerfTimeElapsed,
+       g9982PortPmCur1DayRxErrors          HCPerfCurrentCount,
+       g9982PortPmCur1DayRxSmallFragments  HCPerfCurrentCount,
+       g9982PortPmCur1DayRxLargeFragments  HCPerfCurrentCount,
+       g9982PortPmCur1DayRxBadFragments    HCPerfCurrentCount,
+       g9982PortPmCur1DayRxLostFragments   HCPerfCurrentCount,
+       g9982PortPmCur1DayRxLostStarts      HCPerfCurrentCount,
+       g9982PortPmCur1DayRxLostEnds        HCPerfCurrentCount,
+       g9982PortPmCur1DayRxOverflows       HCPerfCurrentCount
+     }
+
+   g9982PortPm15MinValidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfValidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 15-minute intervals for which the
+       performance data was collected.  The value of this object will
+       be 96 or the maximum number of 15-minute history intervals
+       collected by the implementation, unless the measurement was
+       (re)started recently, in which case the value will be the
+       number of complete 15-minute intervals for which there are at
+       least some data.
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinValidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.32"
+     ::= { g9982PortPmCurEntry 1 }
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 22]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   g9982PortPm15MinInvalidIntervals  OBJECT-TYPE
+     SYNTAX      HCPerfInvalidIntervals
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 15-minute intervals for which the
+       performance data was not always available.  The value will
+       typically be zero, except in cases where the data for some
+       intervals are not available.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinInvalidIntervals."
+     REFERENCE
+       "[TR-159], Section 5.5.1.33"
+     ::= { g9982PortPmCurEntry 2 }
+
+   g9982PortPmCur15MinTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds that have elapsed since the
+       beginning of the current 15-minute performance interval.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerfCurr15MinTimeElapsed."
+     REFERENCE
+       "[TR-159], Section 5.5.1.34"
+     ::= { g9982PortPmCurEntry 3 }
+
+   g9982PortPmCur15MinRxErrors  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of errored fragments received and discarded
+       by a G.Bond/Eth port during the current 15-minute performance
+       interval.
+
+       Note that the total number of errored fragments is indicated by
+       the g9982PortStatRxErrors object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.7"
+     ::= { g9982PortPmCurEntry 4}
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 23]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   g9982PortPmCur15MinRxSmallFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments smaller than minFragmentSize
+       (64 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the current 15-minute performance
+       interval.
+
+       Note that the total number of small fragments is indicated by
+       the g9982PortStatRxSmallFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.8"
+     ::= { g9982PortPmCurEntry 5}
+
+   g9982PortPmCur15MinRxLargeFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments larger than maxFragmentSize
+       (512 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the current 15-minute performance
+       interval.
+
+       Note that the total number of large fragments is indicated by
+       the g9982PortStatRxLargeFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.9"
+     ::= { g9982PortPmCurEntry 6}
+
+   g9982PortPmCur15MinRxBadFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that do not fit into the
+       sequence expected by the frame assembly function and that have
+       been received and discarded by a G.Bond/Eth port during the
+       current 15-minute performance interval.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 24]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Note that the total number of bad fragments is indicated by
+       the g9982PortStatRxBadFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.10"
+     ::= { g9982PortPmCurEntry 7}
+
+   g9982PortPmCur15MinRxLostFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of gaps in the sequence of fragments
+       expected by the frame assembly function of a G.Bond/Eth port
+       during the current 15-minute performance interval.
+
+       Note that the total number of these lost fragments is indicated
+       by the g9982PortStatRxLostFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.11"
+     ::= { g9982PortPmCurEntry 8}
+
+   g9982PortPmCur15MinRxLostStarts  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing StartOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       current 15-minute performance interval.
+
+       Note that the total number of missing StartOfPacket indicators
+       is indicated by the g9982PortStatRxLostStarts object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.12"
+     ::= { g9982PortPmCurEntry 9}
+
+   g9982PortPmCur15MinRxLostEnds  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 25]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A read-only count of missing EndOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       current 15-minute performance interval.
+
+       Note that the total number of missing EndOfPacket indicators
+       is indicated by the g9982PortStatRxLostEnds object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.13"
+     ::= { g9982PortPmCurEntry 10}
+
+   g9982PortPmCur15MinRxOverflows  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that have been received and
+       discarded by a G.Bond/Eth port, which would have caused the
+       frame assembly buffer to overflow, during the current 15-minute
+       performance interval.
+
+       Note that the total number of fragments that would have caused
+       the frame assembly buffer to overflow is indicated by the
+       g9982PortStatRxOverflows object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.14"
+     ::= { g9982PortPmCurEntry 11}
+
+   g9982PortPm1DayValidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 1-day intervals for which data was
+       collected.  The value of this object will be 7 or the maximum
+       number of 1-day history intervals collected by the
+       implementation, unless the measurement was (re)started recently,
+       in which case the value will be the number of complete 1-day
+       intervals for which there are at least some data.
+       In certain cases, it is possible that some intervals are
+       unavailable.  In this case, this object reports the maximum
+       interval number for which data is available."
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 26]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.1.45"
+     ::= { g9982PortPmCurEntry 12 }
+
+   g9982PortPm1DayInvalidIntervals  OBJECT-TYPE
+     SYNTAX      Unsigned32 (0..7)
+     UNITS       "days"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only number of 1-day intervals for which data was not
+       always available.  The value will typically be zero, except in
+       cases where the data for some intervals are not available."
+     REFERENCE
+       "[TR-159], Section 5.5.1.46"
+     ::= { g9982PortPmCurEntry 13 }
+
+   g9982PortPmCur1DayTimeElapsed  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds that have elapsed since the
+       beginning of the current 1-day performance interval."
+     REFERENCE
+       "[TR-159], Section 5.5.1.47"
+     ::= { g9982PortPmCurEntry 14 }
+
+   g9982PortPmCur1DayRxErrors  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of errored fragments received and discarded
+       by a G.Bond/Eth port during the current 1-day performance
+       interval.
+
+       Note that the total number of errored fragments is indicated by
+       the g9982PortStatRxErrors object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.7"
+     ::= { g9982PortPmCurEntry 15 }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 27]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   g9982PortPmCur1DayRxSmallFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments smaller than minFragmentSize
+       (64 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the current 1-day performance interval.
+
+       Note that the total number of small fragments is indicated by
+       the g9982PortStatRxSmallFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.8"
+     ::= { g9982PortPmCurEntry 16}
+
+   g9982PortPmCur1DayRxLargeFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments larger than maxFragmentSize
+       (512 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the current 1-day performance interval.
+
+       Note that the total number of large fragments is indicated by
+       the g9982PortStatRxLargeFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.9"
+     ::= { g9982PortPmCurEntry 17}
+
+   g9982PortPmCur1DayRxBadFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that do not fit into the
+       sequence expected by the frame assembly function and that have
+       been received and discarded by a G.Bond/Eth port during the
+       current 1-day performance interval.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 28]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Note that the total number of bad fragments is indicated by
+       the g9982PortStatRxBadFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.10"
+     ::= { g9982PortPmCurEntry 18}
+
+   g9982PortPmCur1DayRxLostFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of gaps in the sequence of fragments
+       expected by the frame assembly function of a G.Bond/Eth port
+       during the current 1-day performance interval.
+
+       Note that the total number of these lost fragments is indicated
+       by the g9982PortStatRxLostFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.11"
+     ::= { g9982PortPmCurEntry 19}
+
+   g9982PortPmCur1DayRxLostStarts  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing StartOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       current 1-day performance interval.
+
+       Note that the total number of missing StartOfPacket indicators
+       is indicated by the g9982PortStatRxLostStarts object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.12"
+     ::= { g9982PortPmCurEntry 20}
+
+   g9982PortPmCur1DayRxLostEnds  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 29]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A read-only count of missing EndOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       current 1-day performance interval.
+
+       Note that the total number of missing EndOfPacket indicators
+       is indicated by the g9982PortStatRxLostEnds object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.13"
+     ::= { g9982PortPmCurEntry 21}
+
+   g9982PortPmCur1DayRxOverflows  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that have been received and
+       discarded by a G.Bond/Eth port, which would have caused the
+       frame assembly buffer to overflow, during the current 1-day
+       performance interval.
+
+       Note that the total number of fragments that would have caused
+       the frame assembly buffer to overflow is indicated by the
+       g9982PortStatRxOverflows object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.14"
+     ::= { g9982PortPmCurEntry 22}
+
+   -- Port PM history: 15-min buckets
+
+   g9982PortPm15MinTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortPm15MinEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 15-minute buckets of Performance
+       Monitoring information for a G.Bond/Eth port (a row for each
+       15-minute interval, up to 96 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { g9982PM 2 }
+
+   g9982PortPm15MinEntry OBJECT-TYPE
+     SYNTAX      G9982PortPm15MinEntry
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 30]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth Port historical 15-minute PM table.
+       Each entry represents Performance Monitoring data for a
+       G.Bond/Eth port, indexed by the ifIndex, collected during a
+       particular 15-minute interval, indexed by the
+       g9982PortPm15MinIntervalIndex."
+     INDEX  { ifIndex, g9982PortPm15MinIntervalIndex }
+     ::= { g9982PortPm15MinTable 1 }
+
+   G9982PortPm15MinEntry ::=
+     SEQUENCE {
+       g9982PortPm15MinIntervalIndex            Unsigned32,
+       g9982PortPm15MinIntervalMoniTime         HCPerfTimeElapsed,
+       g9982PortPm15MinIntervalRxErrors         HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxSmallFragments HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxLargeFragments HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxBadFragments   HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxLostFragments  HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxLostStarts     HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxLostEnds       HCPerfCurrentCount,
+       g9982PortPm15MinIntervalRxOverflows      HCPerfCurrentCount,
+       g9982PortPm15MinIntervalValid            TruthValue
+     }
+
+   g9982PortPm15MinIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..96)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance Data Interval number.  1 is the most recent
+       previous interval; interval 96 is 24 hours ago.
+       Intervals 2..96 are OPTIONAL.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinIntervalNumber."
+     REFERENCE
+       "[TR-159], Section 5.5.1.57"
+     ::= { g9982PortPm15MinEntry 1 }
+
+   g9982PortPm15MinIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 31]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A read-only count of seconds over which the performance data
+       was actually monitored.  This value will be the same as the
+       interval duration (900 seconds), except in a situation where
+       performance data could not be collected for any reason."
+     ::= { g9982PortPm15MinEntry 2 }
+
+   g9982PortPm15MinIntervalRxErrors  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of errored fragments received and discarded
+       by a G.Bond/Eth port during the 15-minute performance history
+       interval.
+
+       Note that the total number of errored fragments is indicated by
+       the g9982PortStatRxErrors object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.7"
+     ::= { g9982PortPm15MinEntry 3}
+
+   g9982PortPm15MinIntervalRxSmallFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments smaller than minFragmentSize
+       (64 bytes) that have been received and discarded by a
+        G.Bond/Eth port during the 15-minute performance history
+        interval.
+
+       Note that the total number of small fragments is indicated by
+       the g9982PortStatRxSmallFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.8"
+     ::= { g9982PortPm15MinEntry 4}
+
+   g9982PortPm15MinIntervalRxLargeFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 32]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments larger than maxFragmentSize
+       (512 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the 15-minute performance history
+       interval.
+
+       Note that the total number of large fragments is indicated by
+       the g9982PortStatRxLargeFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.9"
+     ::= { g9982PortPm15MinEntry 5}
+
+   g9982PortPm15MinIntervalRxBadFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that do not fit into the
+       sequence expected by the frame assembly function and that have
+       been received and discarded by a G.Bond/Eth port during the
+       15-minute performance history interval.
+
+       Note that the total number of bad fragments is indicated by
+       the g9982PortStatRxBadFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.10"
+     ::= { g9982PortPm15MinEntry 6}
+
+   g9982PortPm15MinIntervalRxLostFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of gaps in the sequence of fragments
+       expected by the frame assembly function of a G.Bond/Eth port
+       during the 15-minute performance history interval.
+
+       Note that the total number of these lost fragments is indicated
+       by the g9982PortStatRxLostFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 33]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.3.11"
+     ::= { g9982PortPm15MinEntry 7}
+
+   g9982PortPm15MinIntervalRxLostStarts  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing StartOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       15-minute performance history interval.
+
+       Note that the total number of missing StartOfPacket indicators
+       is indicated by the g9982PortStatRxLostStarts object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.12"
+     ::= { g9982PortPm15MinEntry 8}
+
+   g9982PortPm15MinIntervalRxLostEnds  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing EndOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       15-minute performance history interval.
+
+       Note that the total number of missing EndOfPacket indicators
+       is indicated by the g9982PortStatRxLostEnds object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.13"
+     ::= { g9982PortPm15MinEntry 9}
+
+   g9982PortPm15MinIntervalRxOverflows  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that have been received and
+       discarded by a G.Bond/Eth port, which would have caused the
+       frame assembly buffer to overflow, during the 15-minute
+       performance history interval.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 34]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Note that the total number of fragments that would have caused
+       the frame assembly buffer to overflow is indicated by the
+       g9982PortStatRxOverflows object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.14"
+     ::= { g9982PortPm15MinEntry 10}
+
+   g9982PortPm15MinIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf15MinIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.58"
+     ::= { g9982PortPm15MinEntry 11 }
+
+   -- Port PM history: 1-day buckets
+
+   g9982PortPm1DayTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982PortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table contains historical 1-day buckets of Performance
+       Monitoring information for a G.Bond/Eth port (a row for each
+       1-day interval, up to 7 intervals).
+       Entries in this table MUST be maintained in a persistent manner."
+     ::= { g9982PM 3 }
+
+   g9982PortPm1DayEntry OBJECT-TYPE
+     SYNTAX      G9982PortPm1DayEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 35]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "An entry in the G.Bond/Eth port historical 1-day PM table.
+       Each entry represents Performance Monitoring data for such a
+       port, indexed by the ifIndex, collected during a particular
+       1-day interval, indexed by the g9982PortPm1DayIntervalIndex."
+     INDEX  { ifIndex, g9982PortPm1DayIntervalIndex }
+     ::= { g9982PortPm1DayTable 1 }
+
+   G9982PortPm1DayEntry ::=
+     SEQUENCE {
+       g9982PortPm1DayIntervalIndex             Unsigned32,
+       g9982PortPm1DayIntervalMoniTime          HCPerfTimeElapsed,
+       g9982PortPm1DayIntervalRxErrors          HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxSmallFragments  HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxLargeFragments  HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxBadFragments    HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxLostFragments   HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxLostStarts      HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxLostEnds        HCPerfCurrentCount,
+       g9982PortPm1DayIntervalRxOverflows       HCPerfCurrentCount,
+       g9982PortPm1DayIntervalValid             TruthValue
+     }
+
+   g9982PortPm1DayIntervalIndex  OBJECT-TYPE
+     SYNTAX      Unsigned32 (1..7)
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Performance Data Interval number.  1 is the most recent
+       previous interval; interval 7 is 7 days ago.
+       Intervals 2..7 are OPTIONAL.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalNumber."
+     REFERENCE
+       "[TR-159], Section 5.5.1.62"
+     ::= { g9982PortPm1DayEntry 1 }
+
+   g9982PortPm1DayIntervalMoniTime  OBJECT-TYPE
+     SYNTAX      HCPerfTimeElapsed
+     UNITS       "seconds"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of seconds over which the performance data
+       was actually monitored.  This value will be the same as the
+       interval duration (86400 seconds), except in a situation where
+       performance data could not be collected for any reason.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 36]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalMoniSecs."
+     REFERENCE
+       "[TR-159], Section 5.5.1.64"
+     ::= { g9982PortPm1DayEntry 2 }
+
+   g9982PortPm1DayIntervalRxErrors  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of errored fragments received and discarded
+       by a G.Bond/Eth port during the 1-day performance history
+       interval.
+
+       Note that the total number of errored fragments is indicated by
+       the g9982PortStatRxErrors object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.7"
+     ::= { g9982PortPm1DayEntry 3 }
+
+   g9982PortPm1DayIntervalRxSmallFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments smaller than minFragmentSize
+       (64 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the 1-day performance history interval.
+
+       Note that the total number of small fragments is indicated by
+       the g9982PortStatRxSmallFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.8"
+     ::= { g9982PortPm1DayEntry 4}
+
+   g9982PortPm1DayIntervalRxLargeFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 37]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A read-only count of fragments larger than maxFragmentSize
+       (512 bytes) that have been received and discarded by a
+       G.Bond/Eth port during the 1-day performance history interval.
+
+       Note that the total number of large fragments is indicated by
+       the g9982PortStatRxLargeFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.9"
+     ::= { g9982PortPm1DayEntry 5}
+
+   g9982PortPm1DayIntervalRxBadFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that do not fit into the
+       sequence expected by the frame assembly function and that have
+       been received and discarded by a G.Bond/Eth port during the
+       1-day performance history interval.
+
+       Note that the total number of bad fragments is indicated by
+       the g9982PortStatRxBadFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.10"
+     ::= { g9982PortPm1DayEntry 6}
+
+   g9982PortPm1DayIntervalRxLostFragments  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of gaps in the sequence of fragments
+       expected by the frame assembly function of a G.Bond/Eth port
+       during the 1-day performance history interval.
+
+       Note that the total number of these lost fragments is indicated
+       by the g9982PortStatRxLostFragments object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 38]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     REFERENCE
+       "[TR-159], Section 5.5.3.11"
+     ::= { g9982PortPm1DayEntry 7}
+
+   g9982PortPm1DayIntervalRxLostStarts  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing StartOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       1-day performance history interval.
+
+       Note that the total number of missing StartOfPacket indicators
+       is indicated by the g9982PortStatRxLostStarts object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.12"
+     ::= { g9982PortPm1DayEntry 8}
+
+   g9982PortPm1DayIntervalRxLostEnds  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of missing EndOfPacket indicators expected
+       by the frame assembly function of a G.Bond/Eth port during the
+       1-day performance history interval.
+
+       Note that the total number of missing EndOfPacket indicators
+       is indicated by the g9982PortStatRxLostEnds object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.13"
+     ::= { g9982PortPm1DayEntry 9}
+
+   g9982PortPm1DayIntervalRxOverflows  OBJECT-TYPE
+     SYNTAX      HCPerfCurrentCount
+     UNITS       "fragments"
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only count of fragments that have been received and
+       discarded by a G.Bond/Eth port, which would have caused the
+       frame assembly buffer to overflow, during the 1-day performance
+       history interval.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 39]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Note that the total number of fragments that would have caused
+       the frame assembly buffer to overflow is indicated by the
+       g9982PortStatRxOverflows object.
+
+       This object is inhibited during Unavailable Seconds (UAS)."
+     REFERENCE
+       "[TR-159], Section 5.5.3.14"
+     ::= { g9982PortPm1DayEntry 10}
+
+   g9982PortPm1DayIntervalValid  OBJECT-TYPE
+     SYNTAX      TruthValue
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A read-only object indicating whether or not this history
+       bucket contains valid data.  A valid bucket is reported as
+       true(1) and an invalid bucket as false(2).
+       If this history bucket is invalid, the BTU MUST NOT produce
+       notifications based upon the value of the counters in this
+       bucket.
+       Note that an implementation may decide not to store invalid
+       history buckets in its database.  In such a case, this object
+       is not required, as only valid history buckets are available
+       while invalid history buckets are simply not in the database.
+
+       This object partially maps to the TR-159 attribute
+       aGroupPerf1DayIntervalValid."
+     REFERENCE
+       "[TR-159], Section 5.5.1.63"
+     ::= { g9982PortPm1DayEntry 11 }
+
+   -------------------------------
+   -- BCE group
+   -------------------------------
+
+   g9982BceConfTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982BceConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "Table for configuration of G.Bond/Eth-specific aspects for the
+       Bonding Channel Entity (BCE) ports (modems/channels).
+
+       Entries in this table MUST be maintained in a persistent
+       manner."
+     ::= { g9982Bce 1 }
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 40]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   g9982BceConfEntry OBJECT-TYPE
+     SYNTAX      G9982BceConfEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth BCE Configuration table.
+       Each entry represents G.998.2-specific aspects of a BCE port
+       indexed by the ifIndex.  Note that a G.Bond/Eth BCE port can be
+       stacked below a single GBS port, also indexed by the ifIndex."
+     INDEX  { ifIndex }
+     ::= { g9982BceConfTable 1 }
+
+   G9982BceConfEntry ::=
+     SEQUENCE {
+       g9982BceConfEligibleGroupID      PhysAddress,
+       g9982BceConfPeerEligibleGroupID  PhysAddress
+     }
+
+   g9982BceConfEligibleGroupID  OBJECT-TYPE
+     SYNTAX      PhysAddress (SIZE(0|6))
+     MAX-ACCESS  read-write
+     STATUS      current
+     DESCRIPTION
+       "BACP Eligible Group ID of a G.Bond/ETH BCE port.
+       A universally unique 6-octet-long identifier, used by the
+       OPTIONAL BACP, to determine bonding eligibility.  When two BCEs
+       have the same g9982BceConfEligibleGroupID on a system, they
+       are eligible to be aggregated on that system.  Typically, all
+       BCEs on a BTU-R device would be assigned the same
+       g9982BceConfEligibleGroupID, to assert that all of the BCEs
+       should be in the same bonded group.  BCEs with different
+       g9982BceConfEligibleGroupID values MUST NOT be connected to
+       the same GBS.
+       BCEs with the same g9982BceConfEligibleGroupID MAY be
+       connected to different GBS ports.
+       This object MUST be instantiated during BACP initialization,
+       when every BCE belongs to its own GBS.  Attempts to change this
+       object MUST be rejected (with the error inconsistentValue), if
+       the BCE is aggregated with other BCEs, i.e., more than one BCE
+       is connected to the same GBS, or if the BCE in question is not
+       eligible to be bonded with other BCEs having the same value
+       (e.g., the bonding is limited to a single line card and BCEs are
+       located on different line cards, or BCEs are the channels of
+       the same line).
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 41]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       Note that bonding eligibility is reflected in the
+       ifCapStackTable and its inverse, the ifInvCapStackTable;
+       as such, any modification of g9982BceConfEligibleGroupID MUST
+       be reflected in these tables.
+
+       A zero-length octet string SHALL be returned on an attempt to
+       read this object on systems not supporting BACP (the value of
+       g9982PortCapBacpSupported for the connected GBS is false).
+
+       This object maps to the TR-159 attribute
+       aChannelEligibleGroupID."
+     REFERENCE
+       "[TR-159], Section 5.5.7.3"
+     ::= { g9982BceConfEntry 1 }
+
+   g9982BceConfPeerEligibleGroupID  OBJECT-TYPE
+     SYNTAX      PhysAddress (SIZE(0|6))
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "BACP Eligible Group ID of a peer G.Bond/ETH BCE port, most
+       recently received by the local BCE via a Local info TLV BACPDU
+       message from the peer BCE.
+       A universally unique 6-octet-long identifier, used by the
+       OPTIONAL BACP, to determine bonding eligibility.
+       BCEs with different g9982BceConfPeerEligibleGroupID values
+       MUST NOT be connected to the same GBS.
+       BCEs with the same g9982BceConfPeerEligibleGroupID MAY be
+       connected to different GBS ports.
+
+       A zero-length octet string SHALL be returned on an attempt to
+       read this object on systems not supporting BACP (the value of
+       g9982PortCapBacpSupported for the connected GBS is false)
+       or when no BACPDUs have been received from the peer BCE.
+
+       This object maps to the G.998.2-Amd2 attribute
+       Remote Group ID."
+     REFERENCE
+       "[G.998.2-Amd2], Appendix C.3.1.6"
+     ::= { g9982BceConfEntry 2 }
+
+   g9982BceStatTable OBJECT-TYPE
+     SYNTAX      SEQUENCE OF G9982BceStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "This table provides common status information of G.Bond/Eth
+       BCE ports.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 42]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       This table contains live data from the equipment.  As such,
+       it is NOT persistent."
+     ::= { g9982Bce 2 }
+
+   g9982BceStatEntry OBJECT-TYPE
+     SYNTAX      G9982BceStatEntry
+     MAX-ACCESS  not-accessible
+     STATUS      current
+     DESCRIPTION
+       "An entry in the G.Bond/Eth BCE Status table.
+       Each entry represents common aspects of a G.Bond/Eth BCE port
+       indexed by the ifIndex.  Note that a BCE port can be stacked
+       below a single GBS port, also indexed by the ifIndex,
+       possibly together with other BCE ports."
+     INDEX  { ifIndex }
+     ::= { g9982BceStatTable 1 }
+
+   G9982BceStatEntry ::=
+     SEQUENCE {
+       g9982BceStatTcInCodingErrors        Counter32,
+       g9982BceStatTcInCrcErrors           Counter32
+     }
+
+   g9982BceStatTcInCodingErrors OBJECT-TYPE
+     SYNTAX      Counter32
+     MAX-ACCESS  read-only
+     STATUS      current
+     DESCRIPTION
+       "A number of PTM-TC encapsulation errors.  This counter is
+       incremented for each encapsulation error detected by the
+       PTM-TC receive function.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute
+       aChannelPtmTcRxCodingViolations."
+     REFERENCE
+       "[TR-159], Section 5.5.7.8"
+     ::= { g9982BceStatEntry 1 }
+
+   g9982BceStatTcInCrcErrors OBJECT-TYPE
+     SYNTAX      Counter32
+     MAX-ACCESS  read-only
+     STATUS      current
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 43]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A number of PTM-TC CRC errors.  This counter is incremented
+       for each CRC error detected by the PTM-TC receive function.
+
+       Discontinuities in the value of this counter can occur at
+       re-initialization of the management system, and at other times
+       as indicated by the value of ifCounterDiscontinuityTime, as
+       defined in the IF-MIB.
+
+       This object maps to the TR-159 attribute
+       aChannelPtmTcRxCrcErrors."
+     REFERENCE
+       "[TR-159], Section 5.5.7.9"
+     ::= { g9982BceStatEntry 2 }
+
+
+  -------------------------------
+  -- Conformance Statements
+  -------------------------------
+
+   g9982Groups      OBJECT IDENTIFIER
+     ::= { g9982Conformance 1 }
+
+   g9982Compliances OBJECT IDENTIFIER
+     ::= { g9982Conformance 2 }
+
+   -- Object groups
+
+   g9982BasicGroup OBJECT-GROUP
+     OBJECTS {
+       g9982PortCapTcTypesSupported,
+       g9982PortCapBacpSupported,
+       g9982PortConfTcAdminType,
+       g9982PortStatTcOperType,
+       g9982PortStatRxErrors,
+       g9982PortStatRxSmallFragments,
+       g9982PortStatRxLargeFragments,
+       g9982PortStatRxBadFragments,
+       g9982PortStatRxLostFragments,
+       g9982PortStatRxLostStarts,
+       g9982PortStatRxLostEnds,
+       g9982PortStatRxOverflows,
+       g9982BceStatTcInCodingErrors,
+       g9982BceStatTcInCrcErrors
+     }
+     STATUS      current
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 44]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     DESCRIPTION
+       "A collection of objects representing management information
+       for G.Bond/Eth GBS ports."
+     ::= { g9982Groups 1 }
+
+   g9982BacpGroup OBJECT-GROUP
+     OBJECTS {
+       g9982PortConfAdminCp,
+       g9982PortStatOperCp,
+       g9982BceConfEligibleGroupID,
+       g9982BceConfPeerEligibleGroupID
+
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects representing management information
+       for the OPTIONAL frame-based Bonding Aggregation Control
+       Protocol (BACP) used by G.Bond/Eth GBS ports instead of the
+       mandatory G.hs-based discovery and aggregation protocol."
+     ::= { g9982Groups 2 }
+
+   g9982BceGroup OBJECT-GROUP
+     OBJECTS {
+       g9982BceStatTcInCodingErrors,
+       g9982BceStatTcInCrcErrors
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects representing OPTIONAL management
+       information for G.Bond/Eth BCE ports."
+     ::= { g9982Groups 3 }
+
+   g9982PerfCurrGroup OBJECT-GROUP
+     OBJECTS {
+       g9982PortPm15MinValidIntervals,
+       g9982PortPm15MinInvalidIntervals,
+       g9982PortPmCur15MinTimeElapsed,
+       g9982PortPmCur15MinRxErrors,
+       g9982PortPmCur15MinRxSmallFragments,
+       g9982PortPmCur15MinRxLargeFragments,
+       g9982PortPmCur15MinRxBadFragments,
+       g9982PortPmCur15MinRxLostFragments,
+       g9982PortPmCur15MinRxLostStarts,
+       g9982PortPmCur15MinRxLostEnds,
+       g9982PortPmCur15MinRxOverflows,
+       g9982PortPm1DayValidIntervals,
+       g9982PortPm1DayInvalidIntervals,
+       g9982PortPmCur1DayTimeElapsed,
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 45]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       g9982PortPmCur1DayRxErrors,
+       g9982PortPmCur1DayRxSmallFragments,
+       g9982PortPmCur1DayRxLargeFragments,
+       g9982PortPmCur1DayRxBadFragments,
+       g9982PortPmCur1DayRxLostFragments,
+       g9982PortPmCur1DayRxLostStarts,
+       g9982PortPmCur1DayRxLostEnds,
+       g9982PortPmCur1DayRxOverflows
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL current Performance
+       Monitoring information for G.Bond/Eth ports."
+     ::= { g9982Groups 4 }
+
+   g9982Perf15MinGroup OBJECT-GROUP
+     OBJECTS {
+       g9982PortPm15MinIntervalMoniTime,
+       g9982PortPm15MinIntervalRxErrors,
+       g9982PortPm15MinIntervalRxSmallFragments,
+       g9982PortPm15MinIntervalRxLargeFragments,
+       g9982PortPm15MinIntervalRxBadFragments,
+       g9982PortPm15MinIntervalRxLostFragments,
+       g9982PortPm15MinIntervalRxLostStarts,
+       g9982PortPm15MinIntervalRxLostEnds,
+       g9982PortPm15MinIntervalRxOverflows,
+       g9982PortPm15MinIntervalValid
+     }
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond/Eth ports, during
+       previous 15-minute intervals."
+     ::= { g9982Groups 5 }
+
+   g9982Perf1DayGroup OBJECT-GROUP
+     OBJECTS {
+       g9982PortPm1DayIntervalMoniTime,
+       g9982PortPm1DayIntervalRxErrors,
+       g9982PortPm1DayIntervalRxSmallFragments,
+       g9982PortPm1DayIntervalRxLargeFragments,
+       g9982PortPm1DayIntervalRxBadFragments,
+       g9982PortPm1DayIntervalRxLostFragments,
+       g9982PortPm1DayIntervalRxLostStarts,
+       g9982PortPm1DayIntervalRxLostEnds,
+       g9982PortPm1DayIntervalRxOverflows,
+       g9982PortPm1DayIntervalValid
+     }
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 46]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+     STATUS      current
+     DESCRIPTION
+       "A collection of objects supporting OPTIONAL historical
+       Performance Monitoring information for G.Bond/Eth ports, during
+       previous 1-day intervals."
+     ::= { g9982Groups 6 }
+
+  -------------------------------
+  -- Compliance Statements
+  -------------------------------
+
+   g9982Compliance MODULE-COMPLIANCE
+     STATUS      current
+     DESCRIPTION
+       "The compliance statement for G.Bond Ethernet interfaces.
+       Compliance with the following external compliance statements
+       is REQUIRED:
+
+       MIB Module             Compliance Statement
+       ----------             --------------------
+       IF-MIB                 ifCompliance3
+       GBOND-MIB              gBondCompliance"
+
+     MODULE  -- this module
+       MANDATORY-GROUPS {
+         g9982BasicGroup
+       }
+
+       GROUP       g9982BceGroup
+       DESCRIPTION
+         "Support for this group is OPTIONAL."
+
+       GROUP       g9982BacpGroup
+       DESCRIPTION
+         "Support for this group is OPTIONAL and only required for
+         implementations supporting BACP."
+
+       GROUP       g9982PerfCurrGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting Performance Monitoring."
+
+       GROUP       g9982Perf15MinGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting 15-minute historical Performance Monitoring."
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 47]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+       GROUP       g9982Perf1DayGroup
+       DESCRIPTION
+         "Support for this group is only required for implementations
+         supporting 1-day historical Performance Monitoring."
+
+       OBJECT      g9982PortCapTcTypesSupported
+       SYNTAX      BITS {
+         tc6465(0),
+         tcHDLC(1)
+       }
+       DESCRIPTION
+         "Support for all TC types is not required.  However, at least
+         one value SHALL be supported."
+
+       OBJECT      g9982PortCapBacpSupported
+       SYNTAX      TruthValue
+       DESCRIPTION
+         "Support for BACP is OPTIONAL; therefore, a value of false(2)
+         SHALL be supported."
+
+       OBJECT      g9982PortConfTcAdminType
+       MIN-ACCESS  read-only
+       DESCRIPTION
+         "Write access is not required (needed only for GBS
+         supporting more than a single TC encapsulation type, i.e.,
+         tc6465 and tcHDLC)."
+
+       OBJECT      g9982PortConfAdminCp
+       MIN-ACCESS  read-only
+       DESCRIPTION
+         "Write access is not required (needed only for GBS
+         supporting BACP in addition to mandatory G.hs-based bonding
+         discovery and aggregation protocol)."
+
+     ::= { g9982Compliances 1 }
+END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 48]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+7.  Security Considerations
+
+   There are a number of managed objects defined in this MIB module with
+   a MAX-ACCESS clause of read-write and/or read-create.  Such objects
+   may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  Changing of g9982PortConfTable configuration parameters (e.g.,
+      g9982PortConfTcAdminType) may lead to a complete service
+      interruption in cases where the specified PTM-TC encapsulation
+      type is not supported by the remote end.
+
+   o  Changing of g9982BceConfTable configuration parameters (e.g.,
+      g9982BceConfEligibleGroupID) may lead to preventing a non-bonded
+      BCE from being bonded in any bonding group, or false advertisement
+      of bonding eligibility (e.g., between BCEs residing on different
+      line cards in an application that does not support cross-card
+      bonding).
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments since, collectively, they
+   provide information about the performance of network interfaces and
+   can reveal some aspects of their configuration.
+
+   It is thus important to control even GET and/or NOTIFY access to
+   these objects and possibly to even encrypt the values of these
+   objects when sending them over the network via SNMP.  These are the
+   tables and objects and their sensitivity/vulnerability:
+
+   o  g9982PortStatTable - objects in this table (e.g.,
+      g9982PortStatTcOperType) provide status information for the G.Bond
+      port, which may aid in deciphering of the G.Bond/ETH
+      transmissions.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+   authentication and privacy via the User-based Security Model (USM)
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 49]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+8.  IANA Considerations
+
+   IANA has assigned 264 as the object identifier for the g9982MIB
+   MODULE-IDENTITY in the MIB-2 transmission sub-tree
+   <http://www.iana.org/>.
+
+9.  Acknowledgments
+
+   This document was produced by the [ADSLMIB] working group.
+
+   Special thanks to Dan Romascanu for his meticulous review of this
+   text.
+
+10.  References
+
+10.1.  Normative References
+
+   [802.3]    IEEE, "IEEE Standard for Information technology -
+              Telecommunications and information exchange between
+              systems - Local and metropolitan area networks - Specific
+              requirements - Part 3: Carrier Sense Multiple Access with
+              Collision Detection (CSMA/CD) Access Method and Physical
+              Layer Specifications", IEEE Std 802.3-2005, December 2005.
+
+   [G.998.2]  ITU-T, "Ethernet-based multi-pair bonding", ITU-T
+              Recommendation G.998.2, January 2005,
+              <http://www.itu.int/rec/T-REC-G.998.2/en>.
+
+   [G.998.2-Amd2]
+              ITU-T, "Ethernet-based multi-pair bonding Amendment 2",
+              ITU-T Recommendation G.998.2/Amd.2, December 2007,
+              <http://www.itu.int/rec/T-REC-G.998.2-200712-I!Amd2/en>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 50]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+              "Conformance Statements for SMIv2", STD 58, RFC 2580,
+              April 1999.
+
+   [RFC2863]  McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+              MIB", RFC 2863, June 2000.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3705]  Ray, B. and R. Abbi, "High Capacity Textual Conventions
+              for MIB Modules Using Performance History Based on 15
+              Minute Intervals", RFC 3705, February 2004.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)",
+              RFC 5591, June 2009.
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+   [RFC6765]  Beili, E. and M. Morgenstern, "xDSL Multi-Pair Bonding
+              (G.Bond) MIB", RFC 6765, February 2013.
+
+   [TR-159]   Beili, E. and M. Morgenstern, "Management Framework for
+              xDSL Bonding", Broadband Forum Technical Report TR-159,
+              December 2008, <http://www.broadband-forum.org/technical/
+              download/TR-159.pdf>.
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 51]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+10.2.  Informative References
+
+   [ADSLMIB]  IETF, "ADSL MIB (adslmib) Charter",
+              <http://datatracker.ietf.org/wg/adslmib/charter/>.
+
+   [G.991.2]  ITU-T, "Single-pair high-speed digital subscriber line
+              (SHDSL) transceivers", ITU-T Recommendation G.991.2,
+              December 2003, <http://www.itu.int/rec/T-REC-G.991.2/en>.
+
+   [G.993.1]  ITU-T, "Very high speed digital subscriber line
+              transceivers (VDSL)", ITU-T Recommendation G.993.1,
+              June 2004, <http://www.itu.int/rec/T-REC-G.993.1/en>.
+
+   [G.994.1]  ITU-T, "Handshake procedures for digital subscriber line
+              (DSL) transceivers", ITU-T Recommendation G.994.1,
+              February 2007, <http://www.itu.int/rec/T-REC-G.994.1/en>.
+
+   [IEEE802.3.1]
+              IEEE, "IEEE P802.3.1 Revision to IEEE Std 802.3.1-2011
+              (IEEE 802.3.1a) Ethernet MIBs Task Force", January 2012,
+              <http://grouper.ieee.org/groups/802/3/1/>.
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC3593]  Tesink, K., "Textual Conventions for MIB Modules Using
+              Performance History Based on 15 Minute Intervals",
+              RFC 3593, September 2003.
+
+   [RFC3635]  Flick, J., "Definitions of Managed Objects for the
+              Ethernet-like Interface Types", RFC 3635, September 2003.
+
+   [RFC3728]  Ray, B. and R. Abbi, "Definitions of Managed Objects for
+              Very High Speed Digital Subscriber Lines (VDSL)",
+              RFC 3728, February 2004.
+
+   [RFC4181]  Heard, C., "Guidelines for Authors and Reviewers of MIB
+              Documents", BCP 111, RFC 4181, September 2005.
+
+   [RFC4319]  Sikes, C., Ray, B., and R. Abbi, "Definitions of Managed
+              Objects for High Bit-Rate DSL - 2nd generation (HDSL2) and
+              Single-Pair High-Speed Digital Subscriber Line (SHDSL)
+              Lines", RFC 4319, December 2005.
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 52]
+
+RFC 6767                   G.Bond/Ethernet MIB             February 2013
+
+
+   [RFC4836]  Beili, E., "Definitions of Managed Objects for
+              IEEE 802.3 Medium Attachment Units (MAUs)", RFC 4836,
+              April 2007.
+
+   [RFC5066]  Beili, E., "Ethernet in the First Mile Copper (EFMCu)
+              Interfaces MIB", RFC 5066, November 2007.
+
+Authors' Addresses
+
+   Edward Beili
+   Actelis Networks
+   25 Bazel St.
+   Petach-Tikva  49103
+   Israel
+
+   Phone: +972-3-924-3491
+   EMail: edward.beili@actelis.com
+
+
+   Moti Morgenstern
+   ECI Telecom
+   30 Hasivim St.
+   Petach-Tikva  4951169
+   Israel
+
+   Phone: +972-3-926-6258
+   EMail: moti.morgenstern@ecitele.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Beili & Morgenstern          Standards Track                   [Page 53]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6767.txt](<www.ietf.org/rfc/rfc6767.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
