### PR TITLE
Archive rfc6776.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6776.txt
+++ b/www.ietf.org/rfc/rfc6776.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          A. Clark
+Request for Comments: 6776                                      Telchemy
+Category: Standards Track                                          Q. Wu
+ISSN: 2070-1721                                                   Huawei
+                                                            October 2012
+
+
+         Measurement Identity and Information Reporting Using a
+ Source Description (SDES) Item and an RTCP Extended Report (XR) Block
+
+Abstract
+
+   This document defines an RTP Control Protocol (RTCP) Source
+   Description (SDES) item and an RTCP Extended Report (XR) block
+   carrying parameters that identify and describe a measurement period
+   to which one or more other RTCP XR blocks may refer.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6776.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 1]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+     1.1.  RTCP and RTCP XRs . . . . . . . . . . . . . . . . . . . . . 3
+     1.2.  Performance Metrics Framework . . . . . . . . . . . . . . . 3
+     1.3.  Applicability . . . . . . . . . . . . . . . . . . . . . . . 3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . . . 4
+     2.1.  Standards Language  . . . . . . . . . . . . . . . . . . . . 4
+   3.  Measurement Identity SDES Item  . . . . . . . . . . . . . . . . 4
+     3.1.  APSI: Application-Specific Identifier SDES Item . . . . . . 4
+   4.  Measurement Information XR Block  . . . . . . . . . . . . . . . 5
+     4.1.  Report Block Structure  . . . . . . . . . . . . . . . . . . 5
+     4.2.  Definition of Fields in Measurement Information Report
+           Block . . . . . . . . . . . . . . . . . . . . . . . . . . . 5
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 7
+     5.1.  New RTCP SDES Item Type Value . . . . . . . . . . . . . . . 7
+     5.2.  New RTCP XR Block Type Value  . . . . . . . . . . . . . . . 7
+     5.3.  Contact Information for Registrations . . . . . . . . . . . 7
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . . . 7
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 8
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . . . 8
+     7.2.  Informative References  . . . . . . . . . . . . . . . . . . 8
+
+1.  Introduction
+
+   This document defines one new RTP Control Protocol (RTCP) Source
+   Description (SDES) [RFC3550] item and one new Extended Report (XR)
+   block carrying parameters that identify and describe a measurement
+   period to which one or more other RTCP XR blocks may refer.
+
+   The SDES item provides a field for an application-specific auxiliary
+   identifier.  This identifier may be used to correlate data in XR
+   blocks within an RTP session with data from a non-RTP session.
+
+   An RTCP Measurement Identity SDES packet may be associated with a set
+   of RTCP XR metrics blocks that share the same application-specific
+   measurement identifier.
+
+   The XR block does not contain any measurement results (metrics).
+   Instead, it provides information relevant to a measurement reported
+   in one or more other block types, including:
+
+   o  the sequence number of the first packet of the RTP session,
+
+   o  the extended sequence numbers of the first packet of the current
+      measurement interval, and the last packet included in the
+      measurement,
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 2]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+   o  the duration of the most recent measurement interval, and
+
+   o  the duration of the interval applicable to cumulative measurements
+      (which may be the duration of the RTP session to date).
+
+   The calculation method of the extended RTP sequence number is
+   provided in the Real-time Transport Protocol (RTP) [RFC3550].
+
+   The RTCP XR block containing the measurement information is intended
+   to provide a single copy of the information necessary to relate
+   measurement data in the RTCP XR blocks to the stream and measurement
+   period to which they refer.  Commonly, multiple other small metric
+   blocks contain measurement data for the same stream and period, and
+   overhead would be large if all of these metric blocks carried
+   duplicated data for measurement identification.
+
+   The RTCP XR block may be associated with a set of RTCP XR metrics
+   blocks that share the same information relevant to a reported
+   measurement.  There may be several such sets in an RTCP packet, in
+   which each set shares the same information relevant to a reported
+   measurement.  There may also be RTCP XR blocks in the packet that are
+   not associated with a Measurement Information block, for example,
+   blocks that were defined before the Measurement Identity and
+   information mechanism were introduced by this document.
+
+1.1.  RTCP and RTCP XRs
+
+   The use of RTCP for reporting is defined in [RFC3550].  [RFC3611]
+   defines an extensible structure for reporting by using an RTCP XR.
+   [RFC3611] also defines the use of XR blocks.  This document defines a
+   new Extended Report block.
+
+1.2.  Performance Metrics Framework
+
+   The Performance Metrics Framework [RFC6390] provides guidance on the
+   definition and specification of performance metrics.  The RTP
+   Monitoring Architectures [MONARCH] provides guidelines for reporting
+   block format using RTCP XR.  The SDES item and XR block described in
+   this document are in accordance with [RFC6390] and [MONARCH].
+
+1.3.  Applicability
+
+   The RTCP SDES item and the RTCP XR block defined in this document
+   provide information relevant to the measurements for members of a
+   family of RTCP XR metrics blocks that are designed to use it.  To use
+   the mechanism defined here, the RTCP XR block containing measurement
+   information is not required to be in the same RTCP packet as the SDES
+   item containing measurement identity.
+
+
+
+Clark & Wu                   Standards Track                    [Page 3]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+2.  Terminology
+
+2.1.  Standards Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Measurement Identity SDES Item
+
+   This section defines the format of the Measurement Identity SDES
+   item.  The SDES item is carried in the RTCP SDES packet.  The packet
+   format for the RTCP SDES is defined in Section 6.5 of [RFC3550].
+   Each SDES packet is composed of a header with fixed-length fields for
+   version, source count, packet type (PT), and length, followed by zero
+   or more SDES items.  In the SDES packet, the PT field is set to SDES
+   (202).
+
+3.1.  APSI: Application-Specific Identifier SDES Item
+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |    APSI=10    |     length    |application-specific identifier
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   ....
+   +-+-+-+-+-+-+-+-+
+
+   The application-specific identifier is an additional identifier that
+   is useful in the context of a specific application, e.g., an MPEG-2
+   transport identifier [MPEG2].  This item MUST be ignored by
+   applications that are not configured to make use of it.  The
+   identifier is variable length.  Its length is described by the length
+   field.  The value of the length field does not include the two-octet
+   SDES item header.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 4]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+4.  Measurement Information XR Block
+
+4.1.  Report Block Structure
+
+    0               1               2               3
+    0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     BT=14     |    Reserved   |      block length = 7         |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                    SSRC of stream source                      |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |            Reserved           |    first sequence number      |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |           extended first sequence number of interval          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                 extended last sequence number                 |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |              Measurement Duration (Interval)                  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     Measurement Duration (Cumulative) - Seconds (bit 0-31)    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |     Measurement Duration (Cumulative) - Fraction (bit 0-31)   |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                          Report Block Structure
+
+4.2.  Definition of Fields in Measurement Information Report Block
+
+   Block type (BT): 8 bits
+
+      A Measurement Information Block is identified by the constant 14.
+
+   Reserved: 8 bits
+
+      These bits are reserved.  They MUST be set to zero by senders and
+      ignored by receivers.
+
+   Block Length: 16 bits
+
+      The length of this report block in 32-bit words minus one.  For
+      the Measurement Information Block, the block length is equal to 7.
+
+   SSRC of source: 32 bits
+
+      As defined in Section 4.1 of [RFC3611].
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 5]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+   Reserved: 16 bits
+
+      These bits are reserved.  They MUST be set to zero by senders and
+      ignored by receivers.
+
+   First sequence number: 16 bits
+
+      The RTP sequence number of the first received RTP packet of the
+      session, used to determine the number of packets contributing to
+      cumulative measurements.
+
+   Extended first sequence number of interval: 32 bits
+
+      The extended RTP sequence number of the first received RTP packet
+      of the current measurement interval.  The extended sequence number
+      is expressed as the low 16-bit value containing the sequence
+      number received in an RTP data packet and the most significant
+      16-bit value containing the corresponding count of sequence number
+      cycles.  For additional information on extended sequence numbers,
+      see the "extended highest sequence number received" definition in
+      Section 6.4.1 of RFC 3550 and Appendix A.1 of RFC 3550.
+
+   Extended last sequence number: 32 bits
+
+      The extended RTP sequence number of the last received RTP packet
+      that contributed to this measurement.  The extended sequence
+      number is expressed as the low 16-bit value containing the
+      sequence number received in an RTP data packet and the most
+      significant 16-bit value containing the corresponding count of
+      sequence number cycles.  For additional information on extended
+      sequence numbers, see the "extended highest sequence number
+      received" definition in Section 6.4.1 of RFC 3550 and Appendix A.1
+      of RFC 3550.
+
+   Measurement Duration (Interval): 32 bits
+
+      The duration, expressed in units of 1/65536 seconds, of the
+      reporting interval applicable to Interval reports that use this
+      Measurement Information Block.  The value of this field can be
+      calculated by the receiver of the RTP media stream, for example,
+      based on received RTP media packets or using the RTCP method
+      described in [RFC3550].
+
+
+
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 6]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+   Measurement Duration (Cumulative): 64 bits
+
+      The duration of the reporting interval applicable to Cumulative
+      reports that use this Measurement Information Block.  The value of
+      this field is represented using a 64-bit NTP-format timestamp as
+      defined in [RFC5905], which is a 64-bit unsigned fixed-point
+      number with the integer part in the first 32 bits and the
+      fractional part in the last 32 bits.  It can be calculated by the
+      receiver of the RTP media stream, for example, based on received
+      RTP media packets or using the RTCP method described in [RFC3550].
+
+5.  IANA Considerations
+
+   A new SDES item type for RTCP SDES and a new XR block type for RTCP
+   XR have been registered with IANA.  For general guidelines on IANA
+   considerations, refer to [RFC3550] for RTCP SDES and [RFC3611] for
+   RTCP XR.
+
+5.1.  New RTCP SDES Item Type Value
+
+   This document adds the Measurement Identity SDES item to the IANA
+   "RTP SDES item types" registry as follows:
+
+   abbrev.      name                               value
+   APSI         Application-Specific Identifier    10
+
+5.2.  New RTCP XR Block Type Value
+
+   This document assigns the block type value 14 in the IANA "RTCP XR
+   Block Type Registry" to the "Measurement Information Block".
+
+5.3.  Contact Information for Registrations
+
+   The contact information for the registrations is:
+
+   Qin Wu (sunseawq@huawei.com)
+   101 Software Avenue, Yuhua District
+   Nanjing, Jiangsu  210012
+   China
+
+6.  Security Considerations
+
+   RTCP reports can contain sensitive information, including information
+   about the nature and duration of a session established between two or
+   more endpoints.  Therefore, the use of security mechanisms with RTP,
+   as documented in Section 9 of [RFC3550], applies.
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 7]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC3611]  Friedman, T., Ed., Caceres, R., Ed., and A. Clark, Ed.,
+              "RTP Control Protocol Extended Reports (RTCP XR)",
+              RFC 3611, November 2003.
+
+   [RFC5905]  Mills, D., Martin, J., Ed., Burbank, J., and W. Kasch,
+              "Network Time Protocol Version 4: Protocol and Algorithms
+              Specification", RFC 5905, June 2010.
+
+7.2.  Informative References
+
+   [MONARCH]  Wu, Q., Hunt, G., and P. Arden, "Monitoring Architectures
+              for RTP", Work in Progress, September 2012.
+
+   [MPEG2]    ISO/IEC, "Standard 13818-1, Information technology --
+              Generic coding of moving pictures and associated audio
+              information: Systems", October 2007.
+
+   [RFC6390]  Clark, A. and B. Claise, "Guidelines for Considering New
+              Performance Metric Development", BCP 170, RFC 6390,
+              October 2011.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 8]
+
+RFC 6776            Measurement Identity and Duration       October 2012
+
+
+Authors' Addresses
+
+   Alan Clark
+   Telchemy Incorporated
+   2905 Premiere Parkway, Suite 280
+   Duluth, GA  30097
+   United States
+
+   EMail: alan.d.clark@telchemy.com
+
+
+   Qin Wu
+   Huawei
+   101 Software Avenue, Yuhua District
+   Nanjing, Jiangsu  210012
+   China
+
+   EMail: sunseawq@huawei.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark & Wu                   Standards Track                    [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6776.txt](<www.ietf.org/rfc/rfc6776.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
