### PR TITLE
Archive rfc6814.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6814.txt
+++ b/www.ietf.org/rfc/rfc6814.txt
@@ -1,0 +1,339 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                      C. Pignataro
+Request for Comments: 6814                                 Cisco Systems
+Obsoletes: 1385, 1393, 1475, 1770                                F. Gont
+Category: Standards Track                         UTN-FRH / SI6 Networks
+ISSN: 2070-1721                                            November 2012
+
+
+                 Formally Deprecating Some IPv4 Options
+
+Abstract
+
+   A number of IPv4 options have become obsolete in practice, but have
+   never been formally deprecated.  This document deprecates such IPv4
+   options, thus cleaning up the corresponding IANA registry.
+   Additionally, it obsoletes RFCs 1385, 1393, 1475, and 1770, and
+   requests that the RFC Editor change their status to Historic.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6814.
+
+Copyright Notice
+
+   Copyright (c) 2012 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 1]
+
+RFC 6814              Deprecating Some IPv4 Options        November 2012
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . . . 2
+   2.  Discussion of Deprecated Options  . . . . . . . . . . . . . . . 2
+     2.1.  Stream ID . . . . . . . . . . . . . . . . . . . . . . . . . 2
+     2.2.  Extended Internet Protocol  . . . . . . . . . . . . . . . . 3
+     2.3.  Traceroute  . . . . . . . . . . . . . . . . . . . . . . . . 3
+     2.4.  ENCODE  . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+     2.5.  VISA  . . . . . . . . . . . . . . . . . . . . . . . . . . . 3
+     2.6.  Address Extension . . . . . . . . . . . . . . . . . . . . . 3
+     2.7.  Selective Directed Broadcast  . . . . . . . . . . . . . . . 3
+     2.8.  Dynamic Packet State  . . . . . . . . . . . . . . . . . . . 3
+     2.9.  Upstream Multicast Pkt. . . . . . . . . . . . . . . . . . . 3
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . . . 4
+   4.  Changing the Status of the Corresponding RFCs to Historic . . . 4
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . . . 4
+   6.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . 4
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . . . 5
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . . . 5
+     7.2.  Informative References  . . . . . . . . . . . . . . . . . . 5
+
+1.  Introduction
+
+   The Internet Protocol version 4 (IPv4) [RFC791] provides for
+   expansion of the protocol by supporting a number of "options" in the
+   variable-length IPv4 header.  IPv4 options are identified by an
+   option "type" value, whose registration is managed by IANA [IANA-IP].
+   A number of IPv4 options have become obsolete in practice, but have
+   never been formally deprecated.  This document deprecates such IPv4
+   options, thus cleaning up the corresponding IANA registry.
+
+   This document also obsoletes [RFC1385], [RFC1393], [RFC1475], and
+   [RFC1770], and requests that the RFC Editor change their status to
+   Historic.
+
+2.  Discussion of Deprecated Options
+
+   The following subsections discuss the options being deprecated.  No
+   other reference information has been found.
+
+2.1.  Stream ID
+
+   The Stream ID option is obsolete.  It is specified in RFC 791
+   [RFC791], and is deprecated in Section 3.2.1.8 of RFC 1122 [RFC1122]
+   and Section 4.2.2.1 of RFC 1812 [RFC1812].
+
+
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 2]
+
+RFC 6814              Deprecating Some IPv4 Options        November 2012
+
+
+2.2.  Extended Internet Protocol
+
+   The Extended Internet Protocol option is defined in [RFC1385] and is
+   superseded by [RFC2460].
+
+2.3.  Traceroute
+
+   The Traceroute option is defined in [RFC1393].  The Traceroute option
+   is defined as Experimental; it was never widely deployed on the
+   public Internet.
+
+2.4.  ENCODE
+
+   This option was used for experimentation around IP-layer encryption.
+   No products are known to ever have shipped with support for this
+   option.
+
+2.5.  VISA
+
+   This option was part of an experiment [VISA87] [VISA89] at USC and
+   was never widely deployed.
+
+2.6.  Address Extension
+
+   The Address Extension option is defined in an Experimental RFC
+   [RFC1475] and marked as IPv7.  IPv7 was never widely deployed.
+
+2.7.  Selective Directed Broadcast
+
+   The Selective Directed Broadcast option was originally defined in
+   [RFC1770].  This option was never widely deployed and the approach
+   was abandoned.
+
+2.8.  Dynamic Packet State
+
+   The Dynamic Packet State option was specified in [DIFFSERV-DPS].  The
+   aforementioned document was meant to be published as Experimental,
+   but it never became an RFC.  The IP option was never widely deployed.
+
+2.9.  Upstream Multicast Pkt.
+
+   This option was originally specified in [BIDIR-PIM].  Its use was
+   deprecated by [RFC5015], which employs a control-plane mechanism to
+   solve the problem of doing upstream forwarding of multicast packets
+   on a multi-access LAN.
+
+
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 3]
+
+RFC 6814              Deprecating Some IPv4 Options        November 2012
+
+
+3.  IANA Considerations
+
+   The "IP OPTION NUMBERS" registry [IANA-IP] contains the list of
+   currently assigned IP option numbers.  This registry also denotes a
+   deprecated IP Option Number by marking it with a footnote.
+
+   This document formally deprecates the following options.  IANA has
+   marked them as such in the corresponding registry [IANA-IP].
+
+   Copy Class Number Value Name                                Reference
+   ---- ----- ------ ----- -------------------------------  ------------
+      1     0      8   136 SID    - Stream ID               [RFC791,JBP]
+      1     0     14   142 VISA   - Experimental Access Control [Estrin]
+      0     0     15    15 ENCODE - ???                       [VerSteeg]
+      1     0     17   145 EIP    - Extended Internet Protocol [RFC1385]
+      0     2     18    82 TR     - Traceroute                 [RFC1393]
+      1     0     19   147 ADDEXT - Address Extension     [Ullmann IPv7]
+      1     0     21   149 SDB    - Selective Directed Broadcast [Graff]
+      1     0     23   151 DPS    - Dynamic Packet State         [Malis]
+      1     0     24   152 UMP    - Upstream Multicast Pkt.  [Farinacci]
+
+   The IP options "MTU Probe" (MTUP, value 11) and "MTU Reply" (MTUR,
+   value 12) were initially defined in [RFC1063] and have already been
+   deprecated by [RFC1191].
+
+4.  Changing the Status of the Corresponding RFCs to Historic
+
+   Per this document, the RFC Editor has changed the status of
+   [RFC1385], [RFC1393], [RFC1475], and [RFC1770] to Historic.
+
+5.  Security Considerations
+
+   This document does not modify the security properties of the IPv4
+   options being deprecated.
+
+6.  Acknowledgments
+
+   The authors would like to thank Ron Bonica for his guidance.
+
+   The authors would like to thank Ran Atkinson, Fred Baker, Deborah
+   Estrin, Dino Farinacci, Andrew Malis, Gene Tsudik, and Bill VerSteeg
+   for providing insights on some of the options being formally
+   deprecated by this document.
+
+
+
+
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 4]
+
+RFC 6814              Deprecating Some IPv4 Options        November 2012
+
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC791]   Postel, J., "Internet Protocol", STD 5, RFC 791, September
+              1981.
+
+   [RFC1122]  Braden, R., Ed., "Requirements for Internet Hosts -
+              Communication Layers", STD 3, RFC 1122, October 1989.
+
+7.2.  Informative References
+
+   [BIDIR-PIM] Estrin, D. and D. Farinacci, "Bi-Directional Shared Trees
+              in PIM-SM",  Work in Progress, May 1999.
+
+   [DIFFSERV-DPS]
+              Stoica, I., Zhang, H., Venkitaraman, N., and J. Mysore,
+              "Per Hop Behaviors Based on Dynamic Packet State", Work in
+              Progress, October 2002.
+
+   [IANA-IP]  Internet Assigned Numbers Authority, "IP OPTION NUMBERS",
+              <http://www.iana.org/assignments/ip-parameters>.
+
+   [RFC1063]  Mogul, J., Kent, C., Partridge, C., and K. McCloghrie, "IP
+              MTU discovery options", RFC 1063, July 1988.
+
+   [RFC1191]  Mogul, J. and S. Deering, "Path MTU discovery", RFC 1191,
+              November 1990.
+
+
+   [RFC1385]  Wang, Z., "EIP: The Extended Internet Protocol", RFC 1385,
+              November 1992.
+
+   [RFC1393]  Malkin, G., "Traceroute Using an IP Option", RFC 1393,
+              January 1993.
+
+   [RFC1475]  Ullmann, R., "TP/IX: The Next Internet", RFC 1475, June
+              1993.
+
+   [RFC1770]  Graff, C., "IPv4 Option for Sender Directed Multi-
+              Destination Delivery", RFC 1770, March 1995.
+
+   [RFC1812]  Baker, F., Ed., "Requirements for IP Version 4 Routers",
+              RFC 1812, June 1995.
+
+   [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", RFC 2460, December 1998.
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 5]
+
+RFC 6814              Deprecating Some IPv4 Options        November 2012
+
+
+   [RFC5015]  Handley, M., Kouvelas, I., Speakman, T., and L. Vicisano,
+              "Bidirectional Protocol Independent Multicast (BIDIR-
+              PIM)", RFC 5015, October 2007.
+
+   [VISA87]   Estrin, D. and G. Tsudik, "VISA Scheme for Inter-
+              Organizational Network Security", IEEE Symposium on
+              Security and Privacy (S&P), 1987.
+
+   [VISA89]   Estrin, D., Mogul, J., and G. Tsudik, "VISA Protocols for
+              Controlling Inter-Organizational Datagram Flow", IEEE
+              Journal on Selected Areas in Communications, 1989.
+
+Authors' Addresses
+
+   Carlos Pignataro
+   Cisco Systems
+   7200-12 Kit Creek Road
+   Research Triangle Park, NC  27709
+   United States
+
+   EMail: cpignata@cisco.com
+
+
+   Fernando Gont
+   UTN-FRH / SI6 Networks
+   Evaristo Carriego 2644
+   Haedo, Provincia de Buenos Aires  1706
+   Argentina
+
+   Phone: +54 11 4650 8472
+   EMail: fgont@si6networks.com
+   URI:   http://www.si6networks.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Pignataro & Gont             Standards Track                    [Page 6]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6814.txt](<www.ietf.org/rfc/rfc6814.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
