### PR TITLE
Archive rfc688.txt

### DIFF
--- a/www.ietf.org/rfc/rfc688.txt
+++ b/www.ietf.org/rfc/rfc688.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                    David C. Walden
+RFC # 688                                                BBN
+NIC # 32655                                              June 4, 1975
+
+
+                     Tentative Schedule for the New
+                   TELNET Implementation for the TIP
+
+    Implementation of the New TELNET Protocol has now become the top
+priority item on the TIP development queue.  Because what is done in the
+TIP potentially affects what is done at a number of hosts, below we give
+the implementation schedule to which we hope to adhere.
+
+    - July 18, 1975 -- Done with the basic design.  A version of the TIP
+      which has a general version of the option negotiator, but refuses
+      all options, operational.
+
+    - Mid-September, 1975 -- Design of the options done.  A version of
+      the TIP which includes any modifications that are necessary to
+      support the options operational.
+
+    - Mid-November -- Operational version of the TIP with the basic set
+      of options implemented (Binary Transmission, Echo, Suppress Go-
+      Ahead, Timing Mark, RCTE).
+
+    - End of 1975 -- Any problems with hosts worked out, any necessary
+      revisions done, and a solid version of the TIP up and running the
+      TELNET Protocol with options.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            10/99 ]
+
+
+
+
+
+
+
+
+
+
+Walden                                                          [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc688.txt](<www.ietf.org/rfc/rfc688.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
