### PR TITLE
Archive rfc6859.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6859.txt
+++ b/www.ietf.org/rfc/rfc6859.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          B. Leiba
+Request for Comments: 6859                           Huawei Technologies
+BCP: 10                                                     January 2013
+Updates: 3777
+Category: Best Current Practice
+ISSN: 2070-1721
+
+
+           Update to RFC 3777 to Clarify Nominating Committee
+                     Eligibility of IETF Leadership
+
+Abstract
+
+   RFC 3777 specifies that "sitting members" of the IAB and IESG "may
+   not volunteer to serve on the nominating committee".  Since the time
+   that document was written, the IETF Administrative Oversight
+   Committee (IAOC) was formed; that body is not covered by RFC 3777.
+   There is also ambiguity in RFC 3777 about whether ex officio members
+   and liaisons are included as "sitting members".  This document
+   updates RFC 3777 to clarify the rules as they apply to members of the
+   IAB, the IESG, and the IAOC.
+
+Status of This Memo
+
+   This memo documents an Internet Best Current Practice.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   BCPs is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6859.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Leiba                     Best Current Practice                 [Page 1]
+
+RFC 6859                NomCom Eligibility Update           January 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+1.  Introduction
+
+   The "IAB and IESG Selection, Confirmation, and Recall Process:
+   Operation of the Nominating and Recall Committees" document [RFC3777]
+   defines the nominating committee process.  On the nominating
+   committee, it is important to include people who have the experience
+   necessary to understand the IETF process: those individuals can bring
+   a broader perspective to the nominating committee and will help
+   ensure that the people it selects are better prepared to fulfill the
+   roles.  That said, one of the key points in the process and in the
+   selection of the nominating committee is that the IETF wants to avoid
+   having the IAB and the IESG be self-selecting.  The selection of the
+   nominating committee, therefore, excludes individuals who currently
+   serve on the bodies to which the nominating committee selects seats.
+
+   RFC 3777 specifies that "sitting members" of the IAB and IESG "may
+   not volunteer to serve on the nominating committee".  Since the time
+   that document was written, the IETF Administrative Oversight
+   Committee (IAOC) was formed.  Some IAOC members are selected by the
+   nominating committee (see [RFC4071], Section 4), and that body is not
+   covered by RFC 3777.  There is also ambiguity in RFC 3777 about
+   whether ex officio members, liaisons, and such are included as
+   "sitting members".  This document updates RFC 3777 to clarify the
+   rules as they apply to members of the IAB, the IESG, and the IAOC,
+   with the understanding of the intent of RFC 3777 as outlined above.
+
+   RFC 3777 does not exclude participation by working group chairs, IRTF
+   research group chairs, members of directorates and special review
+   teams, or members of other advisory bodies.  This document makes no
+   changes in that regard.
+
+
+
+
+
+
+Leiba                     Best Current Practice                 [Page 2]
+
+RFC 6859                NomCom Eligibility Update           January 2013
+
+
+2.  Replacement of RFC 3777, Section 4, Rule 15
+
+   The following paragraph replaces RFC 3777, Section 4, rule 15 in its
+   entirety.
+
+   15.  Any person who serves on any of the Internet Society Board of
+   Trustees, the IAB, the IESG, or the IAOC, including those who serve
+   on these bodies in ex officio positions, may not volunteer to serve
+   as voting members of the nominating committee.  Liaisons to these
+   bodies from other bodies or organizations are not excluded by this
+   rule.
+
+3.  Security Considerations
+
+   This is a procedural document, and it is entirely unrelated to
+   security.
+
+4.  References
+
+4.1.  Normative References
+
+   [RFC3777]  Galvin, J., "IAB and IESG Selection, Confirmation, and
+              Recall Process: Operation of the Nominating and Recall
+              Committees", BCP 10, RFC 3777, June 2004.
+
+4.2.  Informative References
+
+   [RFC4071]  Austein, R. and B. Wijnen, "Structure of the IETF
+              Administrative Support Activity (IASA)", BCP 101,
+              RFC 4071, April 2005.
+
+Author's Address
+
+   Barry Leiba
+   Huawei Technologies
+
+   Phone: +1 646 827 0648
+   EMail: barryleiba@computer.org
+   URI:   http://internetmessagingtechnology.org/
+
+
+
+
+
+
+
+
+
+
+
+
+Leiba                     Best Current Practice                 [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6859.txt](<www.ietf.org/rfc/rfc6859.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
