### PR TITLE
Archive rfc69.txt

### DIFF
--- a/www.ietf.org/rfc/rfc69.txt
+++ b/www.ietf.org/rfc/rfc69.txt
@@ -1,0 +1,59 @@
+
+
+
+
+
+
+Network Working Group                                         A. Bhushan
+Request for Comments: 69                                          M.I.T.
+Updates: 52                                                 22 Sept. '70
+
+
+                  Distribution List Change for M.I.T.
+
+
+   Please delete my name from your distribution list and add that of Mr.
+Albert Vezza.  His address is:
+
+                  Mr. Albert Vezza               M.I.T.
+                  Rm 831 - Project MAC           (617) 864-6900
+                  545 Technology Square          X5877
+                  Cambridge. Mass. 02139
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+          [ into the online RFC archives by Ted Fischer 1/97 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                                                [Page 1]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc69.txt](<www.ietf.org/rfc/rfc69.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
