### PR TITLE
Archive rfc6825.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6825.txt
+++ b/www.ietf.org/rfc/rfc6825.txt
@@ -1,0 +1,2243 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                       M. Miyazawa
+Request for Comments: 6825                                 KDDI R&D Labs
+Category: Standards Track                                       T. Otani
+ISSN: 2070-1721                                                K. Kumaki
+                                                        KDDI Corporation
+                                                               T. Nadeau
+                                                        Juniper Networks
+                                                            January 2013
+
+
+        Traffic Engineering Database Management Information Base
+                      in Support of MPLS-TE/GMPLS
+
+Abstract
+
+   This memo defines the Management Information Base (MIB) objects for
+   managing the Traffic Engineering Database (TED) information with
+   extensions in support of the Multiprotocol Label Switching (MPLS)
+   with Traffic Engineering (TE) as well as Generalized MPLS (GMPLS) for
+   use with network management protocols.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6825.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 1]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 2]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................3
+   2. Introduction ....................................................3
+   3. Overview ........................................................4
+      3.1. Conventions Used in This Document ..........................4
+      3.2. Terminology ................................................4
+      3.3. Acronyms ...................................................5
+   4. Motivations .....................................................5
+   5. Brief Description of MIB Module .................................5
+      5.1. tedTable ...................................................5
+      5.2. tedLocalIfAddrTable ........................................5
+      5.3. tedRemoteIfAddrTable .......................................5
+      5.4. tedSwCapTable ..............................................6
+      5.5. tedSrlgTable ...............................................6
+   6. Example of the TED MIB Module Usage .............................6
+   7. TED MIB Module Definitions in Support of GMPLS ..................9
+   8. Security Considerations ........................................35
+   9. IANA Considerations ............................................36
+   10. References ....................................................36
+      10.1. Normative References .....................................36
+      10.2. Informative References ...................................37
+   11. Acknowledgments ...............................................39
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Introduction
+
+   The OSPF MIB was originally defined for OSPF version 2 in support of
+   IPv4 [RFC4750] and extended to support the Internet Protocol
+   version 6 (IPv6) as OSPF version 3 MIB [RFC5643].  The IS-IS MIB is
+   also defined in [RFC4444].  On the other side, MPLS-/GMPLS-based
+   traffic engineering has so far extended the OSPF/IS-IS routing
+   protocol with TE functionality [RFC4202] [RFC3630] [RFC5329]
+   [RFC5307] [RFC5305].  To manage such MPLS-TE/GMPLS networks
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 3]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   effectively, routing information associated with MPLS/GMPLS TE
+   parameters is preferred for network management; however, there is no
+   clear definition of MPLS/GMPLS TE information in existing MIBs
+   related to OSPF(v2 and v3)/IS-IS.
+
+   This memo defines the MIB objects for managing TED in support of
+   MPLS-TE/GMPLS for use with network management protocols.
+
+   This MIB module should be used in conjunction with the OSPFv2 MIB,
+   OSPF v3 MIB, and IS-IS MIB, as well as other MIBs defined in
+   [RFC3812], [RFC3813], [RFC4802], and [RFC4803] for the management of
+   MPLS-/GMPLS-based traffic engineering information.  By implementing
+   such MIB modules, it is helpful to simultaneously understand the
+   entire MPLS/GMPLS network, for example, understanding routing
+   information as well as LSP information using a management system.
+   However, note that this MIB module is able to be implemented and
+   performed without implementation of other MIB modules when the
+   management system, for example, only comprehends MPLS/GMPLS topology
+   information such as TE link information.
+
+3.  Overview
+
+3.1.  Conventions Used in This Document
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   RFC 2119 [RFC2119].
+
+3.2.  Terminology
+
+   Definitions of key terms for MPLS Operations, Administration, and
+   Maintenance (OAM) and GMPLS are found in [RFC4377] and [RFC3945], and
+   the reader is assumed to be familiar with those definitions, which
+   are not repeated here.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 4]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+3.3.  Acronyms
+
+   GMPLS: Generalized Multiprotocol Label Switching
+   IS-IS: Intermediate System to Intermediate System
+   LSA:   Link State Advertisement
+   LSP:   Label Switching Path
+   LSR:   Label Switching Router
+   MIB:   Management Information Base
+   OSPF:  Open Shortest Path First
+   PSC:   Packet Switch Capable
+   SRLG:  Shared Risk Link Group
+   TE:    Traffic Engineering
+   TED:   Traffic Engineering Database
+   TDM:   Time Division Multiplexing
+
+4.  Motivations
+
+   The existing OSPFv2, OSPFv3, IS-IS, MPLS, and GMPLS MIBs do not
+   provide for the management interface to retrieve topology information
+   of MPLS and GMPLS networks.
+
+5.  Brief Description of MIB Module
+
+   The objects described in this section support the management of TED
+   as described in [RFC4202], [RFC4203], and [RFC5307] for GMPLS
+   extensions as well as in [RFC3630] and [RFC5305] for MPLS/GMPLS.
+
+5.1.  tedTable
+
+   The TED table is basically used to indicate TED information of OSPF-
+   TE or ISIS-TE.  However, this table does not contain information for
+   the Local/Remote Interface IP Address, Interface Switching Capability
+   Descriptor, or Shared Risk Link Group information within the sub-TLVs
+   for the Link-TLV.
+
+5.2.  tedLocalIfAddrTable
+
+   The tedLocalIfAddrTable is identical to the Local Interface IP
+   Address information in a sub-TLV for the Link-TLV.  This is
+   independently defined, because the Interface IP Address sub-TLV may
+   appear more than once with the same Link-TLV.
+
+5.3.  tedRemoteIfAddrTable
+
+   The tedRemoteIfAddrTable is identical to the Remote Interface IP
+   Address information in a sub-TLV of the Link-TLV.  This is
+   independently defined, because the Interface IP Address sub-TLV may
+   appear more than once with the same Link-TLV.
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 5]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+5.4.  tedSwCapTable
+
+   The tedSwCapTable is identical to the Interface Switching Capability
+   Descriptor information in a sub-TLV of the Link-TLV.  This is
+   independently defined, because the Interface Switching Capability
+   Descriptor sub-TLV may appear more than once with the same Link-TLV.
+
+5.5.  tedSrlgTable
+
+   The tedSrlgTable is identical to the Shared Risk Link Group
+   information in a sub-TLV of the Link-TLV.  This table is
+   independently defined because the Shared Risk Link Group sub-TLV may
+   appear more than once with the same Link-TLV.
+
+6.  Example of the TED MIB Module Usage
+
+   In this section, we provide an example of the TED MIB module usage.
+   The following indicates the information of a numbered TE link
+   originated in a GMPLS-controlled node.  When TE link information is
+   retrieved in an MPLS network, GMPLS-specific objects such as
+   tedLocalIfAddrTable, tedRemoteIfAddrTable, tedSwCapTable, and
+   tedSrlgTable are not supported.
+
+   By retrieval of such information periodically, the management system
+   can comprehend the detailed topology information related to
+   MPLS/GMPLS networks.  In particular, the basic TED information can be
+   collected by tedTable, and Local/Remote Interface IP Address
+   information related to MPLS/GMPLS networks are collected by
+   tedLocalIfAddrTable and tedRemoteIfAddrTable, and the attribute
+   information related to GMPLS TE links can be retrieved by
+   tedSwCapTable and tedSrlgTable.  Regarding fault management, there is
+   no functionality to notify network failures in this MIB module.
+   However, if network topologies are changed, the module can notify the
+   management system of the change information by using tedStatusChange,
+   tedEntryCreated, and tedEntryDeleted.
+
+   Note that the TED MIB module is limited to "read-only" access except
+   for tedCreatedDeletedNotificationMaxRate and
+   tedStatusChangeNotificationMaxRate.  The TED MIB module is designed
+   to be independent of OSPF or IS-IS MIBs; however, information for
+   each TE link belongs to a node or a link that is managed by the
+   routing protocol.
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 6]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   In tedTable:
+   {
+   tedLinkInformationData.2.3232235777.3232235778.16777264  zeroDotZero
+   tedLinkType.2.3232235777.3232235778.16777264         pointToPoint(1)
+   tedLinkState.2.3232235777.3232235778.16777264                  up(1)
+   tedAreaId.2.3232235777.3232235778.16777264                         0
+   tedTeRouterIdAddrType.2.3232235777.3232235778.16777264       ipv4(1)
+   tedTeRouterIdAddr.2.3232235777.3232235778.16777264         192.0.2.1
+   tedLinkIdAddrType.2.3232235777.3232235778.16777264           ipv4(1)
+   tedLinkIdAddr.2.3232235777.3232235778.16777264            192.0.2.10
+   tedMetric.2.3232235777.3232235778.16777264                         1
+   tedMaxBandwidth.2.3232235777.3232235778.16777264            4d9450c0
+   tedMaxReservableBandwidth.2.3232235777.3232235778.16777264  4d9450c0
+   tedUnreservedBandwidthPri0.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri1.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri2.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri3.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri4.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri5.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri6.2.3232235777.3232235778.16777264 4d9450c0
+   tedUnreservedBandwidthPri7.2.3232235777.3232235778.16777264 4d9450c0
+   tedAdministrativeGroup.2.3232235777.3232235778.16777264            0
+   tedLocalId.2.3232235777.3232235778.16777264                        0
+   tedRemoteId.2.3232235777.3232235778.16777264                       0
+   tedLinkProtectionType.2.3232235777.3232235778.16777264 01 00 00 00 7
+   }
+
+   In tedLocalIfAddrTable:
+   {
+   tedLocalIfAddrType.16777264.192.0.2.21       ipv4(1)
+   }
+
+   In tedRemoteIfAddrTable:
+   {
+   tedRemoteIfAddrType.16777264.192.0.2.22      ipv4(1)
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 7]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   In tedSwCapTable:
+   {
+   tedSwCapType.16777264.1                      lsc(150)
+   tedSwCapEncoding.16777264.1               ethernet(2)
+   tedSwCapMaxLspBandwidthPri0.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri1.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri2.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri3.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri4.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri5.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri6.16777264.1       4d9450c0
+   tedSwCapMaxLspBandwidthPri7.16777264.1       4d9450c0
+   tedSwCapMinLspBandwidth.16777264.1                  0
+   tedSwCapIfMtu.16777264.1                            0
+   tedSwCapIndication.16777264.1             standard(0)
+   }
+
+   In tedSrlgTable:
+   {
+   tedSrlg.16777264.1   0
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 8]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+7.  TED MIB Module Definitions in Support of GMPLS
+
+   This MIB module makes references to the following documents:
+
+   [RFC2328], [RFC2578], [RFC2580], [RFC3630], [RFC4001], [RFC4203],
+   [RFC4220], [RFC4444], [RFC4801], [RFC4802], [RFC5305], [RFC5307],
+   [RFC5329], [RFC5340], [RFC6340], and [ISO10589].
+
+   TED-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+      MODULE-IDENTITY, OBJECT-TYPE, Integer32, Unsigned32, transmission,
+      NOTIFICATION-TYPE
+        FROM SNMPv2-SMI                            -- RFC 2578
+      MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF                           -- RFC 2580
+      TEXTUAL-CONVENTION, RowPointer
+        FROM SNMPv2-TC                             -- RFC 2579
+      IANAGmplsLSPEncodingTypeTC, IANAGmplsSwitchingTypeTC
+        FROM IANA-GMPLS-TC-MIB                     -- RFC 4802
+      InetAddress, InetAddressType
+        FROM INET-ADDRESS-MIB                      -- RFC 4001
+      Float32TC
+        FROM FLOAT-TC-MIB                          -- RFC 6340
+      ;
+
+   tedMIB MODULE-IDENTITY
+      LAST-UPDATED "201212210000Z"  -- 21 Dec. 2012 00:00:00 GMT
+      ORGANIZATION "IETF CCAMP Working Group."
+      CONTACT-INFO
+         "          Tomohiro Otani
+                    Tm-otani@kddi.com
+
+                    Masanori Miyazawa
+                    ma-miyazawa@kddilabs.jp
+
+                    Thomas D. Nadeau
+                    tnadeau@juniper.net
+
+                    Kenji Kumaki
+                    ke-kumaki@kddi.com
+
+                    Comments and discussion to ccamp@ietf.org"
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                    [Page 9]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   DESCRIPTION
+     "This MIB module contains managed object definitions for TED in
+     support of MPLS/GMPLS TE Database.
+
+     Copyright (c) 2013 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, is permitted pursuant to, and subject to the license
+     terms contained in, the Simplified BSD License set forth in
+     Section 4.c of the IETF Trust's Legal Provisions Relating to IETF
+     Documents (http://trustee.ietf.org/license-info)."
+   -- Revision history.
+      REVISION
+        "201212210000Z"  -- 21 Dec. 2012 00:00:00 GMT
+      DESCRIPTION
+        "Initial version.  Published as RFC 6825."
+      ::= { transmission 273 }
+   -- assigned by IANA; see Section 9 for details.
+
+   -- Textual Conventions.
+
+   TedAreaIdTC ::= TEXTUAL-CONVENTION
+       STATUS       current
+       DESCRIPTION
+        "The area identifier of the IGP.  If OSPF is used to advertise
+        LSA, this represents an ospfArea.  If IS-IS is used, this
+        represents an area address."
+       SYNTAX       OCTET STRING (SIZE (0..20))
+
+   TedRouterIdTC ::= TEXTUAL-CONVENTION
+      STATUS       current
+       DESCRIPTION
+        "The router identifier.  If OSPF is used to advertise LSA, this
+        represents a Router ID.  If IS-IS is used, this represents a
+        System ID."
+       SYNTAX       OCTET STRING (SIZE (0..6))
+
+   TedLinkIndexTC ::= TEXTUAL-CONVENTION
+      STATUS       current
+      DESCRIPTION
+        "The link identifier.  If OSPF is used, this represents an
+        ospfLsdbID.  If IS-IS is used, this represents an isisLSPID.
+        If a locally configured link is used, this object represents an
+        arbitrary value, which is locally defined in a router."
+       SYNTAX       OCTET STRING (SIZE (0..8))
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 10]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   -- Top-level components of this MIB module.
+
+   tedNotifications OBJECT IDENTIFIER ::= { tedMIB 0 }
+   tedObjects       OBJECT IDENTIFIER ::= { tedMIB 1 }
+   tedConformance   OBJECT IDENTIFIER ::= { tedMIB 2 }
+
+   --  TED Table
+
+   tedTable OBJECT-TYPE
+      SYNTAX       SEQUENCE OF TedEntry
+      MAX-ACCESS   not-accessible
+      STATUS       current
+      DESCRIPTION
+        "This table indicates multiple TED information, which has been
+        supported by RFC 3630 and RFC 5305."
+   ::= { tedObjects 1 }
+
+   tedEntry OBJECT-TYPE
+       SYNTAX       TedEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This entry contains TED information commonly utilized in both
+        MPLS and GMPLS."
+      INDEX { tedLocalRouterId, tedRemoteRouterId,
+      tedLinkInformationSource, tedLinkIndex }
+
+   ::= { tedTable 1 }
+
+   TedEntry ::= SEQUENCE {
+       tedLinkInformationSource     INTEGER,
+       tedLocalRouterId             TedRouterIdTC,
+       tedRemoteRouterId            TedRouterIdTC,
+       tedLinkIndex                 TedLinkIndexTC,
+       tedLinkInformationData       RowPointer,
+       tedLinkState                 INTEGER,
+       tedAreaId                    TedAreaIdTC,
+       tedLinkType                  INTEGER,
+       tedTeRouterIdAddrType        InetAddressType,
+       tedTeRouterIdAddr            InetAddress,
+       tedLinkIdAddrType            InetAddressType,
+       tedLinkIdAddr                InetAddress,
+       tedMetric                    Integer32,
+       tedMaxBandwidth              Float32TC,
+       tedMaxReservableBandwidth    Float32TC,
+       tedUnreservedBandwidthPri0   Float32TC,
+       tedUnreservedBandwidthPri1   Float32TC,
+       tedUnreservedBandwidthPri2   Float32TC,
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 11]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       tedUnreservedBandwidthPri3   Float32TC,
+       tedUnreservedBandwidthPri4   Float32TC,
+       tedUnreservedBandwidthPri5   Float32TC,
+       tedUnreservedBandwidthPri6   Float32TC,
+       tedUnreservedBandwidthPri7   Float32TC,
+       tedAdministrativeGroup       Integer32,
+       tedLocalId                   Integer32,
+       tedRemoteId                  Integer32,
+       tedLinkProtectionType        BITS
+       }
+
+   tedLinkInformationSource OBJECT-TYPE
+       SYNTAX       INTEGER {
+                    unknown(0),
+                    locallyConfigured(1),
+                    ospfv2(2),
+                    ospfv3(3),
+                    isis(4),
+                    other(5)
+                    }
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the source of the information about the
+        TE link."
+     ::= { tedEntry 1 }
+
+   tedLocalRouterId OBJECT-TYPE
+       SYNTAX       TedRouterIdTC
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object represents the Router ID of the router originating
+        the LSA.  If OSPF is used to advertise LSA, this represents a
+        Router ID.  If IS-IS is used, this represents a System ID.
+        Otherwise, this represents zero."
+       REFERENCE
+         "OSPF Version 2, RFC 2328, Appendix C.1
+           OSPF for IPv6, RFC 5340, Appendix C.1
+           ISO10589, Section 7.1"
+   ::= { tedEntry 2 }
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 12]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedRemoteRouterId OBJECT-TYPE
+       SYNTAX       TedRouterIdTC
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the router at the remote end of the link
+        from the originating router.  If OSPF is used to advertise LSA,
+        this represents a Link ID in the Link TLV.  If IS-IS is used,
+        this represents a neighbor System ID defined in RFC 5305.
+        Otherwise, this represents zero."
+       REFERENCE
+         "OSPF Version 2, RFC 2328, Appendix C.1
+           OSPF for IPv6, RFC 5340, Appendix C.1
+           ISO10589, Section 7.1"
+   ::= { tedEntry 3 }
+
+   tedLinkIndex OBJECT-TYPE
+       SYNTAX       TedLinkIndexTC
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the link state identifier.  If OSPF is
+        used, this represents an ospfLsdbID.  If IS-IS is used, this
+        represents an isisLSPID.  Otherwise, this represents a unique
+        identifier within a node."
+       REFERENCE
+         "OSPF Version 2, RFC 2328, Appendix A.4.1,
+           OSPF for IPv6, RFC 5340, Appendix A.4.2
+           ISO10589, Section 9.8 "
+   ::= { tedEntry 4 }
+
+   tedLinkInformationData OBJECT-TYPE
+       SYNTAX       RowPointer
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "If tedLinkInformationSource has the value unknown(0), this
+        object MUST contain a value of zeroDotZero.
+
+        If tedLinkInformationSource has the value locallyConfigured(1),
+        an implementation can use this object to supply the identifier
+        of the corresponding row entry in the teLinkTable of TE-LINK-
+        STD-MIB (RFC 4220), the identifier of the corresponding row in
+        a local proprietary TE link MIB module, or the value of
+        zeroDotZero.
+
+        If tedLinkInformationSource has the value ospfv2(2) and
+        ospfv3(3), an implementation can use this object to supply the
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 13]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+        identifier of the corresponding row entry in the
+        ospfLocalLsdbTable (OSPFv2-MIB) and the ospfv3AreaLsdbTable
+        (OSPFv3-MIB), or the value of zeroDotZero.
+
+        If tedLinkInformationSource has the value isis(4), an
+        implementation can use this object to supply the identifier of
+        the corresponding row entry in the isisAreaAddr of ISIS-MIB
+        (RFC 4444), or the value of zeroDotZero.
+
+        If tedLinkInformationSource has the value other(5), an
+        implementation can use this object to supply the identifier of
+        the corresponding row entry in the local proprietary MIB module,
+        or the value of zeroDotZero."
+   ::= { tedEntry 5 }
+
+   tedLinkState OBJECT-TYPE
+        SYNTAX       INTEGER {
+                     unknown (0),
+                     up (1),
+                     down (2)
+                     }
+        MAX-ACCESS   read-only
+        STATUS       current
+        DESCRIPTION
+         "This object represents the actual operational state of this TE
+         link.  For instance, if a row is created in the TED table, but
+         the actual TE link is not available for some reason (e.g., when
+         there is not yet a physical link or the link has been manually
+         disabled), then the object would be down(2) state.
+         In contrast, if a row is added and the TE link is available,
+         this would be operationally up(1)."
+   ::= { tedEntry 6 }
+
+   tedAreaId OBJECT-TYPE
+       SYNTAX       TedAreaIdTC
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the area identifier of the IGP.  If OSPF
+        is used to advertise LSA, this represents an ospfArea.  If IS-IS
+        is used, this represents an area address.  Otherwise, this
+        represents zero."
+       REFERENCE
+         "OSPF Version 2, RFC 2328, Appendix C.2
+           OSPF for IPv6, RFC 5340, Appendix C.2
+           ISO10589, Section 9.8"
+   ::= { tedEntry 7 }
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 14]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedLinkType OBJECT-TYPE
+       SYNTAX       INTEGER {
+                    pointToPoint (1),
+                    multiAccess (2)
+                    }
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the type of the link, such as point to point or
+        multi-access."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.1"
+   ::= { tedEntry 8 }
+
+   tedTeRouterIdAddrType OBJECT-TYPE
+       SYNTAX       InetAddressType
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the TE-Router ID address type.  Only
+        values unknown(0), ipv4(1), or ipv6(2) are supported."
+   ::= { tedEntry 9 }
+
+   tedTeRouterIdAddr OBJECT-TYPE
+       SYNTAX       InetAddress
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+         "This object indicates the TE-Router ID."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.4.1
+          IS-IS extensions for TE, RFC 5305, Section 4.3"
+   ::= { tedEntry 10 }
+
+   tedLinkIdAddrType OBJECT-TYPE
+       SYNTAX       InetAddressType
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the address type of the TE Link ID.  Only
+        values unknown(0), ipv4(1), or ipv6(2) are supported."
+   ::= { tedEntry 11 }
+
+   tedLinkIdAddr OBJECT-TYPE
+       SYNTAX       InetAddress
+       MAX-ACCESS   read-only
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 15]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       STATUS       current
+       DESCRIPTION
+        "This indicates the Router ID of the neighbor in the case of
+        point-to-point links.  This also indicates the interface
+        address of the designated router in the case of multi-access
+        links."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.2
+          IS-IS extensions for TE, RFC 5305, Section 4.3"
+   ::= { tedEntry 12 }
+
+   tedMetric OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the traffic engineering metric value of the TE
+        link."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.5
+          IS-IS extensions for TE, RFC 5305, Section 3.7"
+   ::= { tedEntry 13 }
+
+   tedMaxBandwidth OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the maximum bandwidth that can be used on this
+        link in this direction."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.6
+          IS-IS extensions for TE, RFC 5305, Section 3.4"
+   ::= { tedEntry 14 }
+
+   tedMaxReservableBandwidth OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the maximum bandwidth that may be reserved on
+        this link in this direction."
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 16]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.7
+          IS-IS extensions for TE, RFC 5305, Section 3.5"
+   ::= { tedEntry 15 }
+
+   tedUnreservedBandwidthPri0 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 0."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 16 }
+
+   tedUnreservedBandwidthPri1 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 1."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 17 }
+
+   tedUnreservedBandwidthPri2 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 2."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 18 }
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 17]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedUnreservedBandwidthPri3 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 3."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 19 }
+
+   tedUnreservedBandwidthPri4 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 4."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 20 }
+
+   tedUnreservedBandwidthPri5 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 5."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 21 }
+
+   tedUnreservedBandwidthPri6 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 18]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 6."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, 3.6"
+   ::= { tedEntry 22 }
+
+   tedUnreservedBandwidthPri7 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the amount of bandwidth not yet reserved at the
+        priority 7."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.8
+          IS-IS extensions for TE, RFC 5305, Section 3.6"
+   ::= { tedEntry 23 }
+
+   tedAdministrativeGroup OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the Administrative Group to which the link
+        belongs.  Since the value is a bit mask, the link can belong
+        to multiple groups.  This is also called Resource Class/Color."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.9
+          IS-IS extensions for TE, RFC 5305, Section 3.1"
+   ::= { tedEntry 24 }
+
+   tedLocalId OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the Link Local Identifier of an unnumbered
+        link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.1
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.1"
+   ::= { tedEntry 25 }
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 19]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedRemoteId OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This indicates the Link Remote Identifier of an unnumbered
+        link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.1
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.1"
+   ::= { tedEntry 26 }
+
+   tedLinkProtectionType OBJECT-TYPE
+       SYNTAX       BITS {
+                    extraTraffic(0),
+                    unprotected(1),
+                    shared (2),
+                    dedicatedOneToOne (3),
+                    dedicatedOnePlusOne(4),
+                    enhanced(5)
+                    }
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+         "This object indicates the protection type of the TE link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.2
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.2"
+   ::= { tedEntry 27 }
+
+   --  TED Local Interface IP Address Table
+
+   tedLocalIfAddrTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF TedLocalIfAddrEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This table contains the IP address information of a local TE
+        link."
+   ::= { tedObjects 2 }
+
+   tedLocalIfAddrEntry OBJECT-TYPE
+       SYNTAX       TedLocalIfAddrEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This entry contains the IP address information of the local TE
+        link."
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 20]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       INDEX { tedLinkIndex, tedLocalIfAddr }
+   ::= { tedLocalIfAddrTable 1 }
+
+   TedLocalIfAddrEntry ::= SEQUENCE {
+       tedLocalIfAddrType    InetAddressType,
+       tedLocalIfAddr        InetAddress
+       }
+
+   tedLocalIfAddrType OBJECT-TYPE
+       SYNTAX       InetAddressType
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the address type of the local TE link.
+        Only values unknown(0), ipv4(1), or ipv6(2) have to be
+        supported."
+   ::= { tedLocalIfAddrEntry 1 }
+
+   tedLocalIfAddr OBJECT-TYPE
+       SYNTAX       InetAddress (SIZE (1..20))
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the address of the local TE link."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.3,
+         Traffic Engineering Extensions to OSPF Version 3, RFC 5329,
+         Section 4.3
+          IS-IS extensions for TE, RFC 5305, Section 3.4"
+   ::= { tedLocalIfAddrEntry 2 }
+
+   --  TED Remote Interface IP Address Table
+
+   tedRemoteIfAddrTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF TedRemoteIfAddrEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This table contains the IP address information of a remote TE
+        link."
+   ::= { tedObjects 3 }
+
+   tedRemoteIfAddrEntry OBJECT-TYPE
+       SYNTAX       TedRemoteIfAddrEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 21]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       DESCRIPTION
+        "This entry contains the IP address information of the remote
+        TE link."
+   INDEX { tedLinkIndex, tedRemoteIfAddr }
+       ::= { tedRemoteIfAddrTable 1 }
+
+   TedRemoteIfAddrEntry ::= SEQUENCE {
+       tedRemoteIfAddrType    InetAddressType,
+       tedRemoteIfAddr        InetAddress
+       }
+
+   tedRemoteIfAddrType OBJECT-TYPE
+       SYNTAX       InetAddressType
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+         "This object indicates the address type of the remote TE link."
+   ::= { tedRemoteIfAddrEntry 1 }
+
+   tedRemoteIfAddr OBJECT-TYPE
+       SYNTAX       InetAddress(SIZE (1..20))
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the address of the remote TE link."
+       REFERENCE
+        "Traffic Engineering (TE) Extensions to OSPF Version 2,
+         RFC 3630, Section 2.5.4,
+         Traffic Engineering Extensions to OSPF Version3, RFC 5329,
+         Section 4.4
+          IS-IS extensions for TE, RFC 5305, Section 3.3"
+   ::= { tedRemoteIfAddrEntry 2 }
+
+   --  TED Switching Capability Table
+
+   tedSwCapTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF TedSwCapEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This table contains the GMPLS TED switching capability
+        information."
+   ::= { tedObjects 4 }
+
+   tedSwCapEntry OBJECT-TYPE
+       SYNTAX       TedSwCapEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 22]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       DESCRIPTION
+        "This entry relates each TE link with its GMPLS TE switching
+        capability information.  If the MIB module deals with only OSPF-
+        TE information, the value of each object related with GMPLS TE
+        extensions should be null."
+       INDEX { tedLinkIndex, tedSwCapIndex }
+   ::= { tedSwCapTable 1 }
+
+   TedSwCapEntry ::= SEQUENCE {
+       tedSwCapIndex                 Unsigned32,
+       tedSwCapType         IANAGmplsSwitchingTypeTC,
+       tedSwCapEncoding              IANAGmplsLSPEncodingTypeTC,
+       tedSwCapMaxLspBandwidthPri0   Float32TC,
+       tedSwCapMaxLspBandwidthPri1   Float32TC,
+       tedSwCapMaxLspBandwidthPri2   Float32TC,
+       tedSwCapMaxLspBandwidthPri3   Float32TC,
+       tedSwCapMaxLspBandwidthPri4   Float32TC,
+       tedSwCapMaxLspBandwidthPri5   Float32TC,
+       tedSwCapMaxLspBandwidthPri6   Float32TC,
+       tedSwCapMaxLspBandwidthPri7   Float32TC,
+       tedSwCapMinLspBandwidth       Float32TC,
+       tedSwCapIfMtu                 Integer32,
+       tedSwCapIndication            INTEGER
+       }
+
+   tedSwCapIndex OBJECT-TYPE
+       SYNTAX       Unsigned32 (1..255)
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This index is utilized to identify multiple switching
+        functions on a local or remote TE link according to definitions
+        of textual conventions of GMPLS, RFC 4801."
+   ::= { tedSwCapEntry 1 }
+
+   tedSwCapType OBJECT-TYPE
+       SYNTAX       IANAGmplsSwitchingTypeTC
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the GMPLS switching capability assigned
+        to the TE link according to definitions of textual conventions
+        of GMPLS, RFC 4801."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 2 }
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 23]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedSwCapEncoding OBJECT-TYPE
+       SYNTAX       IANAGmplsLSPEncodingTypeTC
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the GMPLS encoding type assigned to the
+        TE link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 3 }
+
+   tedSwCapMaxLspBandwidthPri0 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 0 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 4 }
+
+   tedSwCapMaxLspBandwidthPri1 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 1 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 5 }
+
+   tedSwCapMaxLspBandwidthPri2  OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 2 for GMPLS LSP creation."
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 24]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 6 }
+
+   tedSwCapMaxLspBandwidthPri3 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 3 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 7 }
+
+   tedSwCapMaxLspBandwidthPri4 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 4 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 8 }
+
+   tedSwCapMaxLspBandwidthPri5  OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 5 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 9 }
+
+   tedSwCapMaxLspBandwidthPri6 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 25]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 6 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 10 }
+
+   tedSwCapMaxLspBandwidthPri7 OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the maximum bandwidth of the TE link at
+        the priority 7 for GMPLS LSP creation."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 11 }
+
+   tedSwCapMinLspBandwidth OBJECT-TYPE
+       SYNTAX       Float32TC
+       UNITS        "Byte per second"
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the minimum bandwidth of the TE link for
+        GMPLS LSP creation if the switching capability field is TDM,
+        PSC-1, PSC-2, PSC-3, or PSC-4."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 12 }
+
+   tedSwCapIfMtu OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+         "This object indicates the MTU of the local or remote TE link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 13 }
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 26]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedSwCapIndication OBJECT-TYPE
+       SYNTAX       INTEGER {
+                    standard (0),
+                    arbitrary (1)
+                    }
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates whether the interface supports Standard
+        or Arbitrary SONET/SDH."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.4
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.3"
+   ::= { tedSwCapEntry 14 }
+
+   --  TED SRLG Table
+
+   tedSrlgTable OBJECT-TYPE
+       SYNTAX       SEQUENCE OF TedSrlgEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+         "This table contains the SRLG information of the TE link."
+   ::= { tedObjects 5 }
+
+   tedSrlgEntry OBJECT-TYPE
+       SYNTAX       TedSrlgEntry
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+         "This entry relates each TE link with its SRLG information."
+       INDEX { tedLinkIndex, tedSrlgIndex }
+   ::= { tedSrlgTable 1 }
+
+   TedSrlgEntry ::= SEQUENCE {
+       tedSrlgIndex   Unsigned32,
+       tedSrlg        Integer32
+       }
+
+   tedSrlgIndex OBJECT-TYPE
+       SYNTAX       Unsigned32(1..255)
+       MAX-ACCESS   not-accessible
+       STATUS       current
+       DESCRIPTION
+        "This index is utilized to identify multiple SRLG values on a
+        local or remote TE link.  This object represents an arbitrary
+        value, which is locally defined in a router."
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 27]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       REFERENCE
+        "OSPF Extensions in support of GMPLS, RFC 4203, Section 1.3
+          IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.4"
+   ::= { tedSrlgEntry 1 }
+
+   tedSrlg OBJECT-TYPE
+       SYNTAX       Integer32
+       MAX-ACCESS   read-only
+       STATUS       current
+       DESCRIPTION
+        "This object indicates the SRLG value assigned to a local or
+        remote TE link."
+       REFERENCE
+         "OSPF Extensions in Support of GMPLS, RFC 4203, Section 1.3
+           IS-IS Extensions in Support of GMPLS, RFC 5307, Section 1.4"
+   ::= { tedSrlgEntry 2 }
+
+   -- Notification Configuration
+
+   tedStatusChangeNotificationMaxRate OBJECT-TYPE
+       SYNTAX        Unsigned32
+       MAX-ACCESS    read-write
+       STATUS        current
+       DESCRIPTION
+        "A lot of notifications relating to the status change are
+        expected to generate in a node, especially when a network
+        failure occurs and might cause a performance degradation of the
+        node itself.  To avoid such a defect, this object provides the
+        maximum number of notifications generated per minute.  If
+        events occur more rapidly, the implementation may simply fail
+        to emit these notifications during that period, or may queue
+        them until an appropriate time.  A value of 0 means no
+        throttling is applied and events may be notified at the rate at
+        which they occur."
+       DEFVAL        {1}
+   ::= { tedObjects 6 }
+
+   tedCreatedDeletedNotificationMaxRate OBJECT-TYPE
+       SYNTAX        Unsigned32
+       MAX-ACCESS    read-write
+       STATUS        current
+       DESCRIPTION
+        "A lot of notifications relating to new registration in the TED
+        table by receiving new TE link information or deletion of
+        existing entries in the TED table are expected to generate in a
+        node.  This object provides the maximum number of notifications
+        generated per minute."
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 28]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       DEFVAL        {1}
+   ::= { tedObjects 7 }
+
+   -- Notifications
+
+   tedStatusChange NOTIFICATION-TYPE
+       OBJECTS  {
+         tedLinkState
+         }
+       STATUS   current
+       DESCRIPTION
+        "This notification signifies that there has been change in the
+        TE information of tedTable, tedLocalIfAddrTable,
+        tedRemoteIfAddrTable, tedSwCapTable, and/or tedSrlgTable.  For
+        example, this should be generated when tedUnreservedBandwidth is
+        changed to create or delete LSP using the registered TE link."
+   ::= { tedNotifications 1 }
+
+   tedEntryCreated NOTIFICATION-TYPE
+       OBJECTS  {
+         tedLinkState
+         }
+       STATUS   current
+       DESCRIPTION
+        "This notification signifies that there has been new
+        registration in the TED table by receiving new TE link
+        information.  For example, this should be generated when a new
+        index (tedLinkIndex) is registered in the TED table."
+   ::= { tedNotifications 2 }
+
+   tedEntryDeleted NOTIFICATION-TYPE
+       OBJECTS  {
+         tedLinkState
+         }
+       STATUS      current
+      DESCRIPTION
+        "This notification signifies that there has been deletion of an
+        entry in the TED table.  For example, this should be generated
+        when one of the existing entries is deleted in the TED table."
+   ::= { tedNotifications 3 }
+
+   -- Conformance Statement
+
+   tedCompliances
+       OBJECT IDENTIFIER ::= { tedConformance 1 }
+   tedGroups
+       OBJECT IDENTIFIER ::= { tedConformance 2 }
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 29]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   -- Module Compliance
+
+   tedModuleFullCompliance MODULE-COMPLIANCE
+       STATUS   current
+       DESCRIPTION
+         "Compliance statement for agents provides full support for the
+         TED MIB."
+       MODULE -- this module
+       MANDATORY-GROUPS   { tedMainGroup,
+                            tedObjectsGroup,
+                            tedNotificationGroup
+                          }
+
+   GROUP tedUnnumberedLinkGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the
+        unnumbered links."
+
+   GROUP tedNumberedLinkGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the
+        numbered links."
+
+   GROUP tedSwCapGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support GMPLS
+        switching capability."
+
+   GROUP tedSwCapMinLspBandwidthGroup
+      DESCRIPTION
+        "This group is mandatory for TE links if the switching
+        capability field is TDM, PSC-1, PSC-2, PSC-3, or PSC-4."
+
+   GROUP tedSwCapIfMtuGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the MTU of
+        the local or remote TE link."
+
+   GROUP tedSwCapIndicationGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support Standard or
+        Arbitrary SONET/SDH."
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 30]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   GROUP tedSrlgGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support SRLG
+        information."
+
+   ::= { tedCompliances 1 }
+
+   --
+   -- ReadOnly Compliance
+   --
+
+   tedModuleReadOnlyCompliance MODULE-COMPLIANCE
+      STATUS current
+       DESCRIPTION
+        "Compliance requirement for implementations only provides read-
+        only support for TED.  Such devices can then be monitored but
+        cannot be configured using this MIB module."
+       MODULE -- this module
+       MANDATORY-GROUPS   { tedMainGroup
+                          }
+
+   GROUP tedUnnumberedLinkGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the
+        unnumbered links."
+
+   GROUP tedNumberedLinkGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the
+        numbered links."
+
+   GROUP tedSwCapGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support some GMPLS
+        switching capabilities."
+
+   GROUP tedSwCapMinLspBandwidthGroup
+      DESCRIPTION
+        "This group is mandatory for TE links if the switching
+        capability field is TDM, PSC-1, PSC-2, PSC-3, or PSC-4."
+
+   GROUP tedSwCapIfMtuGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support the MTU of
+        the local or remote TE link."
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 31]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   GROUP tedSwCapIndicationGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support Standard or
+        Arbitrary SONET/SDH."
+
+   GROUP tedSrlgGroup
+      DESCRIPTION
+        "This group is mandatory for TE links that support SRLG
+        information."
+
+   ::= { tedCompliances 2 }
+
+   -- Units of conformance
+
+   tedMainGroup OBJECT-GROUP
+       OBJECTS {
+               tedLinkState,
+               tedAreaId,
+               tedLinkType,
+               tedTeRouterIdAddrType,
+               tedTeRouterIdAddr,
+               tedLinkIdAddrType,
+               tedLinkIdAddr,
+               tedMetric,
+               tedMaxBandwidth,
+               tedMaxReservableBandwidth,
+               tedUnreservedBandwidthPri0,
+               tedUnreservedBandwidthPri1,
+               tedUnreservedBandwidthPri2,
+               tedUnreservedBandwidthPri3,
+               tedUnreservedBandwidthPri4,
+               tedUnreservedBandwidthPri5,
+               tedUnreservedBandwidthPri6,
+               tedUnreservedBandwidthPri7,
+               tedAdministrativeGroup,
+               tedLinkProtectionType,
+               tedLinkInformationData
+               }
+       STATUS   current
+       DESCRIPTION
+        "Collection of objects for TED management"
+   ::= { tedGroups 1 }
+
+   tedObjectsGroup OBJECT-GROUP
+       OBJECTS {
+            tedStatusChangeNotificationMaxRate,
+            tedCreatedDeletedNotificationMaxRate
+       }
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 32]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement notification."
+   ::= { tedGroups 2 }
+
+   tedNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS {
+            tedStatusChange,
+            tedEntryCreated,
+            tedEntryDeleted
+            }
+       STATUS  current
+       DESCRIPTION
+        "This group is mandatory for those implementations that can
+        implement the notifications contained in this group."
+   ::= { tedGroups 3 }
+
+   tedUnnumberedLinkGroup OBJECT-GROUP
+       OBJECTS {
+            tedLocalId,
+            tedRemoteId
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the unnumbered links."
+   ::= { tedGroups 4 }
+
+   tedNumberedLinkGroup OBJECT-GROUP
+       OBJECTS {
+            tedLocalIfAddrType,
+            tedRemoteIfAddrType
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the numbered links."
+   ::= { tedGroups 5 }
+
+   tedSwCapGroup OBJECT-GROUP
+       OBJECTS {
+            tedSwCapType,
+            tedSwCapEncoding,
+            tedSwCapMaxLspBandwidthPri0,
+            tedSwCapMaxLspBandwidthPri1,
+            tedSwCapMaxLspBandwidthPri2,
+            tedSwCapMaxLspBandwidthPri3,
+            tedSwCapMaxLspBandwidthPri4,
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 33]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+            tedSwCapMaxLspBandwidthPri5,
+            tedSwCapMaxLspBandwidthPri6,
+            tedSwCapMaxLspBandwidthPri7
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the TE links with GMPLS TE
+        switching capability information."
+   ::= { tedGroups 6 }
+
+   tedSwCapMinLspBandwidthGroup OBJECT-GROUP
+       OBJECTS {
+            tedSwCapMinLspBandwidth
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the minimum bandwidth of the
+        TE link for GMPLS LSP creation."
+   ::= { tedGroups 7 }
+
+   tedSwCapIfMtuGroup OBJECT-GROUP
+       OBJECTS {
+            tedSwCapIfMtu
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the MTU information of the
+        local or remote TE link."
+   ::= { tedGroups 8 }
+
+   tedSwCapIndicationGroup OBJECT-GROUP
+       OBJECTS {
+            tedSwCapIndication
+       }
+       STATUS  current
+       DESCRIPTION
+        "The objects needed to implement the indication of whether the
+        interface supports Standard or Arbitrary SONET/SDH."
+   ::= { tedGroups 9 }
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 34]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   tedSrlgGroup OBJECT-GROUP
+       OBJECTS {
+            tedSrlg
+       }
+       STATUS  current
+       DESCRIPTION
+         "The objects needed to implement multiple SRLG values with
+         GMPLS TE information."
+   ::= { tedGroups 10 }
+
+   END
+
+8.  Security Considerations
+
+   There are several objects defined in this MIB module that have a MAX-
+   ACCESS clause of read-write.  Such objects may be considered
+   sensitive or vulnerable in some network environments.  The support
+   for SET operations in a non-secure environment without proper
+   protection can have a negative effect on network operations.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability: tedTable, tedLocalIfAddrTable,
+   tedRemoteIfAddrTable, tedSwCapTable, and tedSrlgTable contain
+   topology information for the MPLS/GMPLS network.  If an administrator
+   does not want to reveal this information, then these tables should be
+   considered sensitive/vulnerable.
+
+   There are only two write-access objects in this MIB module:
+   tedStatusChangeNotificationMaxRate and
+   tedCreatedDeletedNotificationMaxRate.  Malicious modification of
+   these objects could cause the management agent, the network, or the
+   router to become overloaded with notifications in cases of high churn
+   within the network.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   Implementations MUST provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), including full support for
+   authentication and privacy via the User-based Security Model (USM)
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 35]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  IANA Considerations
+
+   IANA has assigned 273 to the TED-MIB module specified in this
+   document in the "Internet-standard MIB - Transmission Group"
+   registry.  New assignments can only be made via Specification
+   Required as specified in [RFC5226].
+
+   In addition, the IANA has marked value 273 (the corresponding
+   transmission value allocated according to this document) as
+   "Reserved" in the "ifType definitions" registry.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2328]  Moy, J., "OSPF Version 2", STD 54, RFC 2328, April 1998.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+              STD 58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Conformance Statements for SMIv2",
+              STD 58, RFC 2580, April 1999.
+
+   [RFC4001]  Daniele, M., Haberman, B., Routhier, S., and J.
+              Schoenwaelder, "Textual Conventions for Internet Network
+              Addresses", RFC 4001, February 2005.
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 36]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   [RFC3630]  Katz, D., Kompella, K., and D. Yeung, "Traffic Engineering
+              (TE) Extensions to OSPF Version 2", RFC 3630,
+              September 2003.
+
+   [RFC4203]  Kompella, K., Ed., and Y. Rekhter, Ed., "OSPF Extensions
+              in Support of Generalized Multi-Protocol Label Switching
+              (GMPLS)", RFC 4203, October 2005.
+
+   [RFC4750]  Joyal, D., Ed., Galecki, P., Ed., Giacalone, S., Ed.,
+              Coltun, R., and F. Baker, "OSPF Version 2 Management
+              Information Base", RFC 4750, December 2006.
+
+   [RFC4801]  Nadeau, T., Ed., and A. Farrel, Ed., "Definitions of
+              Textual Conventions for Generalized Multiprotocol Label
+              Switching (GMPLS) Management", RFC 4801, February 2007.
+
+   [RFC5329]  Ishiguro, K., Manral, V., Davey, A., and A. Lindem, Ed.,
+              "Traffic Engineering Extensions to OSPF Version 3",
+              RFC 5329, September 2008.
+
+   [RFC5340]  Coltun, R., Ferguson, D., Moy, J., and A. Lindem, "OSPF
+              for IPv6", RFC 5340, July 2008.
+
+   [RFC5643]  Joyal, D., Ed., and V. Manral, Ed., "Management
+              Information Base for OSPFv3", RFC 5643, August 2009.
+
+   [RFC6340]  Presuhn, R., "Textual Conventions for the Representation
+              of Floating-Point Numbers", RFC 6340, August 2011.
+
+10.2.  Informative References
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for
+              Internet-Standard Management Framework", RFC 3410,
+              December 2002.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3812]  Srinivasan, C., Viswanathan, A., and T. Nadeau,
+              "Multiprotocol Label Switching (MPLS) Traffic Engineering
+              (TE) Management Information Base (MIB)", RFC 3812,
+              June 2004.
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 37]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   [RFC3813]  Srinivasan, C., Viswanathan, A., and T. Nadeau,
+              "Multiprotocol Label Switching (MPLS) Label Switching
+              Router (LSR) Management Information Base (MIB)", RFC 3813,
+              June 2004.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC3945]  Mannie, E., Ed., "Generalized Multi-Protocol Label
+              Switching (GMPLS) Architecture", RFC 3945, October 2004.
+
+   [RFC4202]  Kompella, K., Ed., and Y. Rekhter, Ed., "Routing
+              Extensions in Support of Generalized Multi-Protocol Label
+              Switching (GMPLS)", RFC 4202, October 2005.
+
+   [RFC4220]  Dubuc, M., Nadeau, T., and J. Lang, "Traffic Engineering
+              Link Management Information Base", RFC 4220,
+              November 2005.
+
+   [RFC4377]  Nadeau, T., Morrow, M., Swallow, G., Allan, D., and S.
+              Matsushima, "Operations and Management (OAM) Requirements
+              for Multi-Protocol Label Switched (MPLS) Networks",
+              RFC 4377, February 2006.
+
+   [RFC4444]  Parker, J., Ed., "Management Information Base for
+              Intermediate System to Intermediate System (IS-IS)",
+              RFC 4444, April 2006.
+
+   [RFC4802]  Nadeau, T., Ed., and A. Farrel, Ed., "Generalized
+              Multiprotocol Label Switching (GMPLS) Traffic Engineering
+              Management Information Base", RFC 4802, February 2007.
+
+   [RFC4803]  Nadeau, T., Ed., and A. Farrel, Ed., "Generalized
+              Multiprotocol Label Switching (GMPLS) Label Switching
+              Router (LSR) Management Information Base", RFC 4803,
+              February 2007.
+
+   [RFC5305]  Li, T. and H. Smit, "IS-IS Extensions for Traffic
+              Engineering", RFC 5305, October 2008.
+
+   [RFC5307]  Kompella, K., Ed., and Y. Rekhter, Ed., "IS-IS Extensions
+              in Support of Generalized Multi-Protocol Label Switching
+              (GMPLS)", RFC 5307, October 2008.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 38]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)",
+              RFC 5591, June 2009.
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+   [ISO10589] ISO 10589, "Intermediate System to Intermediate System
+              intra-domain routeing information exchange protocol for
+              use in conjunction with the protocol for providing the
+              connectionless-mode network service (ISO 8473)",
+              ISO/IEC 10589:2002.
+
+11.  Acknowledgments
+
+   The authors wish to acknowledge and thank the following individuals
+   for their valuable comments to this document: Ken Nagami, Shuichi
+   Okamoto, Adrian Farrel, Diego Caviglia, and Acee Lindem.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 39]
+
+RFC 6825                TED MIB for MPLS-TE/GMPLS           January 2013
+
+
+Authors' Addresses
+
+   Masanori Miyazawa
+   KDDI R&D Laboratories, Inc.
+   2-1-15 Ohara Fujimino
+   Saitama, 356-8502
+   Japan
+
+   EMail: ma-miyazawa@kddilabs.jp
+
+
+   Tomohiro Otani
+   KDDI Corporation
+   KDDI Bldg,
+   2-3-2, Nishishinjuku, Shinjuku-ku
+   Tokyo, 163-8003
+   Japan
+
+   EMail: Tm-otani@kddi.com
+
+
+   Kenji Kumaki
+   KDDI Corporation
+   Garden Air Tower
+   Iidabashi, Chyoda-ku
+   Tokyo, 102-8460
+   Japan
+
+   EMail: ke-kumaki@kddi.com
+
+
+   Thomas D. Nadeau
+   Juniper Networks
+   10 Technology Park Drive
+   Westford, MA
+   USA
+
+   EMail: tnadeau@juniper.net
+
+
+
+
+
+
+
+
+
+
+
+
+
+Miyazawa, et al.             Standards Track                   [Page 40]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6825.txt](<www.ietf.org/rfc/rfc6825.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
