### PR TITLE
Archive rfc695.txt

### DIFF
--- a/www.ietf.org/rfc/rfc695.txt
+++ b/www.ietf.org/rfc/rfc695.txt
@@ -1,0 +1,103 @@
+
+
+NWG/RFC# 695                       MCK 5-JUL-75 15:38  32908
+Official Change in Host-Host Protocol
+
+
+
+                                      Mark Krilanovich     1
+
+         Official Change in Host-Host Protocol             2
+
+This is an official change to the Host to Host
+protocol, this document should be filed with the
+protocol specification (nic -- 8246,) in the Current
+Network Protocols Notebook (nic -- 7104,).                 3
+
+                                         -- Jon Postel    3a
+
+This document corrects an ambiguity in the current
+host-host protocol, concerning the ERR command.
+Paragraph "f", page 35, of NIC 8246 defines the
+meaning of an ERR command with error code of 5 to be
+"socket (link) not connected".  The error code is
+stated to apply to two cases, one in which a control
+command other than STR or RTS refers to a socket that
+is neither fully open nor fully closed, and the other
+in which a (non-control) message arrives over a link
+not being used for a connection.                           4
+
+The difficulty arises from the fact that the contents
+of the "data" field of the ERR command has distinctly
+different formats in the two cases.  In the first, it
+is a host-host command, and in the second it is a
+message header.  There is no reliable way for the code
+in the NCP receiving the ERR command (or a human
+reviewing an error log) to distinguish between the two
+cases, and therefore fullest use cannot be made of the
+ERR command.                                               5
+
+The two cases are now defined to have different error
+codes.  In addition, a new error code is defined,
+meaning "invalid host leader received".  Therefore,
+paragraph "f" under "ERR - Error detected" is now
+replaced by the following:                                 6
+
+f.  Request on a non-open socket (Error code = 5)          7
+
+NWG/RFC# 695                       MCK 5-JUL-75 15:38  32908
+Official Change in Host-Host Protocol
+
+
+
+   A request other than an STR or RTS was made for a
+   socket (perhaps referenced by link number) that is
+   not party to an fully established connection.  The
+   socket's inappropriate state could either be that
+   only one RFC has been sent (not yet open) or that
+   only one CLS has been sent (not yet closed).  The
+   "data" field contains the command in error; the
+   value of any fill necessary is zeros.                  7a
+
+g.  Message on an unknown link (Error code = 6)            8
+
+   A message was received over a user link which is
+   not currently being used for any connection.  The
+   contents of the "data" field are the message header
+   followed by the first eight bits of text, if any,
+   or zeros.                                              8a
+
+h.  Invalid host header (Error code = 7)                   9
+
+   A message was received either over the control link
+   or a valid user link that had a host header with
+   invalid format. Examples of when this subtype would
+   be appropriate are the following:  the M1 or M2
+   fields were non-zero, the byte size was invalid
+   (not 8 for a control link, zero for any link), or
+   the declared length (byte size times byte count)
+   exceeded the actual length.  The contents of the
+   "data" field is the message header padded with
+   eight bits of zeros.                                   9a
+
+-------                                                   10
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                             1


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc695.txt](<www.ietf.org/rfc/rfc695.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
