### PR TITLE
Archive rfc6850.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6850.txt
+++ b/www.ietf.org/rfc/rfc6850.txt
@@ -1,0 +1,3307 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                   A. Rijhsinghani
+Request for Comments: 6850                               Hewlett-Packard
+Category: Standards Track                                     K. Zebrose
+ISSN: 2070-1721                                              HW Embedded
+                                                            January 2013
+
+
+     Definitions of Managed Objects for Routing Bridges (RBridges)
+
+Abstract
+
+   This memo defines a portion of the Management Information Base (MIB)
+   for use with network management protocols.  In particular, it defines
+   objects for managing a Routing Bridge (RBridge), also known as a
+   TRILL Switch, based on the IETF TRILL (Transparent Interconnection of
+   Lots of Links) protocol.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6850.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 1]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The Internet-Standard Management Framework ......................3
+   3. Overview ........................................................3
+   4. Conventions .....................................................4
+   5. Structure of the MIB Module .....................................4
+      5.1. Textual Conventions ........................................4
+      5.2. The rbridgeBase Subtree ....................................4
+      5.3. The rbridgeFdb Subtree .....................................4
+      5.4. The rbridgeVlan Subtree ....................................4
+      5.5. The rbridgeEsadi Subtree ...................................4
+      5.6. The rbridgeCounters Subtree ................................4
+      5.7. The rbridgeSnooping Subtree ................................5
+      5.8. The rbridgeDtree Subtree ...................................5
+      5.9. The rbridgeTrill Subtree ...................................5
+      5.10. The Notifications Subtree .................................5
+   6. Relationship to Other MIB Modules ...............................5
+      6.1. Relationship to IF-MIB .....................................5
+      6.2. Relationship to BRIDGE-MIB .................................6
+      6.3. Relationship to P-BRIDGE-MIB ...............................6
+      6.4. Relationship to Q-BRIDGE-MIB ...............................6
+      6.5. Relationship to IEEE8021-BRIDGE-MIB ........................7
+      6.6. Relationship to IEEE8021-Q-BRIDGE-MIB ......................7
+      6.7. Relationship to ISIS-MIB ...................................8
+      6.8. MIB Modules Required for IMPORTS ...........................8
+   7. Definition of the RBridge MIB Module ............................9
+   8. Security Considerations ........................................55
+   9. IANA Considerations ............................................56
+   10. Contributors ..................................................56
+   11. References ....................................................57
+      11.1. Normative References .....................................57
+      11.2. Informative References ...................................58
+
+1.  Introduction
+
+   This document describes a model for managing Routing Bridges
+   (RBridges), also known as TRILL Switches, as defined in [RFC6325].
+   RBridges provide optimal pair-wise forwarding without configuration
+   using IS-IS routing and encapsulation of traffic.  RBridges are
+   compatible with previous IEEE 802.1 customer bridges as well as IPv4
+   and IPv6 routers and end nodes.  They are as invisible to current IP
+   routers as bridges are and, like routers, they terminate the bridge
+   spanning tree protocol.  In creating an RBridge management model, the
+   device is viewed primarily as a customer bridge.  For a discussion of
+   the problem addressed by TRILL (Transparent Interconnection of Lots
+   of Links), see [RFC5556].
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 2]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   RBridges support features specified for transparent bridges in
+   IEEE 802.1, and the corresponding MIB modules are used to manage
+   those features.  For IS-IS purposes, the corresponding MIB module is
+   used to manage the protocol.  This MIB module specifies those objects
+   that are TRILL-specific and hence not available in other MIB modules.
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+3.  Overview
+
+   The RBridge MIB module is intended as an overall framework for
+   managing RBridges, also known as TRILL Switches.  Where possible, the
+   MIB references existing MIB definitions in order to maximize reuse.
+   This results in a considerable emphasis on the relationship with
+   other MIB modules.
+
+   Starting with the physical interfaces, there are requirements for
+   certain elements of the IF-MIB to be implemented.  These elements are
+   required in order to connect the per-port parameters to higher-level
+   functions of the physical device.
+
+   Transparent bridging, VLANs, traffic classes, and multicast filtering
+   are supported by the TRILL protocol, and the corresponding management
+   is expected to conform to the BRIDGE-MIB module [RFC4188] and to the
+   P-BRIDGE-MIB and Q-BRIDGE-MIB modules [RFC4363].
+
+   The IS-IS routing protocol is used in order to determine the optimum
+   pair-wise forwarding path.  This protocol is managed using the IS-IS
+   MIB module defined in [RFC4444].  Since the TRILL protocol specifies
+   the use of a single level and a fixed area address of zero, some
+   IS-IS MIB objects are not applicable.  Some IS-IS MIB objects are
+   used in the TRILL protocol.
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 3]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+4.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   RFC 2119 [RFC2119].
+
+5.  Structure of the MIB Module
+
+   Objects in this MIB module are arranged into subtrees.  Each subtree
+   is organized as a set of related objects.  The various subtrees are
+   shown below.  These are supplemented with required elements of the
+   IF-MIB, ISIS-MIB, BRIDGE-MIB, P-BRIDGE-MIB, Q-BRIDGE-MIB, and IEEE
+   Bridge MIB modules.
+
+5.1.  Textual Conventions
+
+   Textual conventions are defined to represent object types relevant to
+   TRILL.
+
+5.2.  The rbridgeBase Subtree
+
+   This subtree contains system- and port-specific objects applicable to
+   all RBridges.
+
+5.3.  The rbridgeFdb Subtree
+
+   This subtree contains objects applicable to the forwarding database
+   used by the RBridge in making packet-forwarding decisions.  Because
+   it contains additional information used by the TRILL protocol not
+   applicable to 802.1D/Q bridges, it is a superset of the corresponding
+   subtrees defined in the BRIDGE-MIB and Q-BRIDGE-MIB.
+
+5.4.  The rbridgeVlan Subtree
+
+   This subtree describes objects applicable to VLANs configured on the
+   RBridge.
+
+5.5.  The rbridgeEsadi Subtree
+
+   This subtree describes objects relevant to RBridges that support the
+   optional End-Station Address Distribution Information (ESADI)
+   protocol.
+
+5.6.  The rbridgeCounters Subtree
+
+   This subtree contains statistics maintained by RBridges that can aid
+   in monitoring and troubleshooting networks connected by them.
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 4]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+5.7.  The rbridgeSnooping Subtree
+
+   This subtree describes objects applicable to RBridges capable of
+   snooping IPv4 and/or IPv6 multicast control frames and pruning IP
+   multicast traffic based on detection of IP multicast routers and
+   listeners.
+
+5.8.  The rbridgeDtree Subtree
+
+   This subtree contains objects relevant to distribution trees computed
+   by RBridges for the forwarding of multi-destination frames.
+
+5.9.  The rbridgeTrill Subtree
+
+   This subtree contains objects applicable to the TRILL IS-IS protocol,
+   beyond what is available in the ISIS-MIB.
+
+5.10.  The Notifications Subtree
+
+   The defined notifications are focused on the TRILL protocol
+   functionality.  Notifications are defined for changes in the
+   Designated RBridge status and the topology.
+
+6.  Relationship to Other MIB Modules
+
+   The IF-MIB, BRIDGE-MIB, P-BRIDGE-MIB, Q-BRIDGE-MIB,
+   IEEE8021-BRIDGE-MIB, IEEE8021-Q-BRIDGE-MIB, and ISIS-MIB modules all
+   contain objects relevant to the RBridge MIB.  Management objects
+   contained in these modules are not duplicated here, to reduce overlap
+   to the extent possible.
+
+   The Bridge MIB modules were originally written in the IETF and
+   implemented by many vendors.  Per [RFC4663], this has recently been
+   transferred to the IEEE 802.1 working group.  As vendors may have
+   implemented either the IETF or IEEE Bridge MIB modules, this RBridge
+   MIB module is designed to work with either one.
+
+6.1.  Relationship to IF-MIB
+
+   The port identification elements MUST be implemented in order to
+   allow them to be cross-referenced.  The Interfaces MIB [RFC2863]
+   requires that any MIB module that is an adjunct of the Interfaces MIB
+   clarify specific areas within the Interfaces MIB module.  These areas
+   were intentionally left vague in the Interfaces MIB module to avoid
+   over-constraining the MIB, thereby precluding management of certain
+   media types.  Section 4 of [RFC2863] enumerates several areas that a
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 5]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   media-specific MIB module must clarify.  The implementor is referred
+   to [RFC2863] in order to understand the general intent of these
+   areas.
+
+6.2.  Relationship to BRIDGE-MIB
+
+   The following subtrees in the BRIDGE-MIB [RFC4188] contain
+   information relevant to RBridges when the corresponding functionality
+   is implemented.
+
+   o  dot1dBase
+
+   o  dot1dTp
+
+   o  dot1dStatic
+
+6.3.  Relationship to P-BRIDGE-MIB
+
+   The following subtrees in the P-BRIDGE-MIB [RFC4363] contain
+   information relevant to RBridges when the corresponding functionality
+   is implemented.
+
+   o  dot1dExtBase
+
+   o  dot1dPriority
+
+   o  dot1dGarp
+
+   o  dot1dGmrp
+
+   o  dot1dTpHCPortTable
+
+   o  dot1dTpPortOverflowTable
+
+6.4.  Relationship to Q-BRIDGE-MIB
+
+   The following groups in the Q-BRIDGE-MIB [RFC4363] contain
+   information relevant to RBridges when the corresponding functionality
+   is implemented.  This functionality is also contained in the
+   IEEE8021-Q-BRIDGE-MIB.
+
+   o  dot1qBase
+
+   o  dot1qTp
+
+   o  dot1qStatic
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 6]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   o  dot1qVlan
+
+   o  dot1vProtocol
+
+6.5.  Relationship to IEEE8021-BRIDGE-MIB
+
+   The following subtrees in the IEEE8021-BRIDGE-MIB contain information
+   relevant to RBridges when the corresponding functionality is
+   implemented.
+
+   o  ieee8021BridgeBase
+
+   o  ieee8021BridgeTp
+
+   o  ieee8021BridgePriority
+
+   o  ieee8021BridgeMrp
+
+   o  ieee8021BridgeMmrp
+
+   o  ieee8021BridgeInternalLan
+
+   o  ieee8021BridgeDot1d
+
+6.6.  Relationship to IEEE8021-Q-BRIDGE-MIB
+
+   The following subtrees in the IEEE8021-Q-BRIDGE-MIB contain
+   information relevant to RBridges when the corresponding functionality
+   is implemented.
+
+   o  ieee8021QBridgeBase
+
+   o  ieee8021QBridgeTp
+
+   o  ieee8021QBridgeStatic
+
+   o  ieee8021QBridgeVlan
+
+   o  ieee8021QBridgeProtocol
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 7]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+6.7.  Relationship to ISIS-MIB
+
+   "Management Information Base for Intermediate System to Intermediate
+   System (IS-IS)" [RFC4444] defines a MIB module for the IS-IS routing
+   protocol when it is used to construct routing tables for IP networks.
+   While most of these objects are applicable to the TRILL layer 2
+   implementation, note the IS-IS constraints for the current version of
+   TRILL [RFC6325]:
+
+   o  The TRILL IS-IS instance uses a single Level 1 IS-IS area.
+
+   o  The TRILL Level 1 IS-IS area uses the fixed area address zero.
+
+   o  The TRILL IS-IS instance is not used for IP address advertisement.
+
+   o  The TRILL IS-IS instance is used for only a single protocol:
+      TRILL.
+
+   Accordingly, tables that report IP address reachability and tables
+   that allow configuration or reporting of multiple IS-IS areas,
+   multiple IS-IS levels, or multiple protocols will be empty in the
+   ISIS-MIB module for the current version of TRILL.
+
+   Note also that when more than one instance of the IS-IS protocol is
+   running on a device, as in the case of a device performing both
+   RBridge and IS-IS IP router functions, multiple instances of the
+   ISIS-MIB module can be distinguished by the use of SNMPv3 contexts or
+   SNMPv1 communities.
+
+6.8.  MIB Modules Required for IMPORTS
+
+   The following MIB module imports objects from the SNMPv2-SMI
+   [RFC2578], SNMPv2-TC [RFC2579], SNMPv2-CONF [RFC2580], IF-MIB
+   [RFC2863], INET-ADDRESS-MIB [RFC4001], BRIDGE-MIB [RFC4188],
+   and Q-BRIDGE-MIB [RFC4363].  (The IEEE Bridge MIB modules import
+   similar TCs.)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 8]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+7.  Definition of the RBridge MIB Module
+
+   RBRIDGE-MIB DEFINITIONS ::= BEGIN
+
+   -- ---------------------------------------------------------- --
+   -- MIB for RBRIDGE devices, also known as TRILL Switches
+   -- ---------------------------------------------------------- --
+   IMPORTS
+       MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
+       Counter32, Counter64, Unsigned32, mib-2
+           FROM SNMPv2-SMI            -- RFC2578
+       TEXTUAL-CONVENTION, TruthValue, MacAddress, RowStatus
+           FROM SNMPv2-TC             -- RFC2579
+       MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+           FROM SNMPv2-CONF           -- RFC2580
+       VlanId, PortList
+           FROM Q-BRIDGE-MIB          -- RFC4363
+       InetAddress, InetAddressType
+           FROM INET-ADDRESS-MIB      -- RFC4001
+       BridgeId
+           FROM BRIDGE-MIB            -- RFC4188
+       InterfaceIndex
+           FROM IF-MIB                -- RFC2863
+       ;
+
+   rbridgeMIB MODULE-IDENTITY
+   LAST-UPDATED "201301070000Z"
+   ORGANIZATION "IETF TRILL Working Group"
+   CONTACT-INFO
+        "http://datatracker.ietf.org/wg/trill/charter/
+        Email: trill@ietf.org
+
+               Anil Rijhsinghani
+               Hewlett-Packard
+          Tel: +1 508 323 1251
+        Email: anil@charter.net
+
+               Kate Zebrose
+               HW Embedded
+          Tel: +1 617 840 9673
+        Email: zebrose@alum.mit.edu"
+
+       DESCRIPTION
+           "The RBridge MIB module for managing switches that support
+           the TRILL protocol."
+
+   REVISION     "201301070000Z"
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                    [Page 9]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   DESCRIPTION
+        "Initial version, published as RFC 6850.
+
+        Copyright (c) 2013 IETF Trust and the persons identified as
+        authors of the code.  All rights reserved.
+
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject to
+        the license terms contained in, the Simplified BSD License set
+        forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (http://trustee.ietf.org/license-info)."
+
+        ::= { mib-2 214 }
+
+
+   -- ---------------------------------------------------------- --
+   -- Subtrees in the RBridge MIB
+   -- ---------------------------------------------------------- --
+
+   rbridgeNotifications  OBJECT IDENTIFIER ::= { rbridgeMIB 0 }
+   rbridgeObjects        OBJECT IDENTIFIER ::= { rbridgeMIB 1 }
+   rbridgeConformance    OBJECT IDENTIFIER ::= { rbridgeMIB 2 }
+
+   rbridgeBase           OBJECT IDENTIFIER ::= { rbridgeObjects 1 }
+   rbridgeFdb            OBJECT IDENTIFIER ::= { rbridgeObjects 2 }
+   rbridgeVlan           OBJECT IDENTIFIER ::= { rbridgeObjects 3 }
+   rbridgeEsadi          OBJECT IDENTIFIER ::= { rbridgeObjects 4 }
+   rbridgeCounter        OBJECT IDENTIFIER ::= { rbridgeObjects 5 }
+   rbridgeSnooping       OBJECT IDENTIFIER ::= { rbridgeObjects 6 }
+   rbridgeDtree          OBJECT IDENTIFIER ::= { rbridgeObjects 7 }
+   rbridgeTrill          OBJECT IDENTIFIER ::= { rbridgeObjects 8 }
+
+   -- ---------------------------------------------------------- --
+   -- Type Definitions
+   -- ---------------------------------------------------------- --
+
+   RbridgeAddress ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT "1x:"
+       STATUS current
+       DESCRIPTION
+           "The Media Access Control (MAC) address used by an RBridge
+           port.  This may match the RBridge IS-IS SystemID."
+       SYNTAX OCTET STRING (SIZE (6))
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 10]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   RbridgeNickname ::= TEXTUAL-CONVENTION
+       DISPLAY-HINT "d"
+       STATUS current
+       DESCRIPTION
+           "The 16-bit identifier used in TRILL as an
+           abbreviation for the RBridge's 48-bit IS-IS System ID.
+           The value 0 means a nickname is not specified, the values
+           0xFFC0 through 0xFFFE are reserved for future allocation,
+           and the value 0xFFFF is permanently reserved."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       SYNTAX Unsigned32 (0..65471)
+
+   --
+   -- the rbridgeBase subtree
+   --
+   -- Implementation of the rbridgeBase subtree is mandatory for all
+   -- RBridges.
+   --
+
+   rbridgeBaseTrillVersion OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The maximum TRILL version number that this RBridge
+           supports."
+       REFERENCE
+           "RFC 6325, Section 3.2"
+       ::= { rbridgeBase 1 }
+
+   rbridgeBaseNumPorts OBJECT-TYPE
+       SYNTAX      Unsigned32
+       UNITS       "ports"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of ports controlled by this RBridge."
+       REFERENCE
+           "RFC 6325, Section 2.6.1"
+       ::= { rbridgeBase 2 }
+
+   rbridgeBaseForwardDelay OBJECT-TYPE
+       SYNTAX      Unsigned32 (4..30)
+       UNITS       "seconds"
+       MAX-ACCESS  read-write
+       STATUS      current
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 11]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       DESCRIPTION
+           "Modified aging time for address entries after an appointed
+           forwarder change.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8.3"
+       ::= { rbridgeBase 3 }
+
+   rbridgeBaseUniMultipathEnable OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The enabled status of unicast TRILL multipathing.
+           It is enabled when true.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Appendix C"
+       ::= { rbridgeBase 4 }
+
+   rbridgeBaseMultiMultipathEnable OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The enabled status of multi-destination TRILL multipathing.
+           It is enabled when true.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Appendix C"
+       ::= { rbridgeBase 5 }
+
+   rbridgeBaseAcceptEncapNonadj OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Accept TRILL-encapsulated frames from a neighbor with which
+           this RBridge does not have an IS-IS adjacency, when the value
+           of this object is 'true'.
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 12]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.6.2"
+       ::= { rbridgeBase 6 }
+
+   rbridgeBaseNicknameNumber OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..256)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The number of nicknames this RBridge should acquire.
+           These can be acquired dynamically or configured
+           statically.  This value represents the maximum
+           number of entries in rbridgeBaseNicknameTable.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 3.7.3"
+       ::= { rbridgeBase 7 }
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge Base Nickname Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeBaseNicknameTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeBaseNicknameEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about nicknames
+           configured by an operator or learned dynamically
+           by this RBridge."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       ::= { rbridgeBase 8 }
+
+   rbridgeBaseNicknameEntry OBJECT-TYPE
+       SYNTAX      RbridgeBaseNicknameEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information for each nickname of the RBridge."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       INDEX  { rbridgeBaseNicknameName }
+       ::= { rbridgeBaseNicknameTable 1 }
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 13]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   RbridgeBaseNicknameEntry ::=
+       SEQUENCE {
+           rbridgeBaseNicknameName
+               RbridgeNickname,
+           rbridgeBaseNicknamePriority
+               Unsigned32,
+           rbridgeBaseNicknameDtrPriority
+               Unsigned32,
+           rbridgeBaseNicknameType
+               INTEGER,
+           rbridgeBaseNicknameRowStatus
+               RowStatus
+       }
+
+   rbridgeBaseNicknameName OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Nicknames are 16-bit quantities that act as
+           abbreviations for RBridge's 48-bit IS-IS System ID to
+           achieve a more compact encoding."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       ::= { rbridgeBaseNicknameEntry 1 }
+
+   rbridgeBaseNicknamePriority OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "This RBridge's priority to hold this nickname.  When
+           the nickname is configured, the default value of this
+           object is 192.  When the nickname is configured, the most
+           significant bit (0x80) must be set and the bottom 7 bits
+           have the default value of 0x40, so 0x80 + 0x40 == 0xC0,
+           which is 192 decimal.  Additionally, the bottom 7 bits
+           could be configured to a value other than 0x40.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       DEFVAL      { 192 }
+       ::= { rbridgeBaseNicknameEntry 2 }
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 14]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   rbridgeBaseNicknameDtrPriority OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..65535)
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "The distribution tree root priority for this nickname.
+           The default value of this object is 32768.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       DEFVAL      { 32768 }
+       ::= { rbridgeBaseNicknameEntry 3 }
+
+   rbridgeBaseNicknameType OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       static(1),
+                       dynamic(2)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This object indicates the status of the entry.  The
+           default value is static(1).
+               static(1) - this entry has been configured and
+                   will remain after the next reset of the RBridge.
+               dynamic(2) - this entry has been acquired by the
+                   RBridge nickname acquisition protocol."
+       REFERENCE
+           "RFC 6325, Section 3.7"
+       DEFVAL      { static }
+       ::= { rbridgeBaseNicknameEntry 4 }
+
+   rbridgeBaseNicknameRowStatus OBJECT-TYPE
+       SYNTAX      RowStatus
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "This object indicates the status of the entry."
+       ::= { rbridgeBaseNicknameEntry 5 }
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 15]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge Port Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeBasePortTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeBasePortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains generic information about every
+           port that is associated with this RBridge."
+       REFERENCE
+           "RFC 6325, Section 5.3"
+       ::= { rbridgeBase 9 }
+
+   rbridgeBasePortEntry OBJECT-TYPE
+       SYNTAX      RbridgeBasePortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information for each port of the bridge."
+       REFERENCE
+           "RFC 6325, Section 5.3"
+       INDEX  { rbridgeBasePort }
+       ::= { rbridgeBasePortTable 1 }
+
+   RbridgeBasePortEntry ::=
+       SEQUENCE {
+           rbridgeBasePort
+               Unsigned32,
+           rbridgeBasePortIfIndex
+               InterfaceIndex,
+           rbridgeBasePortDisable
+               TruthValue,
+           rbridgeBasePortTrunkPort
+               TruthValue,
+           rbridgeBasePortAccessPort
+               TruthValue,
+           rbridgeBasePortP2pHellos
+               TruthValue,
+           rbridgeBasePortState
+               INTEGER,
+           rbridgeBasePortInhibitionTime
+               Unsigned32,
+           rbridgeBasePortDisableLearning
+               TruthValue,
+           rbridgeBasePortDesiredDesigVlan
+               VlanId,
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 16]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           rbridgeBasePortDesigVlan
+               VlanId,
+           rbridgeBasePortStpRoot
+               BridgeId,
+           rbridgeBasePortStpRootChanges
+               Counter32,
+           rbridgeBasePortStpWiringCloset
+               BridgeId
+   }
+
+   rbridgeBasePort OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..65535)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The port number of the port for which this entry
+           contains RBridge management information."
+       REFERENCE
+           "RFC 6325, Section 5.3"
+       ::= { rbridgeBasePortEntry 1 }
+
+   rbridgeBasePortIfIndex OBJECT-TYPE
+       SYNTAX      InterfaceIndex
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The value of the instance of the ifIndex object,
+           defined in the IF-MIB, for the interface corresponding
+           to this port.  The RBridge port sits on top of
+           this interface."
+       ::= { rbridgeBasePortEntry 2 }
+
+   rbridgeBasePortDisable OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Disable port bit.  When this bit is set (true), all frames
+           received or to be transmitted are discarded, with the
+           possible exception of some layer 2 control frames that may
+           be generated and transmitted or received and processed
+           locally.  Default value is 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 17]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       REFERENCE
+           "RFC 6325, Section 4.9.1"
+       DEFVAL      { false }
+       ::= { rbridgeBasePortEntry 3 }
+
+   rbridgeBasePortTrunkPort OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "End-station service disable (trunk port) bit.  When this bit
+           is set (true), all native frames received on the port and all
+           native frames that would have been sent on the port are
+           discarded.  Default value is 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.9.1"
+       DEFVAL      { false }
+       ::= { rbridgeBasePortEntry 4 }
+
+   rbridgeBasePortAccessPort OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "TRILL traffic disable (access port) bit.  If this bit is
+           set, the goal is to avoid sending any TRILL frames, except
+           TRILL-Hello frames, on the port, since it is intended only
+           for native end-station traffic.  This ensures that the link
+           is not on the shortest path for any destination.  Default
+           value is 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.9.1"
+       DEFVAL      { false }
+       ::= { rbridgeBasePortEntry 5 }
+
+   rbridgeBasePortP2pHellos OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Use point-to-point (P2P) Hellos bit.  If this bit is set,
+           Hellos sent on this port are IS-IS P2P Hellos, not the
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 18]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           default TRILL-Hellos.  In addition, the IS-IS P2P three-way
+           handshake is used on P2P RBridge links.  Default value is
+           'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.9.1"
+       DEFVAL      { false }
+       ::= { rbridgeBasePortEntry 6 }
+
+   rbridgeBasePortState OBJECT-TYPE
+       SYNTAX      INTEGER {
+                          uninhibited(1),
+                          portInhibited(2),
+                          vlanInhibited(3),
+                          disabled(4),
+                          broken(5)
+                      }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The port's current state.  If the entire port is
+           inhibited, its state is portInhibited(2).  If specific VLANs
+           are inhibited, the state is vlanInhibited(3), and
+           rbridgeVlanPortTable will tell which VLANs are inhibited.
+           For ports that are disabled (see rbridgeBasePortDisable),
+           this object will have a value of disabled(4).  If the
+           RBridge has detected a port that is malfunctioning, it will
+           place that port into the broken(5) state."
+       REFERENCE
+           "RFC 6325, Section 4.2.4.3"
+       ::= { rbridgeBasePortEntry 7 }
+
+   rbridgeBasePortInhibitionTime OBJECT-TYPE
+       SYNTAX      Unsigned32
+       UNITS       "seconds"
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Time in seconds that this RBridge will inhibit forwarding
+           on this port after it observes a spanning tree root bridge
+           change on a link or receives conflicting VLAN forwarder
+           information.  The default value is 30.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 19]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       REFERENCE
+           "RFC 6325, Section 4.2.4.3"
+       DEFVAL      { 30 }
+       ::= { rbridgeBasePortEntry 8 }
+
+   rbridgeBasePortDisableLearning OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Disable learning of MAC addresses seen on this port.
+           To disable learning, the value of this object must be
+           set to 'true'.  The default is 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8"
+       DEFVAL      { false }
+       ::= { rbridgeBasePortEntry 9 }
+
+   rbridgeBasePortDesiredDesigVlan OBJECT-TYPE
+       SYNTAX      VlanId
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The VLAN that a Designated RBridge (DRB) will specify in
+           its TRILL-Hellos as the VLAN to be used by all RBridges on
+           the link for TRILL frames.  This VLAN must be enabled on
+           this port.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.4.3"
+       ::= { rbridgeBasePortEntry 10 }
+
+   rbridgeBasePortDesigVlan OBJECT-TYPE
+       SYNTAX      VlanId
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The VLAN being used on this link for TRILL frames."
+       REFERENCE
+           "RFC 6325, Section 4.4.3"
+       ::= { rbridgeBasePortEntry 11 }
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 20]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   rbridgeBasePortStpRoot OBJECT-TYPE
+       SYNTAX      BridgeId
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The bridge identifier of the root of the spanning tree,
+           as learned from a Bridge PDU (BPDU) received on this port.
+           For the Multiple Spanning Tree Protocol (MSTP), this is
+           the root bridge of the Common and Internal Spanning Tree
+           (CIST).  If no BPDU has been heard, the value returned
+           is a string of zeros."
+       REFERENCE
+           "RFC 6325, Section 4.2.4.3"
+       ::= { rbridgeBasePortEntry 12 }
+
+   rbridgeBasePortStpRootChanges OBJECT-TYPE
+       SYNTAX      Counter32
+       UNITS       "changes"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of times a change in the root bridge is seen from
+           spanning tree BPDUs received on this port, indicating a
+           change in bridged LAN topology.  Each such change may cause
+           the port to be inhibited for a period of time.  This counter
+           should be synchronized with ifCounterDiscontinuityTime.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.9.3.2"
+       ::= { rbridgeBasePortEntry 13 }
+
+   rbridgeBasePortStpWiringCloset OBJECT-TYPE
+       SYNTAX      BridgeId
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The Bridge ID to be used as the spanning tree root in BPDUs
+           sent for the Wiring Closet topology solution described in
+           [RFC6325].  Note that the same value of this object must be
+           set on all RBridge ports participating in this solution.
+           The default value is all 0s.  A non-zero value configured
+           into this object indicates that this solution is in use.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 21]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       REFERENCE
+           "RFC 6325, Appendix A.3.3"
+       ::= { rbridgeBasePortEntry 14 }
+
+   -- -------------------------------------------------------------
+   -- RBridge Forwarding Database
+   -- -------------------------------------------------------------
+
+   rbridgeConfidenceNative OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The confidence level associated with MAC addresses
+           learned from native frames.  This is applicable to
+           all RBridge ports.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8.1"
+       ::= { rbridgeFdb 1 }
+
+   rbridgeConfidenceDecap OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The confidence level associated with inner MAC addresses
+           learned after decapsulation of a TRILL data frame.
+           This is applicable to all RBridge ports.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8.1"
+       ::= { rbridgeFdb 2 }
+
+   rbridgeConfidenceStatic OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The confidence level associated with MAC addresses that
+           are statically configured.  The default value is 255.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 22]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       REFERENCE
+           "RFC 6325, Section 4.8.2"
+       DEFVAL      { 255 }
+       ::= { rbridgeFdb 3 }
+
+
+   -- -------------------------------------------------------------
+   -- Multiple Forwarding Databases for RBridges
+   --
+   -- This allows for an instance per FdbId, as defined in the
+   -- Bridge MIB.
+   --
+   -- Each VLAN may have an independent FDB, or multiple VLANs may
+   -- share one.
+   -- -------------------------------------------------------------
+
+   rbridgeUniFdbTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeUniFdbEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about unicast entries
+           for which the device has forwarding and/or filtering
+           information.  This information is used by the
+           transparent bridging function in determining how to
+           propagate a received frame."
+       REFERENCE
+           "RFC 6325, Section 4.8"
+       ::= { rbridgeFdb 4 }
+
+   rbridgeUniFdbEntry OBJECT-TYPE
+       SYNTAX      RbridgeUniFdbEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about a specific unicast MAC address for
+           which the RBridge has some forwarding and/or filtering
+           information."
+       INDEX   { rbridgeFdbId, rbridgeUniFdbAddr }
+       ::= { rbridgeUniFdbTable 1 }
+
+   RbridgeUniFdbEntry ::=
+       SEQUENCE {
+           rbridgeFdbId
+               Unsigned32,
+           rbridgeUniFdbAddr
+               MacAddress,
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 23]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           rbridgeUniFdbPort
+               Unsigned32,
+           rbridgeUniFdbNickname
+               RbridgeNickname,
+           rbridgeUniFdbConfidence
+               Unsigned32,
+           rbridgeUniFdbStatus
+               INTEGER
+       }
+
+   rbridgeFdbId OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The identity of this Filtering Database."
+       ::= { rbridgeUniFdbEntry 1 }
+
+   rbridgeUniFdbAddr OBJECT-TYPE
+       SYNTAX      MacAddress
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A unicast MAC address for which the device has
+           forwarding information."
+       ::= { rbridgeUniFdbEntry 2 }
+
+   rbridgeUniFdbPort OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..65535)
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "Either the value '0', or the RBridge port number of the
+           port on which a frame having a source address equal to the
+           value of the corresponding instance of rbridgeUniFdbAddr
+           has been seen.  A value of '0' indicates that the port
+           number has not been learned but that the device does have
+           some information about this MAC address.
+
+           Implementors are encouraged to assign the port value to
+           this object whenever it is available, even for addresses
+           for which the corresponding value of rbridgeUniFdbStatus is
+           not learned(3)."
+       ::= { rbridgeUniFdbEntry 3 }
+
+   rbridgeUniFdbNickname OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  read-only
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 24]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       STATUS      current
+       DESCRIPTION
+           "The RBridge nickname that is placed in the egress
+           nickname field of a TRILL frame sent to this
+           rbridgeFdbAddress in this rbridgeFdbId."
+       REFERENCE
+           "RFC 6325, Section 4.8.1"
+       ::= { rbridgeUniFdbEntry 4 }
+
+   rbridgeUniFdbConfidence OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The confidence level associated with this entry."
+       REFERENCE
+           "RFC 6325, Section 4.8.1"
+       ::= { rbridgeUniFdbEntry 5 }
+
+   rbridgeUniFdbStatus OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       other(1),
+                       invalid(2),
+                       learned(3),
+                       self(4),
+                       mgmt(5),
+                       esadi(6)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The status of this entry.  The meanings of the values
+           are:
+               other(1) - none of the following.
+               invalid(2) - this entry is no longer valid (e.g., it
+                   was learned but has since aged out) but has not
+                   yet been flushed from the table.
+               learned(3) - the information in this entry was learned
+                   and is being used.
+               self(4) - the value of the corresponding instance of
+                   rbridgeFdbAddress represents one of the device's
+                   addresses.  The corresponding instance of
+                   rbridgeFdbPort indicates which of the device's
+                   ports has this address.
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 25]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+               mgmt(5) - the value of the corresponding instance of
+                   rbridgeFdbAddress was configured by management.
+               esadi(6) - the value of the corresponding instance of
+                   rbridgeFdbAddress was learned from ESADI."
+       ::= { rbridgeUniFdbEntry 6 }
+
+   -- -------------------------------------------------------------
+   -- RBridge Forwarding Information Base (FIB)
+   -- -------------------------------------------------------------
+
+   rbridgeUniFibTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeUniFibEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about nicknames known by
+           the RBridge.  If Equal-Cost Multipath (ECMP) is implemented,
+           there are as many entries for a nickname as there are ECMP
+           paths available for it."
+       ::= { rbridgeFdb 5 }
+
+   rbridgeUniFibEntry OBJECT-TYPE
+       SYNTAX      RbridgeUniFibEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information about nicknames known by the RBridge.
+           If ECMP is implemented, there are as many entries as there
+           are ECMP paths available for a given nickname."
+       INDEX   { rbridgeUniFibNickname, rbridgeUniFibPort,
+                 rbridgeUniFibNextHop }
+       ::= { rbridgeUniFibTable 1 }
+
+   RbridgeUniFibEntry ::=
+       SEQUENCE {
+           rbridgeUniFibNickname
+               RbridgeNickname,
+           rbridgeUniFibPort
+               Unsigned32,
+           rbridgeUniFibNextHop
+               RbridgeNickname,
+           rbridgeUniFibHopCount
+               Unsigned32
+       }
+
+   rbridgeUniFibNickname OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  not-accessible
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 26]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       STATUS      current
+       DESCRIPTION
+           "An RBridge nickname for which this RBridge has
+           forwarding information."
+       ::= { rbridgeUniFibEntry 1 }
+
+   rbridgeUniFibPort OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..65535)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The RBridge port number of the port attached to the
+           next-hop RBridge for the path towards the RBridge whose
+           nickname is specified in this entry."
+       ::= { rbridgeUniFibEntry 2 }
+
+   rbridgeUniFibNextHop OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The nickname of the next-hop RBridge for the path
+           towards the RBridge whose nickname is specified in this
+           entry."
+       ::= { rbridgeUniFibEntry 3 }
+
+   rbridgeUniFibHopCount OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The hop count from this ingress RBridge to the egress
+           RBridge whose nickname is specified in
+           rbridgeUniFibNickname."
+       ::= { rbridgeUniFibEntry 4 }
+
+   rbridgeMultiFibTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeMultiFibEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about egress nicknames
+           used for multi-destination frame forwarding by this
+           RBridge."
+       ::= { rbridgeFdb 6 }
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 27]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   rbridgeMultiFibEntry OBJECT-TYPE
+       SYNTAX      RbridgeMultiFibEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information about egress nicknames used for
+           multi-destination frame forwarding by this RBridge."
+       INDEX   { rbridgeMultiFibNickname }
+       ::= { rbridgeMultiFibTable 1 }
+
+   RbridgeMultiFibEntry ::=
+       SEQUENCE {
+           rbridgeMultiFibNickname
+               RbridgeNickname,
+           rbridgeMultiFibPorts
+               PortList
+       }
+
+   rbridgeMultiFibNickname OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The nickname of the multicast distribution tree."
+       ::= { rbridgeMultiFibEntry 1 }
+
+   rbridgeMultiFibPorts OBJECT-TYPE
+       SYNTAX      PortList
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The list of ports to which a frame destined to this
+           multicast distribution tree is flooded.  This may be pruned
+           further based on other forwarding information."
+       ::= { rbridgeMultiFibEntry 2 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 28]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge VLAN Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeVlanTable  OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeVlanEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about VLANs on the
+           RBridge."
+       ::= { rbridgeVlan 1 }
+
+   rbridgeVlanEntry OBJECT-TYPE
+       SYNTAX      RbridgeVlanEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information about VLANs on the RBridge."
+       INDEX   { rbridgeVlanIndex }
+       ::= { rbridgeVlanTable 1 }
+
+   RbridgeVlanEntry ::=
+       SEQUENCE {
+           rbridgeVlanIndex
+               Unsigned32,
+           rbridgeVlanForwarderLosts
+               Counter32,
+           rbridgeVlanDisableLearning
+               TruthValue,
+           rbridgeVlanSnooping
+               INTEGER
+       }
+
+   rbridgeVlanIndex OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..4094|4096..4294967295)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The VLAN-ID referring to this VLAN."
+       ::= { rbridgeVlanEntry 1 }
+
+   rbridgeVlanForwarderLosts OBJECT-TYPE
+       SYNTAX      Counter32
+       UNITS       "times"
+       MAX-ACCESS  read-only
+       STATUS      current
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 29]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       DESCRIPTION
+           "The number of times this RBridge has lost appointed
+           forwarder status for this VLAN on any of its ports.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8.3"
+       ::= { rbridgeVlanEntry 2 }
+
+   rbridgeVlanDisableLearning OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "Disable learning of MAC addresses seen in this VLAN.
+           One application of this may be to restrict learning to
+           ESADI.  To disable learning, the value of this object
+           should be set to 'true'.  The default is 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.8"
+       DEFVAL      { false }
+       ::= { rbridgeVlanEntry 3 }
+
+   rbridgeVlanSnooping OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       notSupported(1),
+                       ipv4(2),
+                       ipv6(3),
+                       ipv4v6(4)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "IP Multicast Snooping on this VLAN.  For RBridges
+           performing both IPv4 and IPv6 IP Multicast Snooping, the
+           value returned is ipv4v6(4)."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeVlanEntry 4 }
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 30]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge VLAN Port Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeVlanPortTable  OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeVlanPortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about VLANs on an RBridge
+           port."
+       ::= { rbridgeVlan 2 }
+
+   rbridgeVlanPortEntry OBJECT-TYPE
+       SYNTAX      RbridgeVlanPortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A list of information about VLANs on the RBridge port."
+       INDEX   { rbridgeBasePort, rbridgeVlanIndex }
+       ::= { rbridgeVlanPortTable 1 }
+
+   RbridgeVlanPortEntry ::=
+       SEQUENCE {
+           rbridgeVlanPortInhibited
+               TruthValue,
+           rbridgeVlanPortForwarder
+               TruthValue,
+           rbridgeVlanPortAnnouncing
+               TruthValue,
+           rbridgeVlanPortDetectedVlanMapping
+               TruthValue
+       }
+
+   rbridgeVlanPortInhibited OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This VLAN has been inhibited by the RBridge due to
+           conflicting forwarder information received from another
+           RBridge, when the value of this object is 'true'."
+       REFERENCE
+           "RFC 6325, Section 4.2.4.3"
+       ::= { rbridgeVlanPortEntry 1 }
+
+   rbridgeVlanPortForwarder OBJECT-TYPE
+       SYNTAX      TruthValue
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 31]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "This RBridge is an appointed forwarder for this VLAN
+           on this port, when the value of this object is 'true'."
+       REFERENCE
+           "RFC 6325, Section 4.2.4.3"
+       ::= { rbridgeVlanPortEntry 2 }
+
+   rbridgeVlanPortAnnouncing OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "TRILL-Hellos tagged with this VLAN can be sent by this
+           RBridge on this port, when the value of this object
+           is 'true'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.4.3"
+       DEFVAL      { true }
+       ::= { rbridgeVlanPortEntry 3 }
+
+   rbridgeVlanPortDetectedVlanMapping OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "VLAN mapping has been detected on the link attached
+           to this port, when the value of this object is 'true'."
+       REFERENCE
+           "RFC 6325, Section 4.4.5"
+       ::= { rbridgeVlanPortEntry 4 }
+
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge Port Counter Table
+   --
+   -- These counters supplement counters in the Bridge MIB.
+   --
+   -- For example, total frames received by a bridge port and total
+   -- frames transmitted by a bridge port are reported in the
+   -- Port In Frames and Port Out Frames counters of the Bridge MIB.
+   -- These total bridge frame counters include native as well as
+   -- encapsulated frames.
+   --
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 32]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- As another example, frames discarded due to excessive frame
+   -- size are reported in the port counter MTU Exceeded Discards
+   -- in the Bridge MIB.
+   -- ---------------------------------------------------------- --
+
+   rbridgePortCounterTable  OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgePortCounterEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains per-port counters for this RBridge."
+       ::= { rbridgeCounter 1 }
+
+   rbridgePortCounterEntry OBJECT-TYPE
+       SYNTAX      RbridgePortCounterEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Counters for a port on this RBridge."
+       INDEX   { rbridgeBasePort }
+       ::= { rbridgePortCounterTable 1 }
+
+   RbridgePortCounterEntry ::=
+       SEQUENCE {
+           rbridgePortRpfCheckFails
+               Counter32,
+           rbridgePortHopCountExceeds
+               Counter32,
+           rbridgePortOptionDrops
+               Counter32,
+           rbridgePortTrillInFrames
+               Counter64,
+           rbridgePortTrillOutFrames
+               Counter64
+       }
+
+   rbridgePortRpfCheckFails OBJECT-TYPE
+       SYNTAX      Counter32
+       UNITS       "frames"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of times a multi-destination frame was
+           dropped on this port because the Reverse Path Forwarding
+           (RPF) check failed.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system, and at
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 33]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           other times as indicated by the value of the
+           ifCounterDiscontinuityTime object of the associated
+           interface."
+       REFERENCE
+           "RFC 6325, Section 4.5.2"
+       ::= { rbridgePortCounterEntry 1 }
+
+   rbridgePortHopCountExceeds OBJECT-TYPE
+       SYNTAX      Counter32
+       UNITS       "frames"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of times a frame was dropped on this port
+           because its hop count was zero.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system, and at
+           other times as indicated by the value of the
+           ifCounterDiscontinuityTime object of the associated
+           interface."
+       REFERENCE
+           "RFC 6325, Section 3.6"
+       ::= { rbridgePortCounterEntry 2 }
+
+   rbridgePortOptionDrops OBJECT-TYPE
+       SYNTAX      Counter32
+       UNITS       "frames"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of times a frame was dropped on this port
+           because it contained unsupported options.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system, and at
+           other times as indicated by the value of the
+           ifCounterDiscontinuityTime object of the associated
+           interface."
+       REFERENCE
+           "RFC 6325, Section 3.5"
+       ::= { rbridgePortCounterEntry 3 }
+
+   rbridgePortTrillInFrames OBJECT-TYPE
+       SYNTAX      Counter64
+       UNITS       "frames"
+       MAX-ACCESS  read-only
+       STATUS      current
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 34]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       DESCRIPTION
+           "The number of TRILL-encapsulated frames that have been
+           received by this port from its attached link, including
+           management frames.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system, and at
+           other times as indicated by the value of the
+           ifCounterDiscontinuityTime object of the associated
+           interface."
+       REFERENCE
+           "RFC 6325, Section 2.3"
+       ::= { rbridgePortCounterEntry 4 }
+
+   rbridgePortTrillOutFrames OBJECT-TYPE
+       SYNTAX      Counter64
+       UNITS       "frames"
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The number of TRILL-encapsulated frames that have been
+           transmitted by this port to its attached link, including
+           management frames.
+
+           Discontinuities in the value of this counter can occur
+           at re-initialization of the management system, and at
+           other times as indicated by the value of the
+           ifCounterDiscontinuityTime object of the associated
+           interface."
+       REFERENCE
+           "RFC 6325, Section 2.3"
+       ::= { rbridgePortCounterEntry 5 }
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge VLAN ESADI Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeEsadiTable  OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeEsadiEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "A table that contains information about ESADI instances on
+           VLANs, if available."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       ::= { rbridgeEsadi 1 }
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 35]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   rbridgeEsadiEntry OBJECT-TYPE
+       SYNTAX      RbridgeEsadiEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about an ESADI instance on a VLAN."
+       INDEX   { rbridgeVlanIndex }
+       ::= { rbridgeEsadiTable 1 }
+
+   RbridgeEsadiEntry ::=
+       SEQUENCE {
+           rbridgeEsadiEnable
+               TruthValue,
+           rbridgeEsadiConfidence
+               Unsigned32,
+           rbridgeEsadiDrbPriority
+               Unsigned32,
+           rbridgeEsadiDrb
+               RbridgeAddress,
+           rbridgeEsadiDrbHoldingTime
+               Unsigned32,
+           rbridgeEsadiRowStatus
+               RowStatus
+       }
+
+   rbridgeEsadiEnable OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "If the RBridge is participating in an ESADI instance for
+           this VLAN, the value of this object is 'true'.  To disable
+           participation, set it to 'false'.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       DEFVAL      { true }
+       ::= { rbridgeEsadiEntry 1 }
+
+   rbridgeEsadiConfidence OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..255)
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "Confidence level of address entries sent by this
+           ESADI instance.  The default is 16.
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 36]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       DEFVAL      { 16 }
+       ::= { rbridgeEsadiEntry 2 }
+
+   rbridgeEsadiDrbPriority OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..127)
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "The priority of this RBridge for being selected as the
+           DRB for this ESADI instance.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       ::= { rbridgeEsadiEntry 3 }
+
+   rbridgeEsadiDrb OBJECT-TYPE
+       SYNTAX      RbridgeAddress
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The DRB on this ESADI instance's virtual link."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       ::= { rbridgeEsadiEntry 4 }
+
+   rbridgeEsadiDrbHoldingTime OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..127)
+       MAX-ACCESS  read-create
+       STATUS      current
+       DESCRIPTION
+           "The holding time for this ESADI instance.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.2.5"
+       ::= { rbridgeEsadiEntry 5 }
+
+   rbridgeEsadiRowStatus OBJECT-TYPE
+       SYNTAX      RowStatus
+       MAX-ACCESS  read-create
+       STATUS      current
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 37]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       DESCRIPTION
+           "This object indicates the status of the entry."
+       ::= { rbridgeEsadiEntry 6 }
+
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge IP Multicast Snooping Port Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeSnoopingPortTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeSnoopingPortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "For RBridges implementing IP Multicast Snooping,
+           information about ports on which the presence of IPv4
+           or IPv6 multicast routers has been detected."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeSnooping 1 }
+
+   rbridgeSnoopingPortEntry OBJECT-TYPE
+       SYNTAX      RbridgeSnoopingPortEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about ports on which the presence of IPv4
+           or IPv6 multicast routers has been detected for a
+           VLAN."
+       INDEX   { rbridgeBasePort, rbridgeVlanIndex }
+       ::= { rbridgeSnoopingPortTable 1 }
+
+   RbridgeSnoopingPortEntry ::=
+       SEQUENCE {
+           rbridgeSnoopingPortAddrType
+               INTEGER
+       }
+
+   rbridgeSnoopingPortAddrType OBJECT-TYPE
+       SYNTAX      INTEGER {
+                       ipv4(1),
+                       ipv6(2),
+                       ipv4v6(3)
+                   }
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The IP address type of an IP multicast router detected
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 38]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           on this port and VLAN.  If only IPv4 router(s)
+           are detected, the value returned is 'ipv4'.  If only
+           IPv6 routers are detected, the value returned is
+           'ipv6'.  If both IPv4 and IPv6 routers are detected on
+           this port and VLAN, the value returned is 'ipv4v6'."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeSnoopingPortEntry 1 }
+
+   -- ---------------------------------------------------------- --
+   -- The RBridge IP Multicast Snooping Address Table
+   -- ---------------------------------------------------------- --
+
+   rbridgeSnoopingAddrTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeSnoopingAddrEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "For RBridges implementing IP Multicast Snooping,
+           information about IP multicast addresses being
+           snooped."
+       REFERENCE
+           "RFC 6325, Section 4.8"
+       ::= { rbridgeSnooping 2 }
+
+   rbridgeSnoopingAddrEntry OBJECT-TYPE
+       SYNTAX      RbridgeSnoopingAddrEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about IP multicast addresses being
+           snooped."
+       INDEX  { rbridgeVlanIndex, rbridgeSnoopingAddrType,
+                rbridgeSnoopingAddr }
+       ::= { rbridgeSnoopingAddrTable 1 }
+
+   RbridgeSnoopingAddrEntry ::=
+       SEQUENCE {
+           rbridgeSnoopingAddrType
+               InetAddressType,
+           rbridgeSnoopingAddr
+               InetAddress,
+           rbridgeSnoopingAddrPorts
+               PortList
+       }
+
+   rbridgeSnoopingAddrType OBJECT-TYPE
+       SYNTAX      InetAddressType
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 39]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The IP multicast address type for which a listener has been
+           detected by this RBridge.  This MIB requires support for only
+           IPv4 and IPv6 address types."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeSnoopingAddrEntry 1 }
+
+   rbridgeSnoopingAddr OBJECT-TYPE
+       SYNTAX      InetAddress
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The IP multicast address for which a listener has been
+           detected by this RBridge.  The address type of this object
+           is specified in rbridgeSnoopingAddrType.  This MIB requires
+           support for only global IPv4 and IPv6 addresses, so the
+           length of the object can be either 4 or 16 bytes.  Hence,
+           the index will not exceed the OID size limit."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeSnoopingAddrEntry 2 }
+
+   rbridgeSnoopingAddrPorts OBJECT-TYPE
+       SYNTAX      PortList
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The set of ports on which a listener has been detected
+           for this IP multicast address."
+       REFERENCE
+           "RFC 6325, Section 4.7"
+       ::= { rbridgeSnoopingAddrEntry 3 }
+
+
+   -- ---------------------------------------------------------- --
+   -- Distribution Trees
+   -- ---------------------------------------------------------- --
+
+   rbridgeDtreePriority OBJECT-TYPE
+
+       SYNTAX      Unsigned32 (1..65535)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The distribution tree root priority for this RBridge.
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 40]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           The default value of this object is 32768.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtree 1 }
+
+   rbridgeDtreeActiveTrees OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The total number of trees being computed by all RBridges
+           in the campus."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtree 2 }
+
+   rbridgeDtreeMaxTrees OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The maximum number of trees this RBridge can compute."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtree 3 }
+
+   rbridgeDtreeDesiredUseTrees OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The maximum number of trees this RBridge would like to
+           use for transmission of ingress multi-destination frames."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtree 4 }
+
+   rbridgeDtreeTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeDtreeEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about distribution trees being computed
+           by this RBridge."
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 41]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtree 5 }
+
+   rbridgeDtreeEntry OBJECT-TYPE
+       SYNTAX      RbridgeDtreeEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "List of information about distribution trees being computed
+           by this RBridge."
+       INDEX  { rbridgeDtreeNumber }
+       ::= { rbridgeDtreeTable 1 }
+
+   RbridgeDtreeEntry ::=
+       SEQUENCE {
+           rbridgeDtreeNumber
+               Unsigned32,
+           rbridgeDtreeNickname
+               RbridgeNickname,
+           rbridgeDtreeIngress
+               TruthValue
+       }
+
+   rbridgeDtreeNumber OBJECT-TYPE
+       SYNTAX      Unsigned32 (0..65535)
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The tree number of a distribution tree being computed by
+           this RBridge."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtreeEntry 1 }
+
+   rbridgeDtreeNickname OBJECT-TYPE
+       SYNTAX      RbridgeNickname
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The nickname of the distribution tree."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtreeEntry 2 }
+
+   rbridgeDtreeIngress OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 42]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       STATUS      current
+       DESCRIPTION
+           "Indicates whether this RBridge might choose this
+           distribution tree to ingress a multi-destination frame."
+       REFERENCE
+           "RFC 6325, Section 4.5"
+       ::= { rbridgeDtreeEntry 3 }
+
+
+   -- ---------------------------------------------------------- --
+   -- TRILL Neighbor List
+   -- ---------------------------------------------------------- --
+
+   rbridgeTrillMinMtuDesired OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The desired minimum acceptable inter-RBridge link MTU for
+           the campus, that is, originatingLSPBufferSize.
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.3"
+       ::= { rbridgeTrill 1 }
+
+   rbridgeTrillSz OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "The minimum acceptable inter-RBridge link size for the
+           campus for the proper operation of TRILL IS-IS."
+       REFERENCE
+           "RFC 6325, Section 4.3"
+       ::= { rbridgeTrill 2 }
+
+   rbridgeTrillMaxMtuProbes OBJECT-TYPE
+       SYNTAX      Unsigned32 (1..255)
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+           "The number of failed MTU-probes before the RBridge
+           concludes that a particular MTU is not supported by
+           a neighbor.
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 43]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           The value of this object MUST be retained across
+           re-initializations of the management system."
+       REFERENCE
+           "RFC 6325, Section 4.3"
+       ::= { rbridgeTrill 3 }
+
+   rbridgeTrillNbrTable OBJECT-TYPE
+       SYNTAX      SEQUENCE OF RbridgeTrillNbrEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "Information about this RBridge's TRILL neighbors."
+       REFERENCE
+           "RFC 6325, Section 4.4.2.1"
+       ::= { rbridgeTrill 4 }
+
+   rbridgeTrillNbrEntry OBJECT-TYPE
+       SYNTAX      RbridgeTrillNbrEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "List of information about this RBridge's TRILL neighbors."
+       INDEX  { rbridgeTrillNbrMacAddr }
+       ::= { rbridgeTrillNbrTable 1 }
+
+   RbridgeTrillNbrEntry ::=
+       SEQUENCE {
+           rbridgeTrillNbrMacAddr
+               MacAddress,
+           rbridgeTrillNbrMtu
+               Unsigned32,
+           rbridgeTrillNbrFailedMtuTest
+               TruthValue
+       }
+
+   rbridgeTrillNbrMacAddr OBJECT-TYPE
+       SYNTAX      MacAddress
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+           "The MAC address of a neighbor of this RBridge."
+       REFERENCE
+           "RFC 6325, Section 4.4.2.1"
+       ::= { rbridgeTrillNbrEntry 1 }
+
+   rbridgeTrillNbrMtu OBJECT-TYPE
+       SYNTAX      Unsigned32
+       MAX-ACCESS  read-only
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 44]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+       STATUS      current
+       DESCRIPTION
+           "MTU size for this neighbor for IS-IS communication
+           purposes."
+       REFERENCE
+           "RFC 6325, Section 4.3.2"
+       ::= { rbridgeTrillNbrEntry 2 }
+
+   rbridgeTrillNbrFailedMtuTest OBJECT-TYPE
+       SYNTAX      TruthValue
+       MAX-ACCESS  read-only
+       STATUS      current
+       DESCRIPTION
+           "If true, indicates that the neighbor's tested MTU is less
+           than the minimum acceptable inter-bridge link MTU for the
+           campus (1470)."
+       REFERENCE
+           "RFC 6325, Section 4.3.1"
+       ::= { rbridgeTrillNbrEntry 3 }
+
+
+   -- ---------------------------------------------------------- --
+   -- Notifications for use by RBridges
+   -- ---------------------------------------------------------- --
+
+   rbridgeBaseNewDrb NOTIFICATION-TYPE
+       -- OBJECTS     { }
+       STATUS      current
+       DESCRIPTION
+           "The rbridgeBaseNewDrb notification indicates that the
+           sending agent has become the new Designated RBridge; the
+           notification is sent by an RBridge soon after its election
+           as the new DRB root, e.g., upon expiration of the Topology
+           Change Timer, immediately subsequent to its election."
+       ::= { rbridgeNotifications 1 }
+
+   rbridgeBaseTopologyChange NOTIFICATION-TYPE
+       -- OBJECTS     { }
+       STATUS      current
+       DESCRIPTION
+           "The rbridgeBaseTopologyChange notification is sent by an
+           RBridge when any of its configured ports transition to/from
+           the VLAN-x designated forwarder.  The notification is not
+           sent if an rbridgeBaseNewDrb notification is sent for the
+           same transition."
+       ::= { rbridgeNotifications 2 }
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 45]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- Compliance and Group sections
+
+   rbridgeCompliances    OBJECT IDENTIFIER ::= { rbridgeConformance 1 }
+
+   rbridgeGroup          OBJECT IDENTIFIER ::= { rbridgeConformance 2 }
+
+
+   -- ---------------------------------------------------------- --
+   -- Units of Conformance
+   -- ---------------------------------------------------------- --
+
+   rbridgeBaseGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeBaseTrillVersion,
+           rbridgeBaseNumPorts,
+           rbridgeBaseForwardDelay,
+           rbridgeBaseUniMultipathEnable,
+           rbridgeBaseMultiMultipathEnable,
+           rbridgeBaseAcceptEncapNonadj,
+           rbridgeBaseNicknameNumber
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing basic control
+           and status information for the RBridge."
+       ::= { rbridgeGroup 1 }
+
+   rbridgeBaseNicknameGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeBaseNicknamePriority,
+           rbridgeBaseNicknameDtrPriority,
+           rbridgeBaseNicknameType,
+           rbridgeBaseNicknameRowStatus
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing basic control
+           and status information for RBridge nicknames."
+       ::= { rbridgeGroup 2 }
+
+   rbridgeBasePortGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeBasePortIfIndex,
+           rbridgeBasePortDisable,
+           rbridgeBasePortTrunkPort,
+           rbridgeBasePortAccessPort,
+           rbridgeBasePortP2pHellos,
+           rbridgeBasePortState,
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 46]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           rbridgeBasePortDesiredDesigVlan,
+           rbridgeBasePortDesigVlan,
+           rbridgeBasePortInhibitionTime,
+           rbridgeBasePortDisableLearning,
+           rbridgeBasePortStpRoot,
+           rbridgeBasePortStpRootChanges,
+           rbridgeBasePortStpWiringCloset
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing basic control
+           and status information for RBridge ports."
+       ::= { rbridgeGroup 3 }
+
+   rbridgeFdbGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeConfidenceNative,
+           rbridgeConfidenceDecap,
+           rbridgeConfidenceStatic,
+           rbridgeUniFdbPort,
+           rbridgeUniFdbNickname,
+           rbridgeUniFdbConfidence,
+           rbridgeUniFdbStatus
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about the Unicast Address Database."
+       ::= { rbridgeGroup 4 }
+
+   rbridgeFibGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeUniFibHopCount,
+           rbridgeMultiFibPorts
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about the Unicast and Multicast FIBs."
+       ::= { rbridgeGroup 5 }
+
+   rbridgeVlanGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeVlanForwarderLosts,
+           rbridgeVlanDisableLearning,
+           rbridgeVlanSnooping,
+           rbridgeVlanPortInhibited,
+           rbridgeVlanPortForwarder,
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 47]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           rbridgeVlanPortAnnouncing,
+           rbridgeVlanPortDetectedVlanMapping
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about VLANs on the RBridge."
+       ::= { rbridgeGroup 6 }
+
+   rbridgePortCounterGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgePortRpfCheckFails,
+           rbridgePortHopCountExceeds,
+           rbridgePortOptionDrops,
+           rbridgePortTrillInFrames,
+           rbridgePortTrillOutFrames
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing per-port
+           counters for the RBridge."
+       ::= { rbridgeGroup 7 }
+
+   rbridgeEsadiGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeEsadiEnable,
+           rbridgeEsadiConfidence,
+           rbridgeEsadiDrbPriority,
+           rbridgeEsadiDrb,
+           rbridgeEsadiDrbHoldingTime,
+           rbridgeEsadiRowStatus
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about ESADI instances on the RBridge."
+       ::= { rbridgeGroup 8 }
+
+   rbridgeSnoopingGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeSnoopingPortAddrType,
+           rbridgeSnoopingAddrPorts
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information about
+           IP Multicast Snooping.  This MIB requires support for
+           only global IPv4 and IPv6 address types in
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 48]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+           rbridgeSnoopingPortAddrType and rbridgeSnoopingAddrType,
+           so the length of rbridgeSnoopingAddr can be either 4 or
+           16 bytes."
+       ::= { rbridgeGroup 9 }
+
+   rbridgeDtreeGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeDtreePriority,
+           rbridgeDtreeActiveTrees,
+           rbridgeDtreeMaxTrees,
+           rbridgeDtreeDesiredUseTrees,
+           rbridgeDtreeNickname,
+           rbridgeDtreeIngress
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about distribution trees."
+       ::= { rbridgeGroup 10 }
+
+   rbridgeTrillGroup OBJECT-GROUP
+       OBJECTS {
+           rbridgeTrillMinMtuDesired,
+           rbridgeTrillSz,
+           rbridgeTrillMaxMtuProbes,
+           rbridgeTrillNbrMtu,
+           rbridgeTrillNbrFailedMtuTest
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects providing information
+           about TRILL neighbors."
+       ::= { rbridgeGroup 11 }
+
+   rbridgeNotificationGroup NOTIFICATION-GROUP
+       NOTIFICATIONS {
+           rbridgeBaseNewDrb,
+           rbridgeBaseTopologyChange
+       }
+       STATUS      current
+       DESCRIPTION
+           "A collection of objects describing notifications (traps)."
+       ::= { rbridgeGroup 12 }
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 49]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   -- ---------------------------------------------------------- --
+   -- Compliance Statement
+   -- ---------------------------------------------------------- --
+
+   rbridgeCompliance MODULE-COMPLIANCE
+          STATUS      current
+          DESCRIPTION
+              "The compliance statement for support of RBridge
+              services."
+
+          MODULE
+              MANDATORY-GROUPS {
+                  rbridgeBaseGroup,
+                  rbridgeBaseNicknameGroup,
+                  rbridgeBasePortGroup,
+                  rbridgeFdbGroup,
+                  rbridgeFibGroup,
+                  rbridgeVlanGroup,
+                  rbridgeDtreeGroup,
+                  rbridgeTrillGroup,
+                  rbridgeNotificationGroup
+              }
+
+          GROUP   rbridgePortCounterGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          GROUP   rbridgeEsadiGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          GROUP   rbridgeSnoopingGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          ::= { rbridgeCompliances 1 }
+
+   rbridgeReadOnlyCompliance MODULE-COMPLIANCE
+          STATUS      current
+          DESCRIPTION
+              "When this MIB is implemented in read-only mode, then
+              the implementation can claim read-only compliance.
+              In that case, RBridge objects can be monitored but
+              cannot be configured with this implementation."
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 50]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+          MODULE
+              MANDATORY-GROUPS {
+                  rbridgeBaseGroup,
+                  rbridgeBaseNicknameGroup,
+                  rbridgeBasePortGroup,
+                  rbridgeFdbGroup,
+                  rbridgeFibGroup,
+                  rbridgeVlanGroup,
+                  rbridgeDtreeGroup,
+                  rbridgeTrillGroup,
+                  rbridgeNotificationGroup
+              }
+
+          OBJECT  rbridgeBaseForwardDelay
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseUniMultipathEnable
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseMultiMultipathEnable
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseAcceptEncapNonadj
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseNicknameNumber
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseNicknamePriority
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBaseNicknameDtrPriority
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 51]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+          OBJECT  rbridgeBaseNicknameRowStatus
+          SYNTAX  INTEGER { active(1) }
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required, and 'active' is the only
+              status that needs to be supported."
+
+          OBJECT  rbridgeBasePortDisable
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortTrunkPort
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortAccessPort
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortP2pHellos
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortInhibitionTime
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortDisableLearning
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortDesiredDesigVlan
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeBasePortStpWiringCloset
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 52]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+          OBJECT  rbridgeConfidenceNative
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeConfidenceDecap
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeConfidenceStatic
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeVlanDisableLearning
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeVlanPortAnnouncing
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeEsadiEnable
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeEsadiConfidence
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeEsadiDrbPriority
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeEsadiDrbHoldingTime
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeEsadiRowStatus
+          SYNTAX  INTEGER { active(1) }
+          MIN-ACCESS  read-only
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 53]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+          DESCRIPTION
+              "Write access is not required, and 'active' is the only
+              status that needs to be supported."
+
+          OBJECT  rbridgeDtreePriority
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeTrillMinMtuDesired
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          OBJECT  rbridgeTrillMaxMtuProbes
+          MIN-ACCESS  read-only
+          DESCRIPTION
+              "Write access is not required."
+
+          GROUP   rbridgePortCounterGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          GROUP   rbridgeEsadiGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          GROUP   rbridgeSnoopingGroup
+          DESCRIPTION
+              "Implementation of this group is optional."
+
+          ::= { rbridgeCompliances 2 }
+
+      END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 54]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+8.  Security Considerations
+
+   This MIB relates to a system that will provide network connectivity
+   and packet-forwarding services.  As such, improper manipulation of
+   the objects represented by this MIB may result in denial of service
+   to a large number of end-users.
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   The following tables and objects in the RBRIDGE-MIB can be
+   manipulated to interfere with the operation of RBridges:
+
+   o  rbridgeBaseUniMultipathEnable affects the ability of the RBridge
+      to route unicast traffic over multiple paths, and
+      rbridgeBaseMultiMultipathEnable affects the ability of the RBridge
+      to route multi-destination traffic over multiple paths.
+
+   o  rbridgeBasePortTable contains a number of objects that may affect
+      network connectivity.  Actions that may be triggered by
+      manipulating objects in this table include disabling of an RBridge
+      port, discarding of native packets, disabling learning, and
+      others.
+
+   o  rbridgeEsadiTable contains objects that affect the operation of
+      the ESADI protocol used for learning, and manipulation of the
+      objects contained therein can be used to confuse the learning
+      ability of RBridges.
+
+   o  rbridgeDtreePriority can affect computation of distribution trees
+      within an RBridge campus, thereby affecting the forwarding of
+      multi-destination traffic.
+
+   o  rbridgeTrillMinMtuDesired can affect the size of packets being
+      used to exchange information between RBridges.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 55]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   the network via SNMP.  For example, access to network topology and
+   RBridge attributes can reveal information that should not be
+   available to all users of the network.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+   For other RBridge security considerations, see [RFC6325].
+
+9.  IANA Considerations
+
+   The MIB module in this document uses the following IANA-assigned
+   OBJECT IDENTIFIER value recorded in the SMI Numbers registry:
+
+      Descriptor   OBJECT IDENTIFIER value
+      ----------   -----------------------
+
+      rbridgeMIB   { mib-2 214 }
+
+10.  Contributors
+
+   The authors would like to acknowledge the contributions of Donald
+   Eastlake, Radia Perlman, Anoop Ghanwani, Dan Romascanu, Mahesh Akula,
+   Sue Hares, and Joan Cucchiara.
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 56]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]   Bradner, S., "Key words for use in RFCs to Indicate
+               Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Structure of Management Information
+               Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Textual Conventions for SMIv2",
+               STD 58, RFC 2579, April 1999.
+
+   [RFC2580]   McCloghrie, K., Ed., Perkins, D., Ed., and J.
+               Schoenwaelder, Ed., "Conformance Statements for SMIv2",
+               STD 58, RFC 2580, April 1999.
+
+   [RFC2863]   McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+               MIB", RFC 2863, June 2000.
+
+   [RFC3414]   Blumenthal, U. and B. Wijnen, "User-based Security Model
+               (USM) for version 3 of the Simple Network Management
+               Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3826]   Blumenthal, U., Maino, F., and K. McCloghrie, "The
+               Advanced Encryption Standard (AES) Cipher Algorithm in
+               the SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC4001]   Daniele, M., Haberman, B., Routhier, S., and J.
+               Schoenwaelder, "Textual Conventions for Internet Network
+               Addresses", RFC 4001, February 2005.
+
+   [RFC4188]   Norseth, K., Ed., and E. Bell, Ed., "Definitions of
+               Managed Objects for Bridges", RFC 4188, September 2005.
+
+   [RFC4363]   Levi, D. and D. Harrington, "Definitions of Managed
+               Objects for Bridges with Traffic Classes, Multicast
+               Filtering, and Virtual LAN Extensions", RFC 4363,
+               January 2006.
+
+   [RFC4444]   Parker, J., Ed., "Management Information Base for
+               Intermediate System to Intermediate System (IS-IS)",
+               RFC 4444, April 2006.
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 57]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+   [RFC5591]   Harrington, D. and W. Hardaker, "Transport Security Model
+               for the Simple Network Management Protocol (SNMP)",
+               RFC 5591, June 2009.
+
+   [RFC5592]   Harrington, D., Salowey, J., and W. Hardaker, "Secure
+               Shell Transport Model for the Simple Network Management
+               Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6325]   Perlman, R., Eastlake 3rd, D., Dutt, D., Gai, S., and A.
+               Ghanwani, "Routing Bridges (RBridges): Base Protocol
+               Specification", RFC 6325, July 2011.
+
+   [RFC6353]   Hardaker, W., "Transport Layer Security (TLS) Transport
+               Model for the Simple Network Management Protocol (SNMP)",
+               RFC 6353, July 2011.
+
+11.2.  Informative References
+
+   [RFC3410]   Case, J., Mundy, R., Partain, D., and B. Stewart,
+               "Introduction and Applicability Statements for Internet-
+               Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC4663]   Harrington, D., "Transferring MIB Work from IETF Bridge
+               MIB WG to IEEE 802.1 WG", RFC 4663, September 2006.
+
+   [RFC5556]   Touch, J. and R. Perlman, "Transparent Interconnection of
+               Lots of Links (TRILL): Problem and Applicability
+               Statement", RFC 5556, May 2009.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 58]
+
+RFC 6850                RBridges: TRILL Base MIB            January 2013
+
+
+Authors' Addresses
+
+   Anil Rijhsinghani
+   Hewlett-Packard
+   153 Taylor St.
+   Littleton, MA
+   USA
+
+   Phone: +1 508 323 1251
+   EMail: anil@charter.net
+
+
+   Kate Zebrose
+   HW Embedded
+   26 Josephine Ave.
+   Somerville, MA
+   USA
+
+   Phone: +1 617 840 9673
+   EMail: zebrose@alum.mit.edu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Rijhsinghani & Zebrose       Standards Track                   [Page 59]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6850.txt](<www.ietf.org/rfc/rfc6850.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
