### PR TITLE
Archive rfc694.txt

### DIFF
--- a/www.ietf.org/rfc/rfc694.txt
+++ b/www.ietf.org/rfc/rfc694.txt
@@ -1,0 +1,2019 @@
+
+
+
+
+
+
+Network Working Group                                          J. Postel
+NWG / Request for Comments: 694                                  SRI-ARC
+                                                           June 18, 1975
+
+
+                          Protocol Information
+
+Introduction
+
+   This file contains information on the various protocols in the ARPA
+   Network.  An effort will be made to keep the information current, but
+   his depends on the cooperation of the users of this file to convey
+   any information about protocol developments, or corrections to this
+   information to Jon Postel at SRI-ARC.
+
+      Online address is POSTEL@BBNB; Phone is (415) 326-6200 x 3718;
+      U.S. Mail address is Stanford Research Institute, Augmentation
+      Research Center, 222 Ravenswood, Menlo park, California 94025.
+
+   This is a compendium of all the protocol related activity and most of
+   this activity and most of this activity is with experimental
+   protocols, for those protocols, which are official standards the
+   designation "[Official]" will be appended to the name.
+
+   This protocol information file is online as:
+
+      Pathname: [OFFICE-1] <NETINFO.PROTOCOL-INFORMATION.TXT
+
+      and also [BBNB] <POSTEL.PROTCOL-INFORMATION.NLS
+
+   Much of the documentation of protocols appears as Requests for
+   Comments (RFCs) and many of these are available online.  When a
+   document is accessible online a pointer to that source will be given.
+   Also note that recent RFCs are online at Office-1 in directory
+   <NETINFO> with names of the form RFCnnn.TXT where nnn is replaced by
+   the RFC number.  There is also an index of recent RFCs as an online
+   file:
+
+      [Office-1] <NETINFOR>RFC-INDEX.TXT
+
+   There are three other online files that are relevant to protocols:
+
+      There is a file that lists Official Host Names and associated
+      information as described in RFC 608, the pathname of this file is:
+
+         [Office-1] <NETOINFO>HOSTS.TXT
+
+
+
+
+
+Postel                                                          [Page 1]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      There are two files that list the addresses of the Network
+      Liaisons, one file lists the online message address, and the other
+      the US Mail address and phone number.  A network liaison is a
+      person designated by a host organization as the contact and
+      coordinator for network technical information fro that
+      organization.
+
+         [Office-1] <NETINFO>LIAISON-SNDMSG.TXT
+
+         [Office-1] <NETINFO>LIAISON.TXT
+
+      These files are prepared by Jake Feinler of the Network
+      Information Center (NIC).  Indeed the NIC has been very helpful in
+      providing the online file space for the recent Request for
+      Comments, and other protocol related files.  The NIC also
+      maintains the hardcopy reference library of all RFCs.
+
+   The NIC has assembled and filed with the National Technical
+   information Service the collection of documents known as "ARPA
+   Network Current Network Protocols".  This collection represents the
+   more or less "official" protocols as of 1-December-74.  The accession
+   number is ADA003890.
+
+   IMP-IMP
+
+      surface
+
+         Contact:
+
+            Alex McKenzie (MCKENZIE@BBN)
+
+         Documents:
+
+            Heart, F. et. al. "the Interface Message Processor for the
+            ARPA Computer Network," AFIPS Conference Proceedings,
+            36:551-567, SJCC 1970.
+
+            McQuillan, J.M. et. al. "Improvements in the Design and
+            Performance of the ARPA Network," AFIPs Conference
+            Proceedings, 41:741-754 RFCC, 1972.
+
+            McQuillan, J.M. "Throughput in the ARPA network - Analysis
+            and Measurement," BBN Report 2491, the text is also
+            contained in BBN Quarterly Technical Report 16, available
+            from the National Technical Information Service [NTIS]
+            accession number AD7544441.
+
+
+
+
+
+Postel                                                          [Page 2]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         People:
+
+            John McQuillan (MCQUILLAN@BBN)
+
+            Schedule:
+
+            Comments:
+
+            Recent developments:
+
+         Satellite
+
+            Contact:
+
+               Randy Rettberg (RETTBERG@BBN)
+
+            Documents:
+
+            People:
+
+               Robert Kahn (KAHN@ISI)
+
+            Schedule:
+
+            Comments:
+
+            Recent developments:
+
+   IMP-HOST
+
+      IMP-HOST [Official]
+
+         Contact:
+
+            Alex McKenzie (MCKENZIE@BBN)
+
+         Documents:
+
+               "Specification for the Interconnection of a HOST and an
+               IMP," BBN Report 1822, Revised December 1974.  NTIS:
+               ADA002751.
+
+            People:
+
+               Alex McKenzie (MCKENZIE@BBN)
+
+               Dave Walden (WALDEN@BBN)
+
+
+
+
+Postel                                                          [Page 3]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+               Jon Postel (POSTEL@BBNB)
+
+               Jerry Burchfiel (BURCHFIEL@BBN)
+
+               John McQuillan (MCQUILLAN@BBN)
+
+            Schedule:
+
+            Comments:
+
+               The "link number" field has been extended from 8 to 12
+               bits and renamed the "message identification" field.
+               Message type 6 now is used to indicate a reason for at
+               type 7 (destination dead) message. (See BBN1822).
+
+               There has been some recent changes to the Ready line
+               interpretation by the IMP for deciding the alive/dead
+               status of a host.
+
+               Important changes to the IMP and IMP/HOST Interface
+               announced in RFC 660 23-Oct-74.
+
+               (31-DEC-74) The change to allow up to eight messages to
+               be in transit between a source host and destination host
+               should be made very soon.  This should not effect the
+               hosts at all except to provide better thruput and fewer
+               inter-message delays.
+
+               (6-JAN-75) BBN Report 1822 updated.
+
+                  Sections 1, 2, 4, and 5, and Appendix C now include
+                  data on the Pluribus IMP.  The Pluribus IMP is based
+                  on a modular mutliprocessor hardware design; it should
+                  be capable of much higher bandwidth and greater
+                  reliability than other IMP models.
+
+                  Section 3.1 contains additional information, which may
+                  be helpful to Host programmers.
+
+                  Section 3.3 and 3.4 add a new type of Host to Host
+                  data message, the uncontrolled packet.  Section 3.7
+                  has been added to describe the use of this new message
+                  type.
+
+                  Section 3.4 describes changes to the sub-types of IMP
+                  to host message types 6 and 7.
+
+                  Appendix A has been updated.
+
+
+
+Postel                                                          [Page 4]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+                  Appendix B has been expanded to provide specific
+                  recommendations for Host implementation of the
+                  Host/IMP Interface.
+
+                  Minor clarifications have been made in Appendix F. (No
+                  changes have been made to Figure F - (or F-9.)
+
+            Recent developments:
+
+               (18-June-75) Very important changes to the Host to IMP
+               and IMP to Host interface protocol are proposed
+               (specified?) in a recent note.  The areas changed
+               include: expanded leader size, expanded address field,
+               new message length field, expanded handling type field,
+               source host control of packets per message, change in the
+               handling of unordered messages (current type 3 messages),
+               change in the addressing of fake hosts, including an
+               address field in the IMP/Host hop message, (best of all)
+               backward compatibility, and a possible change in the
+               maximum message length.
+
+                 Walden, D. "IMP/Host and Host/IMP Protocol Change,"
+                 RFC 687, NIC 32654, 2-Jun-75.
+
+                         [OPfficed-1] <NETINFOR>RFC687.TXT
+
+               (18-Jun-75) Comments on the changes proposed by Walden in
+               RFC 687:
+
+                 Postel, J. "Comments on the proposed Host/IMP Protocol
+                 Changes," RFC 690, NIC 32699, 6-Jun-75.
+
+   HOST-HOST
+
+      ncp - standard host-to-host [Official]
+
+         Contact:
+
+            Jon Postel (POSTEL@BBN)
+
+         Documents:
+
+            McKenzie, A. "Host/Host Protocol for the ARPA Network," NIC
+            8246, NTIS: AD757680, Jan 1972.
+
+            Postel, J. "Assigned Link Numbers," RFC 604, NIC 21186, 26-
+            Dec-73.
+
+
+
+
+Postel                                                          [Page 5]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         People:
+
+            Jon Postel (POSTEL@BBNB)
+
+            Alex McKenzie (MCKENZIE@BBN)
+
+         Schedule:
+
+         Comments:
+
+         Recent developments:
+
+   ncp - host-to-host [Experimental]
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         McKenzie, A. "host/Host Protocol for the ARPA Network," NIC
+         8246, NTIS: AD757680, Jan 1972.
+
+         Postel, J. "Assigned link Numbers," RFC 604, NIC 21186,
+         26-Dec-73.
+
+         Burchfiel, et. al. "Tip-Tenex Reliability Improvements" RFC 636
+         NIC 30490 June 1974.
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+         Alex McKenzie (MCKENZIE@BBN)
+
+         Jerry Burchfiel (BURCHFIEL@BBN)
+
+         Dave Walden (WALDEN@BBN)
+
+      Schedule:
+
+      Comments:
+
+         The BBN TIP and TENEX groups have specified and are
+         implementing additional protocol commands with the intention of
+         providing better reliability and survivability over system
+
+
+
+
+
+Postel                                                          [Page 6]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         malfunctions.  The additional protocol commands are for
+         cleaning up partly closed connections and resynchronizing the
+         allocation values on open connections (see RFC 636).
+
+         (31-DEC-74) Tenex 1.32 and the Tips are now running this
+         protocol.
+
+      Recent developments:
+
+   ncp - host-to-host [Experimental]
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         McKenzie, A. "Host/Host Protocol for the ARPA Network," NIC
+         8246, [NTIS # AD-757 680], Jan 1972
+
+         Postel, J. "Assigned Link Numbers," RFC604, NIC211685, 26-Dec-
+         73.
+
+         Kanodia, R. "A Lost Message Detection and Recovery Protocol,"
+         RFC 663, NIC 31387, 29-Nov-74.
+
+                 [OFFICE-1] <NETINFO>RFC663.TXT
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+         Alex McKenzie (MCKENZIE@BBN)
+
+         Raj Kanodia (Kanodia.CompNet@MIT-Multics)
+
+      Schedule:
+
+      Comments:
+
+         (31-DEC-74) This recent proposal is interesting in several
+         features, but some have suggested that is aimed at a non-
+         problem.
+
+      Recent developments:
+
+   msp - Message Switching Protocol
+
+
+
+
+Postel                                                          [Page 7]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Contact:
+
+         Dave Walden (WALDEN@BBN)
+
+      Documents:
+
+         Walden, D. "A System for Interprocess Communication in a
+         Resource Sharing Computer Network, " RFC 62, NIC 4962, 3-Aug-
+         70. Also published in Communications of the ACM volume 15,
+         number 4, April 1972.
+
+         Bressler, B. "A Proposed Experiment with a Message Switching
+         Protocol, " RFC 333, NIC 9926, 15-May-72.
+
+      People:
+
+         Dave Walden (WALDEN@BBN)
+
+         Bob Bressler  (BRESSLER@BBN)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   tcp - Transmission Control Protocol
+
+      Contact:
+
+         Vint Cert (CERF@ISI)
+
+      Documents:
+
+         Cert, V. and R,. Kahn. "A Protocol for Packet Network
+         Intercommunication," IEEE Transactions on Communication Vol
+         COM- 22 No 5, May 1974.
+
+         Mader, E. "A Protocol Experiment," RFC 700, NIC 31020.
+
+                 [OFFICE-1] <NETINFO> RFC700.TXT
+
+         Cerf, V. Y. Dalal, and C. Sunshine. "Specification of Internet
+         Transmission Control Program," RFC 675, INWG 72, NIC 31505,
+         December 1974 Revision.
+
+      People:
+
+
+
+
+Postel                                                          [Page 8]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Vint Cerf (CERF@ISI)
+
+         Ray Tomilnson (TOMLINSON@BBN)
+
+         Peter Kirstein (KIRSTEIN@ISI)
+
+         Jon Postel (POSTEL@BBN)
+
+      Schedule:
+
+         Some experiments now running.  Implementation of full protocol
+         to begin by 1-Jan-75.
+
+      Comments:
+
+         Specification completed August 4th, but some work still in
+         progress on handling of single message conversations.  A new
+         sequencing scheme (proposed by Tomlinson) may be utilized.  The
+         addressing field is now used as 4 bit format, 4 bit network, 16
+         bit TCP, and 24 bit process&port.
+
+         Crocker has suggested a 64 bit path address to be parsed and
+         reformatted by the gateways along the route.  There is
+         reluctance to experiment with too many things at once though.
+
+         (28-Oct-74) A file indicating some of the changes in the
+         specifications since the 4-Aug-74 document is now available as
+         [ISI] <CRF> TCP- CHANGES.  The areas of change are "Initial
+         Sequence Number", "Socket definition", "Additional User System
+         Calls", "Packet Format", and "Discussion of opening and closing
+         (SYN, REL)".
+
+         (23-NOV-74) Specifications for test implementation are now said
+         to be ready on 1-DEC-74, and an implementation completed by 1-
+         FEB-74.
+
+         (31-DEC-74) New specification document available:
+
+            Cerf, V. Y. Dalal, and C. Sunshine. "Specification of
+            Internet Transmission Control Program," RFC 675, INWG 72,
+            NIC 31505, December 1974 Revision.
+
+
+
+
+
+
+
+
+
+
+Postel                                                          [Page 9]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Recent developments:
+
+         (30-May-75)
+
+            Status of TCP development.  The BBN version is running at
+            BBN-TENEXA, but simulates a lot of JSYS calls which will be
+            cast into the tenex operating system during the summer.  The
+            SU-DSL version for the PDP-11/20 is in the debugging stage.
+            The UCL (London) version for a PDP-9 is in the coding stage.
+            We are continuing with the "three-way handshake" version
+            which is highly reliable in environments which permit
+            packets to be delivered on the order of hours later than
+            they were injected into the connected networks.  A simple
+            TCP is being designed for the packet radio network and does
+            not use three-way handshake since waiting a second or so to
+            clear out old packets in not serious.
+
+            A test plan for packet radio net, arpanet, and atlantic
+            satellite networks is in preparation (delivery date 1 August
+            1975).
+
+            Recent international agreements indicate that a form of TCP
+            with a simpler header (144 bits instead of 256 bits) and no
+            three-way handshake is the most likely international
+            standard.  An IFIP WG 6.1 Recommendation to CCITT stated
+            that the maximum packet delay through all concatenated
+            networks should not exceed 30 seconds.
+
+   nvp -  Network Voice Protocol
+
+      Contact:
+
+         Danny Cohen (COHEN@ISIB)
+
+      Documents:
+
+         "Specifications for the Network Voice Protocol (NVP)" NSC Note
+            43.
+
+      People:
+
+      Schedule:
+
+      Comments:
+
+         Specification document available (10-Oct-74).
+
+
+
+
+
+Postel                                                         [Page 10]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         (20-JAN-75) An initial version of NVP was implemented for
+         real-time voice experiments between ISI and Lincoln Laboratory
+         in August 1974.  An expanded version has been in operation
+         since December 1974 for real-time voice communication between
+         Lincoln and CHI.  NVP uses both type 0 and type 3 IMP-Host
+         messages, and allows increased bandwidth and decreased delays
+         at the cost of reliability.
+
+      Recent developments:
+
+   packet radio
+
+      Contact:
+
+         Robert Kahn (KAHN@ISI)
+
+      Documents:
+
+      People:
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   Network Debugging Protocol
+
+      Contact:
+
+         Eric Mader (MADER@BBN)
+
+      Documents:
+
+         Mader, E. "Network Debugging Protocol," RFC 643, NIC 30873,
+         July-74.
+
+         Beeler, M. "Response Time in Cross-network Debugging," RFC 685,
+         NIC 32298, 16-April-75.
+
+                 [Office-1] <NETINFO> RFC685.TXT
+
+      People:
+
+         Michael Beeler (BEELER@BBN)
+
+         Eric Mader (MADER@BBN)
+
+
+
+
+Postel                                                         [Page 11]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Dave Retz (RETZ@ISI)
+
+         Ken Victor (VICTOR@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         This is a protocol for a PDP-11 cross-network debugger.
+
+      Recent Developments:
+
+         (15-May-75) A measure of the responsiveness of cross-network
+         debugging has been reported in:
+
+            Beeler, M. "Response Time in Cross-network Debugging," RFC
+            685, NIC 32298, 16-April-75.
+
+         [Office-1] <NETINFO>RFC685.TXT
+
+   pup - PARC Universal Protocol
+
+      Contact:
+
+         Ed Taft (TAF@PARC)
+
+      Documents:
+
+      People:
+
+         Ed Taft (TAFT@PARC)
+
+         Bob Metcalfe (METCALFE@PARC)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments
+
+         (15-May-75) Link 151 (decimal) assigned.
+
+HOST-FRONTED
+
+   Host-Front End
+
+      Contact:
+
+
+
+
+Postel                                                         [Page 12]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Michael Padlipsky (Padlipsky@MIT-Multics)
+
+      Documents:
+
+         Padlipsky, M. "A Proposed Protocol for Connecting Host
+         Computers to ARPA-Like Networks via Front-End Processors," RFC
+         647, NIC 31117, 12-Nov-74.
+
+                 [Office-1] <NETINFO>RFC647.TXT
+
+      People:
+
+         Michael Padlipsky (Padlipsky@MIT-Multics)
+
+         Jon Postel (POSTEL@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         This is a suggested simple protocol for connecting host to
+         front end computers, which are in turn connected to the
+         network.
+
+      Recent developments:
+
+PROCESS-PROCESS
+
+   ICP - Initial Connection Protocol [Official]
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Postel, J. "Official Initial Connection Protocol," NIC 7101,
+         11-June-71.
+
+         Wolfe, S. [no title] RFC 202, NIC 7155, 26-July-71.
+
+         Postel, J. "Official Telnet-Logger Initial Connection
+         Protocol," NIC 7103, 15-June-71.
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+
+
+
+Postel                                                         [Page 13]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+Telnet
+
+   Old Telnet
+
+      Contact:
+
+         Jon Postel: (POSTEL@BBNB)
+
+      Documents:
+
+         Postel, J. "Telnet Protocol," RFC 318 3-April-72.
+
+      People:
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   New Telnet [Official]
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         NIC 18639 "TELNET Protocol Specifications" AUG 73
+
+         NIC 18640 "Telnet Option Specification" Aug 73
+
+            Telnet Options
+
+              0     Transmit Binary
+
+                    "Binary Transmission," NIC 15389
+
+              1     Echo
+
+                    "Echo," NIC 15390
+
+
+
+
+Postel                                                         [Page 14]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+              2     Reconnection
+
+                    "Reconnection," NIC 15391
+
+              3     Suppress Go Ahead
+
+                    "Suppress Go Ahead Option," NIC 15392.
+
+              4     Negotiate Approximate Message Size
+
+                    "Approximate Message Size Negotiation," NIC
+
+              5     Status
+
+                    Crocker, D. "Status," RFC 651, NIC 31154, 25-Oct-74.
+
+                         [Office-1] <NETINFO>RFC651.TXT
+
+              6     Timing Mark
+
+                    "Timing Mark," NIC 16238.
+
+              7     Remote Controlled Transmission and Echoing
+
+                    Crocker, D. "Remote Controlled Transmission and
+                    Echoing," NIC 19859, 1-Nov-73.
+
+              8     Negotiate About Output Line Width
+
+                    Walden, D. "Output Line Width," NIC 20196,
+                    13-Nov-73.
+
+              9     Negotiate About Output Page Size
+
+                    Walden, D. "Output Page Size," NIC 20197, 13-Nov-73.
+
+              10    Output Carriage Return Disposition
+
+                    Crocker, D. "Output Carriage Return Disposition,"
+                    RFC 652, NIC 31155, 25-Oct-74.
+
+                         [Office-1] <NETINFO>RFC652.TXT
+
+              11    Output Horizontal Tab Stops
+
+                    Crocker, D. "Output Horizontal Tab Stops," RFC 653,
+                    NIC 31156, 25-Oct-74.
+
+
+
+
+Postel                                                         [Page 15]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+                         [Office-1] <NETINFO>RFC653.TXT
+
+              12    Output Horizontal Tab Disposition
+
+                    Crocker, D. "Output Horizontal Tab Disposition,"
+                    RFC 654, NIC 31157, 25-Oct-74.
+
+              13    Output Formfeed Disposition
+
+                    Crocker, D. "Output Form Feed Disposition," RFC 655,
+                    NIC 31158, 25-Oct-74.
+
+                         [Office-1] <NETINFO>RFC655.TXT
+
+              14    Output Vertical Tab Stops
+
+                    Crocker, D. "Output Vertical Tab Stops," RFC 656,
+                    NIC 31159, 25-Oct-74.
+
+              15    Output Vertical Tab Disposition
+
+                    Crocker, D. "Output Vertical Tab Disposition," RFC
+                    657, NIC 31160, 25-Oct-74.
+
+                         [Office-1] <NETINFO>RFC657.TXT
+
+              16    Output Linefeed Disposition
+
+                    Crocker, D. "Output Line Feed Disposition," RFC 658,
+                    NIC 31161, 25-Oct-74.
+
+                         [Office -1] <NETINFO>RFC658.TXT
+
+              255  Extended Options List
+
+                   "Extended Options List," NIC 16239.
+
+      People:
+
+         Jon Postel (POSTEL@BBN)
+
+         Alex McKenzie (MCKENZIE@BBN)
+
+         Doug Dodds (DODDS@BBN)
+
+         Dave Crocker (DCROCKER@ISI)
+
+      Schedule:
+
+
+
+Postel                                                         [Page 16]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         All Hosts were to have been running the new Telnet (both user
+         and server) by 1 January 1974.
+
+      Comments:
+
+         Note: the server program is to be available on socket 23
+         decimal (27 octal).
+
+         The Status Option has been revised to take advantage of the
+         subcommand feature and to reduce the amount of data transmitted
+         to report the option status.
+
+         Seven new options have been defined to allow control of the
+         format effectors Carriage Return, Line Feed, Form Feed,
+         Horizontal Tab, and Vertical Tab.
+
+         (31-DEC-74) Rick Schantz has made some suggestions regarding
+         the Reconnection Option in:
+
+            Schantz, R. "A Note on Reconnection Protocol," RFC 671, NIC
+            31439, 6-Dec-74.
+
+                 [Office-1] <NETINFO>RFC671.TXT
+
+      Recent developments:
+
+         (15-May-75) The latest survey of Telnet Server status by Doug
+         Dodds is:
+
+            Dodds, D. "February, 1975, Survey of New-Protocol Telnet
+            Servers," RFC 679, NIC 31890, 21-Feb-75.
+
+                    [Office-1] <NETINFO>RFC669.TXT
+
+         (18-Jun-75) A schedule for implementation of New Telnet in the
+         TIP has been published:
+
+            Walden, D. "Tentative Schedule for the New Telnet
+            Implementation for the TIP," RFC 688, NIC 32655, 4-Jun-75.
+
+                    [Office-1] <NETINFO>RFC688.TXT
+
+FTP
+
+   Old File Transfer
+
+      Contact:
+
+
+
+
+Postel                                                         [Page 17]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+                 Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         McKenzie, A. "File Transfer Protocol," NIC 14333, RFC 454, 16-
+         Feb-73.
+
+         Clements, R. "FTPSRV - Extensions for Tenex Paged Files, "RFC
+         683, NIC 32251, 3-April-75.
+
+                 [Office-1] <NETINFO>RFC683.TXT
+
+         Harvey, B. "One More Try on the FTP," RFC 691, NIC 32700, 6-
+         Jun-75.
+
+                 [Office-1] <NETINFO>RFC691.TXT
+
+      People:
+
+         Nancy Neigus (NEIGUS@BBN)
+
+         Jon Postel (POSTEL@BBN)
+
+         Alex McKenzie (MCKENZIE@BBN)
+
+         Robert Clements (CLEMENTS@BBN)
+
+         Brian Harvey (BH@SU-AI)
+
+      Schedule:
+
+      Comments:
+
+         (31-DEC-74) Kanodia has published an RFC on performance
+         measurements of FTP at Multics, which shows the important
+         effect of Host buffering in constraining thruput.
+
+            Kanodia, R. "Performance Improvement in ARPANET File
+            Transfers From Multics," RFC662, NIC 31386, 26-Nov-74.
+
+                    [Office-1] <NETINFO>RFC662.TXT
+
+      Recent developments:
+
+         (15-May-75) The Tenex FTP implementation has been extended to
+         transfer paged files as described in:
+
+
+
+
+
+Postel                                                         [Page 18]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+            Clements, R. "FTPSRV - Extensions for Tenex Pages Files,"
+            RFC 683, NIC 32251, 3-April-75.
+
+                    [Office-1] <NETINFO>RFC683.TXT
+
+         (18-Jun-75) Brian Harvey has suggested that old FTP is good
+         enough, that it is in wide use, so lets just fix the bugs
+         instead of implementing new FTP.  His suggested bug fixes are
+         also included in his RFC:
+
+            Harvey, B. "One More Try on the FTP," RFC 691, NIC 32700, 6-
+            Jun-75.
+
+                    [Office-1] <NETINFO>RFC691.TXT
+
+   New File Transfer
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Neigus, N. "File Transfer Protocol," NIC 17759 RFC 542 12-
+         July-73.
+
+         Postel, J. "Revised FTP Reply Codes," NIC 30843 RFC 640 5-
+         June-74.
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+         Nancy Neigus (NEIGUS@BBN)
+
+         Ken Pogran (Pogran.CompNet@MIT-Multics)
+
+         Wayne Hathaway (Hathaway@AMES-67)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   Pathnames
+
+      Contact:
+
+
+
+Postel                                                         [Page 19]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Crocker, D. "Network Standard Data Specification Syntax," RFC
+         645, NIC 30899, Jul-74.
+
+      People:
+
+         Dave Crocker (DCROCKER@ISI)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   File Access Protocol
+
+      Contact:
+
+         Jon Day (Day.CAC@MIT-Multics)
+
+      Documents:
+
+         Day, J. "Memo to FTP Group: File Access Protocol," RFC 520, NIC
+         16819, 25-Jun-73.
+
+      People:
+
+         Ken Pogran (Pogran.CompNet@MIT-Multics)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   File formats
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Postel, J. "Standard File Formats," RFC 678, NIC 31524, 19-
+         Dec-74.
+
+
+
+Postel                                                         [Page 20]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+                 [Office-1] <NETINFO>RFC678.TXT
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         (31-DEC-74) This new format standard for document file was
+         published:
+
+            Postel, J. "Standard File Formats," RFC678, NIC 31524, 19-
+            Dec-74.
+
+                    [Office-1] <NETINFO>RFC678.TXT
+
+      Recent developments:
+
+Mail
+
+   Current Mail
+
+      Contact:
+
+                 Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Page 26 of RFC 454 (see old file transfer).
+
+         Myer, T. "Message Transmission Protocol," RFC 680, NIC 32116,
+         30-April-75.
+
+                 [Office-1] <NETINFO>RFC680.TXT
+
+         Sussman, J. "FTP Error Code Usage for More Reliable Mail
+         Service," RFC 630, NIC 30237, 10-Apr-74.
+
+         Thomas, B. "On the problem of Signature Authentication for
+         Network Mail," RFC 644, NIC 30874, 22-July-74.
+
+      People:
+
+         Ted Meyer (MYER@BBN)
+
+         Austin Henderson (HENDERSON@BBN)
+
+
+
+Postel                                                         [Page 21]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Julie Sussman (SUSSMAN@BBN)
+
+         Bob Thomas (THOMAS@BBN)
+
+         Jon Postel (POSTEL@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         Concern over the authentication of the author of network
+         messages has lead to the concept of an authorized mail sending
+         process (see RFC 644).
+
+      Recent developments:
+
+         (15-May-75) The standard formats for mail header information
+         fields have been extended as documented in:
+
+            Myer, T. "Message Transmission Protocol," RFC 680, NIC
+            32116, 30-April-75.
+
+   Proposed Mail
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         White, J. "A Proposed Mail Protocol," RFC 524, NIC 17140, 13-
+         Jun-73.
+
+         Crocker, D. "Thoughts on the Mail Protocol Proposed in RFC
+         524," RFC 539, NIC 17644, 7-JULY-73.
+
+         White, J. "Response to Critiques of the Proposed Mail
+         Protocol," RFC 555, NIC 17993, 27-July-73.
+
+         Crocker, D. "Mail Priority," RFC 577, NIC 19356, 18-Oct-73.
+
+      People:
+
+         Jim White (JWHITE@BBNB)
+
+         Postel (POSTEL@BBNB)
+
+         Dave Crocker at UCLA-NMC (DCROCKER@ISI)
+
+
+
+Postel                                                         [Page 22]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   RJE - Remote Job Entry
+
+      Contact:
+
+                 Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Bressler, B. "Remote Job Entry Protocol," RFC 407, NIC 12112,
+         16-Oct- 72.
+
+         Krilanovich, M. "Announcement of RJS at UCSB," RFC 436, NIC
+         13700, 10-Jan-73.
+
+      People:
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   RJS - CCNs Remote Job Service
+
+      Contact:
+
+         Robert Braden (BRADEN@UCLA-CCN)
+
+      Documents:
+
+         Braden, R. "Interim NETRJS Specification," RFC 189, NIC 7133,
+         15- July-71.
+
+         Harslem, E. "Using Network Remote Job Entry," RFC 307, NIC
+         9258, 24- Feb-72.
+
+         Braden, R. "Update on NETRJS," RFC 599, NIC 20854, 13-Dec-73.
+
+         Crocker, D. "CCNRJS: Remote Job Entry between Tenex and UCLA-
+         CCN," NUTS Note 22, 5-Mar-75.
+
+                 [ISI] <DOCUMENTATION>CCNRJS.DOC
+
+
+
+Postel                                                         [Page 23]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      People:
+
+         Robert Braden (BRADEN@UCLA-CCN)
+
+         Steve Wolfe (WOLFE@UCLA-CCN)
+
+         Dave Crocker (DCROCKER@ISI)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   Graphics
+
+      Contact:
+
+         Robert Spoull (SPROULL@PARC-MAXC)
+
+      Documents:
+
+         Sproull, R. and E. Thomas. "A Networks Graphics Protocol," NIC
+         24308, 16-Aug-74.
+
+      People:
+
+         Robert Sproull (SPROULL@PARC-MAXC)
+
+         Elaine Thomas (Thomas@MIT-Multics)
+
+         James Michener (JCM@MIT-DMS)
+
+      Schedule:
+
+      Comments:
+
+         Document available from Robert Sproull.
+
+      Recent developments:
+
+   Data Reconfiguration Service
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+
+
+Postel                                                         [Page 24]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Anderson, B. "Status Report on Proposed Data Reconfiguration
+         Service," RFC 138, NIC 6715, 28-April-71.
+
+         Feah, "Data Reconfiguration Service at UCSB," RFC 437, NIC
+         13701, 30- June-74.
+
+      People:
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   RSEXEC - The Resource Sharing Executive
+
+      Contact:
+
+         Robert Thomas (THOMAS@BBN)
+
+      Documents:
+
+         Thomas, R. "A Resource Sharing Executive For the ARPANET,"
+         AFIPS Conference Proceedings, 42;155-163, NCC, 1973.
+
+      People:
+
+         Robert Thomas (THOMAS@BBN)
+
+      Schedule:
+
+      Comments:
+
+         The TIPs and some RSEXEC servers now are cooperating to perform
+         TIP user authentication and accounting functions.
+
+      Recent developments:
+
+   Line Processor Protocol
+
+      Contact:
+
+         Don Andrews (ANDREWS@BBNB)
+
+      Documents:
+
+         [BBNB] <LP>MCS4.NLS
+
+
+
+
+Postel                                                         [Page 25]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Andrews, D. "Line Processor - A Device for Amplification of
+         Display Terminal Capabilities for Text Manipulation," AFIPS
+         Conference Proceedings, 43:257-265, NCC, 1974.
+
+      People:
+
+         Martin Hardy (HARDY@BBNB)
+
+         Don Andrews (ANDREWS@BBNB)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+PROGRAMS
+
+   Neted - Network Standard Editor [Official]
+
+      Contact:
+
+         Michael Padlipsky (Padlipsky@MIT-Mulitics)
+
+      Documents:
+
+         Padlipsky, M. "NETED: A Common Editor for the ARPA Network,"
+         RFC 569, NIC 18972, 15-Oct-73.
+
+      People:
+
+         Michale Padlipsky (Padlipsky@MIT-Multics)
+
+         Jon Postel (POSTEL@BBNB)
+
+         Wayne Hathaway (HATHAWAY@AMES-67)
+
+      Schedule:
+
+      Comments:
+
+      Recent developments:
+
+   UULP - Unified User-Level Protocol
+
+      Contact:
+
+                 Michael Padlipsky (Padlipsky@MIT-Multics)
+
+
+
+Postel                                                         [Page 26]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Documents:
+
+         Padlipsky, M. "Specification of a Unified User-Level Protocol,"
+         RFC 666, NIC 31396, 26-Nov-73.
+
+                 [Office-1] <NETINFO>RFC666.TXT
+
+      People:
+
+         Michael Padlipsky (Padlispksy@MIT-Multics)
+
+         Jon Postel (POSTEL@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         Also know as Common Command Language (CCL).
+
+      Recent developments:
+
+NATIONAL SOFTWARE WORKS
+
+   The national Software Works (NSW) is developing a set of protocols
+   for its use of the ARPA Network, other uses of these protocols is
+   encouraged.
+
+   The Distributed Programming System (DPS) is intended to facilitate
+   the sharing of resources in the network at the subroutine level.  The
+   Distributed Programming System will be used to split NLS into a front
+   end and back end components.  Distributed Programming system is also
+   to be used in the NSW and the basis for communication between the
+   Works Manager, the Tool Bearing Hosts, and Front End procedure
+   packages.
+
+   The documents cited below give a view of the Distributed Programming
+   System and its use.
+
+   Contact:
+
+      Jim White (JWHITE@BBNB)
+
+      Jon Postel (POSTEL@BBNB)
+
+
+
+
+
+
+
+
+Postel                                                         [Page 27]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+   Documents:
+
+      The documents cited here represent the state of the protocol in
+      January-75, much as changed since that time that has not been
+      adequately documented, therefore, these documents should be viewed
+      as generally descriptive not specifically definitive.
+
+      Each is available online in two forms: as an NLS file and as a
+      formatted text file.  The Journal number (e.g., 24459) refers to
+      the former, of course and the pathname (e.g., [BBNB] <NLS>PCP.TXT)
+      to the latter, accessible via FTP using username=ANONYMOUS and
+      password=GUEST (no account required).
+
+      In addition, these documents are available from Jon Postel in
+      hardcopy.
+
+                 PCP (24459,) "The Procedure Call Protocol"
+
+            This document describes the virtual programming environment
+            provided by PCP, and the inter-process exchanges that
+            implement it.
+
+                    Pathname: [BBNB] <NLS>PCP.TXT
+
+         PIP (24460,) "The Procedure Interface Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP and that serves as procedure-call-level
+            interface to PCP proper.  It includes procedures for
+            calling, resuming, interrupting, and aborting remote
+            procedures.
+
+                    Pathname: [BBNB] <NLS>PIP.TXT
+
+         PSP (24461,) "The PCP Support Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP and that augments PCP proper, largely in the
+            area of data store manipulation.  It includes procedures for
+            obtaining access to groups of remote procedures and data
+            stores, manipulating remote data stores, and creating
+            temporary ones.
+
+                    Pathname: [BBNB] <NLS>PSP.TXT
+
+
+
+
+
+
+
+Postel                                                         [Page 28]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         PMP (24462,) "The Process Management Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP and that provides the necessary tools for
+            interconnecting two or more processes to form a multi-
+            process system (e.g., NSW).  It includes procedures for
+            creating, deleting, logically and physically interconnecting
+            processes, and for allocating and releasing processors.
+
+                    Pathname: [BBNB] <NLS>PMP.TXT
+
+         PCPFMT (24576,) "PCP Data Structure Formats"
+
+            This document defines formats for PCP data structures, each
+            of which is appropriate for one or more physical channel
+            types.
+
+                    Pathname: [BBNB] <NLS>PCPFMT.TXT
+
+         PCPHST (24577,) "PCP ARPANET Inter-Host IPC Implementation"
+
+            This document defines an implementation, appropriate for
+            mediating communication between Tenex forks, of the IPC
+            primitives required by PCP.
+
+                    Pathname: [BBNB] <NLS>PCPHST.TXT
+
+         PCPFRK (24578,) "PCP Tenex Inter-Fork IPC Implementation"
+
+            This document defines an implementation, appropriate for
+            mediating communication between processes on different hosts
+            within the ARPANET, of the IPC primitives required by PCP.
+
+                    Pathname: [BBNB] <NLS>PCPFRK.TXT
+
+         PCPTNXINT (24792,) "Tenex PCP Process internal Structure"
+
+            This document defines the internal structure of a PCP
+            process implemented to run on Tenex, and as such serves as a
+            process implementer's guide.  It describes the process' fork
+            structure, the role and composition of each fork, and the
+            manner in which the various forks interact with one another;
+            indicates which components are supplied with PCP and which
+            are the responsibility of the process implementer; and
+            describes the manner in which the components are assembled
+            at load time.
+
+                    Pathname: [BBNB] <NLS>PCPTNXINT.TXT
+
+
+
+Postel                                                         [Page 29]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         HOST (24581,) "NSW Host Protocol"
+
+            This document describes the host level protocol used in the
+            NSW.  The protocol is a slightly constrained version of the
+            standard ARPANET host to host protocol.  The constraints
+            affect the allocation, RFNM wait, and retransmission
+            policies.
+
+                    Pathname: [BBNB] <NLS>HOST.TXT
+
+         EXEC (24580,) "The Executive Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP.  It includes procedures and data stores for
+            user identification, accounting, and usage information.
+
+                    Pathname: [BBNB] <NLS>EXEC.TXT
+
+         FILE (24582,) "The File Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP.  It includes procedures and data stores for
+            opening, closing, and listing directories, for creating,
+            deleting, and renaming files, and for transferring the files
+            and file elements between processes.
+
+                    Pathname: [BBNB] <NLS>FILE.TXT
+
+         FILE-APP (24813,) "The File Package Appendix"
+
+            This appendix contains some comments on implementation
+            strategy.  The thrust is to argue that the file package as
+            specified is near minimal and that the conversion between
+            the PCP format and the internal storage format can be
+            encapsulated into a few subroutines.
+
+                    Pathname: [BBNB] <NLS>FILE-APP.TXT
+
+         BATCH (24583,) "The Batch Job Package"
+
+            This document describes a package that urns in the setting
+            provided by PCP.  It includes procedures for creating and
+            deleting batch jobs, obtaining the status of a batch job,
+            and communicating with the operator of a batch processing
+            host.  This package is implemented at the host that provides
+            the batch processing facility.
+
+                    Pathname: [BBNB] <NLS>BATCH.TXT
+
+
+
+Postel                                                         [Page 30]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         LLDBUG (24579,) "The Low-Level Debug Package"
+
+            This document describes a package that runs in the setting
+            provided by PCP.  It includes procedures for a remote
+            process to debug at the assembly-language level, any
+            processes known to the local process.  The package contains
+            procedures for manipulating and searching the process'
+            address space, for manipulating and searching its symbol
+            tables, and for setting and removing breakpoints from its
+            address space.  Its data stores hold process characteristics
+            and state information, and the contents of program symbol
+            tables.
+
+                    Pathname: [BBNB] <NLS.LLDBUG.TXT
+
+         RJE-MODEL (24655,) "The NSW Remote Job Entry Model"
+
+            This document discusses the process of utilizing a batch
+            processing facility to complete a programming task in the
+            NSW environment.  This same activity in another environment
+            might utilize a remote job entry system.
+
+                    Pathname: [BBNB] <NLS>RJE-MODEL.TXT
+
+         TBH (24656,) "NSW Requirements on Tool Rearing Hosts"
+
+            This document discusses the environment needed in the tool
+            bearing host and the interfaces to the operating system
+            components by various PCP packages.
+
+                    Pathname: [BBNB] <NLS>TBH.TXT
+
+         NVTP (24827,) "The Network Virtual Terminal Package"
+
+            The Network Virtual Terminal Package (package name = NVTP)
+            contains the procedures interfacing PCP procedure calls to
+            terminal oriented input and output character streams as
+            defined by the ARPANET Telnet protocol.
+
+                    Pathname: [BBNB] <NLS>NVTP.TXT
+
+         NTP (25008,) "The NSW Tool Package"
+
+            This document describes the procedures and data stores
+            required of a process for use as a tool within the NSW.
+
+                    Pathname: [BBNB] <NLS>NTP.TXT
+
+
+
+
+Postel                                                         [Page 31]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         NSWSTRUC (25009,) "NSW Process Structure"
+
+            This document describes the structure of the PCP process
+            tree used in the NSW.
+
+                    Pathname: [BBNB] <NLS>NSWSTRUC.TXT
+
+         PCPV2CHANGES (25062,) "PCP Inter-Version (2-3) Documentation"
+
+            This document describes the divergence from the Version 2
+            documentation in the implementation and current thinking.
+
+                    Pathname: [BBNB] <NLS>PCPV2CHANGES.TXT
+
+      People:
+
+         Jim White (JWHITE@BBNB)
+
+         Jon Postel (POSTEL@BBNB)
+
+         Steve Warshall (WARSHALL@BBNB)
+
+         Robert Millstein (MILLSTEIN@BBNB)
+
+         Dick Mandell (MANDELL@ISIB)
+
+         Elizabeth Michael (MICHAEL@BBNB)
+
+         Dave Maynard (MAYNARD@BBNB)
+
+         Charles Irby (IRBY@BBNB)
+
+         Ken Victor (VICTOR@BBNB)
+
+      Schedule:
+
+         A demonstration of the National Software Works is to be
+         performed in summer 1975.
+
+      Comments:
+
+         (31-DEC-74) The following are the latest documents:
+
+            PCPFRK (24578,) "PCP Tenex Inter-Fork IPC Implementation"
+
+            FILE-APP (24813,) "The File Package Appendix"
+
+            RJE-MODEL (24655,) "The NSW Remote Job Entry Model"
+
+
+
+Postel                                                         [Page 32]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+            TBH (24656,) "NSW Requirements on Tool Bearing Hosts"
+
+            NVTP (24827,) "The Network Virtual Terminal Package"
+
+         (21-JAN-75) The following are the latest documents:
+
+            NTP (25008,) "The NSW Tool Package"
+
+            NSWSTRUC (25009,) "NSW Process Structure"
+
+            PCPV2CHANGES (25062,) "PCP Inter-Version (2-3)
+            Documentation"
+
+      Recent developments:
+
+         (15-May-75) Significant changes in design and initial scope
+         have altered the implementation of the Distributed Programming
+         System from the design presented in these documents, the
+         documents still serve to give the flavor of the intended
+         system, but no longer are a reliable guide to the details of
+         the actual implementation.
+
+         (18-Jun-75) The L10 source code of the Tenex implementation is
+         available online as:
+
+                 [BBNB] <NLS>C2DPS.TXT
+
+         (18-Jun-75) A description of the user interface to DPS in Tenex
+         is available online as:
+
+                 [BBNB] <JWHITE>DPSJSYS.TXT
+
+         (18-Jun-75) A description of the Works Manager procedures is
+         available online as:
+
+                 [BBNB] <MILLSTEIN>WM-PROCEDURES.TXT
+
+         (18-Jun-75) A set of memos describing the interface to the
+         B4700 batch system is available online as:
+
+                 [BBNB] <MUNTZ>BMEMO.n
+
+                         where n is in the range 1 thru 12.
+
+         (18-Jun-75) A description of the file package is available
+         online as:
+
+                 [BBNB] <NLS>25850.TXT
+
+
+
+Postel                                                         [Page 33]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         (18-Jun-75) A description of the 8 bit binary communication
+         format is available online as:
+
+                 [BBNB]25966.TXT
+
+ADDRESS ASSIGNMENTS
+
+   Assigned Links
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Link Assignments:
+
+            Decimal         Octal           Use
+            0               0               Control Messages
+            1               1               Reserved
+            2-71            2-107           Regular Messages
+            72-151          110-227         Reserved
+            152             230             PARC Universal Protocol
+            153             231             TIP Status Reporting
+            154             232             TIP Accounting
+            155-158         233-236         Internet Protocol
+            159-191         237-277         Measurements
+            192-195         300-303         Message Switching Protocol
+            196-255         304-255         Experimental Protocols
+
+
+      People:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Schedule:
+
+      Comments:
+
+         Numbers issued by Jon Postel (POSTEL@BBNB).
+
+      Recent developments:
+
+         (15-May-75) Link 151 (decimal) assigned for the PARC Universal
+         Protocol.
+
+   Assigned Sockets:
+
+
+
+
+Postel                                                         [Page 34]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+      Contact:
+
+         Jon Postel (POSTEL@BBNB)
+
+      Documents:
+
+         Socket Assignments:
+
+            General Assignments:
+
+               Decimal         Octal     Use
+               0-63            0-77      Network Wide Standard Function
+               64-127          100-177   Hosts Specific Functions
+               128-223         200-337   Reserved for Future Use
+               224-255         340-377   Any Experimental Function
+
+            Specific Assignments:
+
+               Decimal        Octal    Use
+               1               1       Old Telnet
+               3               3       Old File Transfer
+               5               5       Remote Job Entry
+               7               7       Echo
+               9               11      Discard
+               11              13      Who is on or SYSTAT
+               13              15      Date and Time
+               15              17      Who is up or NETSTAT
+               17              21      Short Text Message
+               19              23      Character generator TTYTST
+               21              25      New File Transfer
+               23              27      New Telnet
+               25              31      Distributed Programming System
+               65              101     Speech Data Base at LL-TX-2
+               67              103     Datacomputer at CCA
+               69              105     CPYTNET
+               71              107     NETRJS (EBCDIC) at UCLA-CCN
+               73              111     NETRJS (ASCII) at UCLA-CCN
+               75              113     NETRJS (TTY) at UCLA-CCN
+               77              115     any private RJE server
+               232-237       350-355   Authorized Mailer at BBN
+               239             357     Graphics
+               241             361     NCP Measurement
+               243             363     Survey Measurement
+               245             365     LINK
+               247             367     TIPSRV
+               249-255       371-377   RSEXEC
+
+      People:
+
+
+
+Postel                                                         [Page 35]
+
+RFC 694                   Protocol Information             June 18, 1975
+
+
+         Jon Postel (POSTEL@BBNB)
+
+         Nancy Neigus (NEIGUS@BBN)
+
+      Schedule:
+
+      Comments:
+
+         Numbers issued by Jon Postel (POSTEL@BBNB)
+
+         (31-DEC-74) Socket 25 (31 octal) assigned to Distributed
+         Programming System.
+
+      Recent developments:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel                                                         [Page 36]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc694.txt](<www.ietf.org/rfc/rfc694.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
