### PR TITLE
Archive rfc6878.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6878.txt
+++ b/www.ietf.org/rfc/rfc6878.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        A.B. Roach
+Request for Comments: 6878                                       Mozilla
+Updates: 3261                                                 March 2013
+Category: Standards Track
+ISSN: 2070-1721
+
+
+        IANA Registry for the Session Initiation Protocol (SIP)
+                        "Priority" Header Field
+
+Abstract
+
+   This document defines a new IANA registry to keep track of the values
+   defined for the Session Initiation Protocol (SIP) "Priority" header
+   field.  It updates RFC 3261.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6878.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+Roach                        Standards Track                    [Page 1]
+
+RFC 6878           SIP Priority Header Field Registry         March 2013
+
+
+1.  Introduction
+
+   This document defines a new IANA registry to keep track of the values
+   defined for the Session Initiation Protocol (SIP) "Priority" header
+   field.  This header field was defined in [RFC3261], Section 20.26.
+   It was clearly specified in a way that allows for the creation of new
+   values beyond those originally specified; however, no registry has
+   been established for it.
+
+2.  IANA Considerations
+
+   This document adds a new sub-registry, "Priority Header Field
+   Values", to the "Session Initiation Protocol (SIP) Parameters"
+   registry page.  Its format and initial values are as shown in the
+   following table:
+
+                        +------------+-----------+
+                        | Priority   | Reference |
+                        +------------+-----------+
+                        | non-urgent | RFC 3261  |
+                        | normal     | RFC 3261  |
+                        | urgent     | RFC 3261  |
+                        | emergency  | RFC 3261  |
+                        +------------+-----------+
+
+   The policy for registration of values in this registry is "IETF
+   Review" as that term is defined by [RFC5226].  This policy was chosen
+   over lighter-weight policies due the potential architectural impact
+   of the semantics associated with new values.  Efforts contemplating
+   adding a Priority value should consider whether the SIP Resource-
+   Priority [RFC4412] or even a different protocol would be more
+   appropriate for achieving their requirements.
+
+3.  Security Considerations
+
+   This document does not have any impact on the security of the SIP
+   protocol.  Its purpose is purely administrative in nature.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Roach                        Standards Track                    [Page 2]
+
+RFC 6878           SIP Priority Header Field Registry         March 2013
+
+
+4.  References
+
+4.1.  Normative References
+
+   [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
+              A., Peterson, J., Sparks, R., Handley, M., and E.
+              Schooler, "SIP: Session Initiation Protocol", RFC 3261,
+              June 2002.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+4.2.  Informative References
+
+   [RFC4412]  Schulzrinne, H. and J. Polk, "Communications Resource
+              Priority for the Session Initiation Protocol (SIP)",
+              RFC 4412, February 2006.
+
+Author's Address
+
+   Adam Roach
+   Mozilla
+   Dallas, TX
+   US
+
+   EMail: adam@nostrum.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Roach                        Standards Track                    [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6878.txt](<www.ietf.org/rfc/rfc6878.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
