### PR TITLE
Archive rfc679.txt

### DIFF
--- a/www.ietf.org/rfc/rfc679.txt
+++ b/www.ietf.org/rfc/rfc679.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                         D.W. Dodds
+Request for Comments: 679                                     BBN-TENEXA
+NIC: 31890                                                 February 1975
+
+
+         February, 1975, Survey of New-Protocol TELNET Servers
+
+   It has been two and a half months since our last survey, and it has
+   been depressing to note that "progress" toward an all-new-protocol
+   network has been even slower than previously.  Changes since the last
+   list (with host numbers in octal):
+
+   SRI-ARC (2) and OFFICE-1 (53) have added logger sockets 27, but with
+      Old-Protocol servers (are these forerunners of New-Protocol
+      servers?);
+   SDC-CC (110) has been removed from the list until it starts operating
+      on the network
+   LL-67 (12) now has a New-Protocol server on socket 1;
+   CASE-10 (15) has departed from the network;
+   BBN-TENEX is now host 361 (formerly 105);
+   ANL (ARGONNE, 67) has come on the net with Old- and New-Protocol
+      servers on sockets 1 and 27, respectively.
+
+   The following is the latest version* of the summary and tabulation of
+   server-host Telnet servers.
+           total server hosts             36      100%
+           no New-Prot server             17       47%
+           unknown status (new host)       1        3%
+           total New-Prot implem.         18       50%
+               New-Prot on socket 27,
+                   Old on socket 1 (2)    10       28%
+               New-Prot on 1 and 27 (3)    6       16%
+               New-Prot on 1 only (3)      2        6%
+   Notes:
+
+   * All data in this report were gathered via a surveying program run
+     at various times, plus a few manual checks to fill out the data.
+     What is reported here is the way the various servers work as seen
+     by the new-Protocol User Telnet at BBNA, as of 20 Feb. 1975.
+
+   (2) These are the sites whose operation is 100% correct according to
+       all protocols and conventions, as I understand them.
+
+   (3) We realize that some of the servers that appear here as New-
+       Protocol servers on socket 1 are actually servers which attempt
+       to communicate with both Old- and New-Protocol User TELNETs
+       according to what control sequences are received.
+
+
+
+
+Dodds                                                           [Page 1]
+
+RFC 679          Survey of New-Protocol TELNET Servers      January 1975
+
+
+             Tabulation of server status for all server sites:
+
+   Host     Host          Socket  Socket   New-Prot. Options
+    No.     Name            1       27     Implemented (if any)
+
+   101     UCLA-CCN        Old     X
+   201     UCLA-CCBS       Old     X
+     2     SRI-ARC         Old     Old
+   102     SRI-AI          Old     New      I1,3,6; O3
+     3     UCSB-MOD75      Old     X
+     4     UTAH-10         Old     X
+   305     BBN-TENEXA      Old     New      I1,3,6; O3
+   106     MIT-DMS         New     New      I1,3; O3
+   206     MIT-AI          Old     X
+   306     MIT-ML          Old     X
+     7     RAND-RCC        Old     X
+    10     SDC-LAB         Old     X
+    11     HARV-10         New     X        I1,3; O3
+    12     LL-67           New     X        None
+   112     LL-TX-2         Old     X
+    13     SU-AI           New*    New*     I1,3
+    16     CMU-10B         New     New      I1,3; O3
+   116     CMU-10A         New     New      I1,3; O3
+    17     I4-TENEX        Old     X
+   217     KI4B-TENEX      Old     X
+    20     AMES-67         New     New      None
+   126     USC-ISI         Old     New      I1,3,6; O3
+   226     USC-ISIB        Old     New      I1,3,6; O3
+    27     USC-44          Old     X
+   327     USC-ECL         Old     X
+    37     CCA-TENEX       Old     X
+    40     PARC-MAXC       Old     New      I1,3,6; O3
+    43     UCSD-CC         Old     New      I0(!),3; O0,3
+   344     HAWAII-500      ?       ?
+    52     LONDON          Old     X
+    53     OFFICE-1        Old     Old
+    54     MIT-MULTICS     New     New      None
+    61     BBN-TENEXB      Old     New      I1,3,6; O3
+   361     BBN-TENEX       Old     New      I1,3,6; O3
+   162     BBN-TENEXD      Old     New      I1,3,6; O3
+    67     ANL             Old     New      I1,3,6; O3
+
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 2]
+
+RFC 679          Survey of New-Protocol TELNET Servers      January 1975
+
+
+   Key:
+
+      X  No server at this socket
+      ?  Status not ascertained -- unable to connect to host
+      I# Option # implemented incoming to user (Server says "Will #")
+      O# Option # implemented outgoing from user (Server says "Do #")
+         (# is option number in new Protocol.  All options implemented
+         by anyone are:
+
+            0    Transmit-Binary
+            1    Echo
+            3    Suppress-Go-Ahead
+            6    Timing-Mark )
+
+   Note: * These servers return improper responses to some TELNET option
+   requests.
+
+
+
+
+
+
+
+
+
+
+         [ This RFC was put into machine readable form for entry ]
+         [ into the online RFC archives by Alex McKenzie with    ]
+         [ support from BBN Corp. and its successors.     7/2000 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc679.txt](<www.ietf.org/rfc/rfc679.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
