### PR TITLE
Archive rfc6958.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6958.txt
+++ b/www.ietf.org/rfc/rfc6958.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          A. Clark
+Request for Comments: 6958                                      Telchemy
+Category: Standards Track                                       S. Zhang
+ISSN: 2070-1721                                                  J. Zhao
+                                                                   STTRI
+                                                              Q. Wu, Ed.
+                                                                  Huawei
+                                                                May 2013
+
+
+       RTP Control Protocol (RTCP) Extended Report (XR) Block for
+                    Burst/Gap Loss Metric Reporting
+
+Abstract
+
+   This document defines an RTP Control Protocol (RTCP) Extended Report
+   (XR) Block that allows the reporting of burst and gap loss metrics
+   for use in a range of RTP applications.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6958.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+Clark, et al.                Standards Track                    [Page 1]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Burst/Gap Loss Metrics Block  . . . . . . . . . . . . . .   2
+     1.2.  RTCP and RTCP XR Reports  . . . . . . . . . . . . . . . .   3
+     1.3.  Performance Metrics Framework . . . . . . . . . . . . . .   3
+     1.4.  Applicability . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Burst/Gap Loss Metrics Block  . . . . . . . . . . . . . . . .   4
+     3.1.  Report Block Structure  . . . . . . . . . . . . . . . . .   5
+     3.2.  Definition of Fields in Burst/Gap Loss Metrics Block  . .   5
+     3.3.  Derived Metrics Based on Reported Metrics . . . . . . . .   7
+   4.  Considerations for Voice-over-IP Applications . . . . . . . .   8
+   5.  SDP Signaling . . . . . . . . . . . . . . . . . . . . . . . .   9
+     5.1.  SDP rtcp-xr-attrib Attribute Extension  . . . . . . . . .   9
+     5.2.  Offer/Answer Usage  . . . . . . . . . . . . . . . . . . .   9
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
+     6.1.  New RTCP XR Block Type Value  . . . . . . . . . . . . . .   9
+     6.2.  New RTCP XR SDP Parameter . . . . . . . . . . . . . . . .   9
+     6.3.  Contact Information for Registrations . . . . . . . . . .  10
+   7.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
+   8.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  10
+   9.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  10
+   10. References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+     10.1.  Normative References . . . . . . . . . . . . . . . . . .  11
+     10.2.  Informative References . . . . . . . . . . . . . . . . .  11
+   Appendix A.  Metrics Represented Using the Template from RFC 6390  13
+
+1.  Introduction
+
+1.1.  Burst/Gap Loss Metrics Block
+
+   This document defines a new block type to augment those defined in
+   [RFC3611] for use in a range of RTP applications.  The new block type
+   supports the reporting of the proportion of packets lost by the
+   network.  The losses during loss bursts are reported, together with
+   the number of bursts and additional data, allowing the calculation of
+   statistical parameters (mean and variance) of the distribution of
+   burst lengths.  Some uses of these metrics depend on the availability
+   of the metric "cumulative number of packets lost" from RTCP
+   [RFC3550].
+
+   This block provides information on transient IP problems.  Burst/gap
+   metrics are typically used in Cumulative reports; however, they also
+   may be used in Interval reports.  The burstiness of packet loss
+   affects user experience, may influence any sender strategies to
+   mitigate the problem, and may also have diagnostic value.
+
+
+
+
+Clark, et al.                Standards Track                    [Page 2]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+   The metric belongs to the class of transport-related end system
+   metrics defined in [RFC6792].
+
+   The definitions of "burst", "gap", "loss", and "discard" are
+   consistent with definitions in [RFC3611].  To accommodate the range
+   of jitter buffer algorithms and packet discard logic that may be used
+   by implementors, the method used to distinguish between bursts and
+   gaps may be an equivalent method to that defined in [RFC3611].  The
+   method used should produce the same result as that defined in
+   [RFC3611] for conditions of burst packet loss but may produce
+   different results for conditions of time-varying jitter.
+
+1.2.  RTCP and RTCP XR Reports
+
+   The use of RTCP for reporting is defined in [RFC3550].  [RFC3611]
+   defines an extensible structure for reporting by using an RTCP
+   Extended Report (XR).  This document defines a new Extended Report
+   block for use with [RFC3550] and [RFC3611].
+
+1.3.  Performance Metrics Framework
+
+   The Performance Metrics Framework [RFC6390] provides guidance on the
+   definition and specification of performance metrics.  The "Guidelines
+   for Use of the RTP Monitoring Framework" [RFC6792] provides
+   guidelines for reporting block format using RTCP XR.  The Metrics
+   Block described in this document is in accordance with the guidelines
+   in [RFC6390] and [RFC6792].
+
+1.4.  Applicability
+
+   These metrics are applicable to a range of RTP applications that
+   contain jitter buffers and don't use stream repair means, e.g.,
+   Forward Error Correction (FEC) [RFC5109] and/or retransmission
+   [RFC4588].
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+
+
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                    [Page 3]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+   In addition, the following terms are defined:
+
+   Received, Lost, and Discarded
+
+      A packet shall be regarded as lost if it fails to arrive within an
+      implementation-specific time window.  A packet that arrives within
+      this time window but is too early or late to be played out or
+      thrown away before playout due to packet duplication or redundancy
+      shall be regarded as discarded.  A packet shall be classified as
+      one of received (or OK), discarded, or lost.  The metric
+      "cumulative number of packets lost" defined in [RFC3550] reports a
+      count of packets lost from the media stream (single
+      Synchronization Source (SSRC) within a single RTP session).
+      Similarly, the metric "number of packets discarded" defined in
+      [DISCARD] reports a count of packets discarded from the media
+      stream (single SSRC within single RTP session) arriving at the
+      receiver.  The post-repair Loss RLE metric, which is defined in
+      [RFC5725], can be used to report the number of packets that are
+      not recovered by any repair techniques that are in use.
+
+   Bursts and Gaps
+
+      The terms "burst" and "gap" are used in a manner consistent with
+      that of RTCP XR [RFC3611].  RTCP XR views an RTP stream as being
+      divided into bursts, which are periods when the loss rate is high
+      enough to cause noticeable quality degradation (generally over 5
+      percent loss rate) and gaps, which are periods when lost packets
+      are infrequent and hence quality is generally acceptable.
+
+3.  Burst/Gap Loss Metrics Block
+
+   Metrics in this block report on burst/gap loss in the stream arriving
+   at the RTP system.  The measurement of these metrics is made at the
+   receiving end of the RTP stream.  Each instance of this Metrics Block
+   refers by SSRC to a separate auxiliary Measurement Information Block
+   [RFC6776], which describes the measurement periods in use (see RFC
+   6776, Section 4.2).
+
+   This Metrics Block relies on the measurement period in the
+   Measurement Information Block indicating the span of the report.
+   Senders MUST send this block in the same compound RTCP packet as the
+   Measurement Information Block.  Receivers MUST verify that the
+   measurement period is received in the same compound RTCP packet as
+   this Metrics Block.  If not, this Metrics Block MUST be discarded.
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                    [Page 4]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+3.1.  Report Block Structure
+
+   The structure of the Burst/Gap Loss Metrics Block is as follows.
+
+       0                   1                   2                   3
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     BT=20     | I |C|  resv.  |      Block Length = 5         |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                        SSRC of Source                         |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ -+-+-+-+-+-+-+-+
+      | Threshold     |         Sum of Burst Durations (ms)           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |            Packets Lost in Bursts             |    Total...   |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      | ...Packets Expected in Bursts |    Number of Bursts   | Sum of|
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                ...Squares of Burst Durations (ms-squared)     |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                     Figure 1: Report Block Structure
+
+3.2.  Definition of Fields in Burst/Gap Loss Metrics Block
+
+   Block Type (BT): 8 bits
+
+      A Burst/Gap Loss Metrics Block is identified by the constant 20.
+
+   Interval Metric flag (I): 2 bits
+
+      This field is used to indicate whether the burst/gap loss metrics
+      are Sampled, Interval, or Cumulative metrics:
+
+         I=10: Interval Duration - the reported value applies to the
+         most recent measurement interval duration between successive
+         metrics reports.
+
+         I=11: Cumulative Duration - the reported value applies to the
+         accumulation period characteristic of cumulative measurements.
+
+         I=01: Sampled Value - the reported value is a sampled
+         instantaneous value.
+
+      In this document, burst/gap loss metrics can only be measured over
+      definite intervals and cannot be sampled.  Also, the value I=00 is
+      reserved for future use.  Senders MUST NOT use the values I=00 or
+      I=01.  If a block is received with I=00 or I=01, the receiver MUST
+      discard the block.
+
+
+
+Clark, et al.                Standards Track                    [Page 5]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+    Loss and Discard Combination flag (C): 1 bit
+
+      The 'C' flag is used to indicate whether the loss/discard report
+      is combined with the burst/gap loss report in the same compound
+      RTCP packet.  The value is set to '1' if the loss/discard report
+      and the burst gap loss report are combined.  Otherwise, the value
+      is set to '0'.  If the 'C' flag is set to '1' but the burst/gap
+      discard was not sent, the receiver MUST discard the burst/gap
+      loss.
+
+   Reserved (resv.): 5 bits
+
+      These bits are reserved.  They MUST be set to zero by senders and
+      ignored by receivers (see [RFC6709], Section 4.2).
+
+   Block Length: 16 bits
+
+      The length of this report block in 32-bit words, minus one.  For
+      the Burst/Gap Loss Metrics Block, the block length is equal to 5.
+      The block MUST be discarded if the block length is set to a
+      different value.
+
+   SSRC of Source: 32 bits
+
+      As defined in Section 4.1 of [RFC3611].
+
+   Threshold: 8 bits
+
+      The Threshold is equivalent to Gmin in [RFC3611], i.e., the number
+      of successive packets that must be received prior to and following
+      a lost packet in order for this lost packet to be regarded as part
+      of a gap.  Note that the threshold is calculated in accordance
+      with the Gmin Calculation defined in Section 4.7.2 of RFC 3611.
+
+   Sum of Burst Durations (ms): 24 bits
+
+      The total duration of bursts of lost packets in the period of the
+      report (Interval or Cumulative).
+
+      The measured value is an unsigned value.  If the measured value
+      exceeds 0xFFFFFD, the value 0xFFFFFE MUST be reported to indicate
+      an over-range measurement.  If the measurement is unavailable, the
+      value 0xFFFFFF MUST be reported.
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                    [Page 6]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+   Packets Lost in Bursts: 24 bits
+
+      The total number of packets lost during loss bursts.
+
+      The measured value is an unsigned value.  If the measured value
+      exceeds 0xFFFFFD, the value 0xFFFFFE MUST be reported to indicate
+      an over-range measurement.  If the measurement is unavailable, the
+      value 0xFFFFFF MUST be reported.
+
+   Total Packets Expected in Bursts: 24 bits
+
+      The total number of packets expected during loss bursts (that is,
+      the sum of received packets and lost packets).
+
+      The measured value is an unsigned value.  If the measured value
+      exceeds 0xFFFFFD, the value 0xFFFFFE MUST be reported to indicate
+      an over-range measurement.  If the measurement is unavailable, the
+      value 0xFFFFFF MUST be reported.
+
+   Number of Bursts: 16 bits
+
+      The number of bursts in the period of the report (Interval or
+      Cumulative).
+
+      The measured value is an unsigned value.  If the measured value
+      exceeds 0xFFFD, the value 0xFFFE MUST be reported to indicate an
+      over-range measurement.  If the measurement is unavailable, the
+      value 0xFFFF MUST be reported.
+
+   Sum of Squares of Burst Durations (ms-squared): 36 bits
+
+      The sum of the squares of burst durations (where individual burst
+      durations are expressed in ms) in the period of the report
+      (Interval or Cumulative).  The units for this quantity are
+      milliseconds-squared.
+
+      The measured value is an unsigned value.  If the measured value
+      exceeds 0xFFFFFFFFD, the value 0xFFFFFFFFE MUST be reported to
+      indicate an over-range measurement.  If the measurement is
+      unavailable, the value 0xFFFFFFFFF MUST be reported.
+
+3.3.  Derived Metrics Based on Reported Metrics
+
+   The metrics described here are intended to be used as described in
+   this section, in conjunction with information from the Measurement
+   Information Block [RFC6776] and also with the metric "cumulative
+   number of packets lost" provided in standard RTCP [RFC3550].
+
+
+
+
+Clark, et al.                Standards Track                    [Page 7]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+   These metrics provide information relevant to statistical parameters,
+   including:
+
+   o  the fraction of packets lost during bursts (i.e., Burst Loss Rate
+      in [SUMSTAT]), which can be calculated using the metric "Packets
+      Loss in Bursts" and the metric "Total Packets Expected in Bursts"
+      provided in the Burst/Gap Loss Metrics Block.
+
+   o  the fraction of packets lost during gaps (i.e., Gap Loss Rate in
+      [SUMSTAT]), which can be calculated using the metric "Packets Loss
+      in Bursts" and the metric "Total Packets Expected in Bursts"
+      provided in the Burst/Gap Loss Metrics Block.
+
+   o  burst duration mean [SUMSTAT], which can be calculated using the
+      metric "Packets Loss in Bursts" and the metric "Total Packets
+      Expected in Bursts" provided in the Burst/Gap Loss Metrics Block.
+
+   o  burst duration variance [SUMSTAT], which can be calculated using
+      the metric "Packets Loss in Bursts" and the metric "Total Packets
+      Expected in Bursts" provided in the Burst/Gap Loss Metrics Block.
+
+   The details on calculation of these parameters in the metrics are
+   described in [SUMSTAT].
+
+4.  Considerations for Voice-over-IP Applications
+
+   This Metrics Block is applicable to a broad range of RTP
+   applications.  Where the metric is used with a Voice-over-IP (VoIP)
+   application and the stream repair means is not available, the
+   following considerations apply.
+
+   RTCP XR views a call as being divided into bursts, which are periods
+   when the loss rate is high enough to cause noticeable call quality
+   degradation (generally over 5 percent loss rate), and gaps, which are
+   periods when lost packets are infrequent and hence call quality is
+   generally acceptable.
+
+   If Voice Activity Detection is used, the Burst and Gap Durations
+   shall be determined as if silence packets had been sent, i.e., a
+   period of silence in excess of Gmin packets will terminate a burst
+   condition.
+
+   The recommended value for the threshold Gmin in [RFC3611] causes a
+   burst during which the call quality is degraded to a similar extent
+   as it would be during a typical Pulse Code Modulation (PCM) Severely
+   Errored Second.
+
+
+
+
+
+Clark, et al.                Standards Track                    [Page 8]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+5.  SDP Signaling
+
+   [RFC3611] defines the use of the Session Description Protocol (SDP)
+   [RFC4566] for signaling the use of XR blocks.  XR blocks MAY be used
+   without prior signaling.
+
+5.1.  SDP rtcp-xr-attrib Attribute Extension
+
+   This section augments the SDP [RFC4566] attribute "rtcp-xr" defined
+   in [RFC3611] by providing an additional value of "xr-format" to
+   signal the use of the report block defined in this document.  The
+   ABNF [RFC5234] syntax is below.
+
+   xr-format =/ xr-bgl-block
+
+   xr-bgl-block = "burst-gap-loss"
+
+5.2.  Offer/Answer Usage
+
+   When SDP is used in the offer/answer context, the SDP Offer/Answer
+   usage defined in [RFC3611] for unilateral "rtcp-xr" attribute
+   parameters applies.  For detailed usage of offer/answer for
+   unilateral parameters, refer to Section 5.2 of [RFC3611].
+
+6.  IANA Considerations
+
+   New block types for RTCP XR are subject to IANA registration.  For
+   general guidelines on IANA considerations for RTCP XR, refer to
+   [RFC3611].
+
+6.1.  New RTCP XR Block Type Value
+
+   This document assigns the block type value 20 in the IANA "RTP
+   Control Protocol Extended Reports (RTCP XR) Block Type Registry" to
+   the "Burst/Gap Loss Metrics Block".
+
+6.2.  New RTCP XR SDP Parameter
+
+   This document also registers a new parameter "burst-gap-loss" in the
+   "RTP Control Protocol Extended Reports (RTCP XR) Session Description
+   Protocol (SDP) Parameters Registry".
+
+
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                    [Page 9]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+6.3.  Contact Information for Registrations
+
+   The contact information for the registrations is:
+
+      Qin Wu (sunseawq@huawei.com)
+
+      101 Software Avenue, Yuhua District
+      Nanjing, Jiangsu  210012
+      China
+
+7.  Security Considerations
+
+   This block does not provide per-packet statistics, so the risk to
+   confidentiality documented in Section 7, paragraph 3 of [RFC3611]
+   does not apply.  However, the gaps indicated within this block could
+   be used to detect the timing of other events on the path between the
+   sender and receiver.  For example, a competing multimedia stream
+   might cause a loss burst for the duration of the stream, allowing the
+   receiver of this block to know when the competing stream was active.
+   This risk is not a significant threat since the only information
+   leaked is the timing of the loss, not the cause.  Besides this, it is
+   believed that this proposed RTCP XR report block introduces no other
+   new security considerations beyond those described in [RFC3611].
+
+8.  Contributors
+
+   Geoff Hunt wrote the initial draft of this document.
+
+9.  Acknowledgments
+
+   The authors gratefully acknowledge reviews and feedback provided by
+   Bruce Adams, Philip Arden, Amit Arora, Bob Biskner, Kevin Connor,
+   Claus Dahm, Randy Ethier, Roni Even, Jim Frauenthal, Albert Higashi,
+   Tom Hock, Shane Holthaus, Paul Jones, Rajesh Kumar, Keith Lantz,
+   Mohamed Mostafa, Amy Pendleton, Colin Perkins, Mike Ramalho, Ravi
+   Raviraj, Albrecht Schwarz, Tom Taylor, Hideaki Yamada, Adam Roach,
+   Dan Romascanu, Chris Lonvick, Alfred C. Morton Jr., Pete Resnick, Ted
+   Lemon, Stephen Farrell, Richard Barnes, and Benoit Claise.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                   [Page 10]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC3611]  Friedman, T., Caceres, R., and A. Clark, "RTP Control
+              Protocol Extended Reports (RTCP XR)", RFC 3611, November
+              2003.
+
+   [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
+              Description Protocol", RFC 4566, July 2006.
+
+   [RFC5234]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5725]  Begen, A., Hsu, D., and M. Lague, "Post-Repair Loss RLE
+              Report Block Type for RTP Control Protocol (RTCP) Extended
+              Reports (XRs)", RFC 5725, February 2010.
+
+10.2.  Informative References
+
+   [DISCARD]  Clark, A., Huang, R., and Q. Wu, Ed., "RTP Control
+              Protocol (RTCP) Extended Report (XR) Block for Discard
+              Count metric Reporting", Work in Progress, April 2013.
+
+   [RFC4588]  Rey, J., Leon, D., Miyazaki, A., Varsa, V., and R.
+              Hakenberg, "RTP Retransmission Payload Format", RFC 4588,
+              July 2006.
+
+   [RFC5109]  Li, A., "RTP Payload Format for Generic Forward Error
+              Correction", RFC 5109, December 2007.
+
+   [RFC6390]  Clark, A. and B. Claise, "Guidelines for Considering New
+              Performance Metric Development", BCP 170, RFC 6390,
+              October 2011.
+
+   [RFC6709]  Carpenter, B., Aboba, B., and S. Cheshire, "Design
+              Considerations for Protocol Extensions", RFC 6709,
+              September 2012.
+
+
+
+
+
+
+Clark, et al.                Standards Track                   [Page 11]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+   [RFC6776]  Clark, A. and Q. Wu, "Measurement Identity and Information
+              Reporting Using a Source Description (SDES) Item and an
+              RTCP Extended Report (XR) Block", RFC 6776, October 2012.
+
+   [RFC6792]  Wu, Q., Hunt, G., and P. Arden, "Guidelines for Use of the
+              RTP Monitoring Framework", RFC 6792, November 2012.
+
+   [SUMSTAT]  Zorn, G., Schott, R., Wu, Q., Ed., and R. Huang, "RTP
+              Control Protocol (RTCP) Extended Report (XR) Blocks for
+              Summary Statistics Metrics Reporting", Work in Progress,
+              March 2013.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                   [Page 12]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+Appendix A.  Metrics Represented Using the Template from RFC 6390
+
+   The six metrics defined in this document are described below using
+   the template from Section 5.4.4 of RFC 6390.
+
+   a.  Threshold Metric
+
+       *  Metric Name: Threshold in RTP
+
+       *  Metric Description: The Threshold is equivalent to Gmin in
+          [RFC3611], i.e., the number of successive RTP packets that
+          must be received prior to and following a lost RTP packet in
+          order for this lost RTP packet to be regarded as part of a
+          gap.
+
+       *  Method of Measurement or Calculation: See Section 3.2,
+          Threshold definition.
+
+       *  Units of Measurement: See Section 3.2, Threshold definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+       *  Use and Applications: See Section 1.4.
+
+       *  Reporting Model: See RFC 3611.
+
+   b.  Sum of Burst Durations Metric
+
+       *  Metric Name: Sum of Burst Durations in RTP
+
+       *  Metric Description: The total duration of bursts of lost RTP
+          packets in the period of the report.
+
+       *  Method of Measurement or Calculation: See Section 3.2, Sum of
+          Burst Durations definition.
+
+       *  Units of Measurement: See Section 3.2, Sum of Burst Durations
+          definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+
+
+Clark, et al.                Standards Track                   [Page 13]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+       *  Use and Applications: See Section 1.4.
+
+       *  Reporting Model: See RFC 3611.
+
+   c.  Packets Lost in Bursts Metric
+
+       *  Metric Name: RTP Packets lost in bursts
+
+       *  Metric Description: The total number of RTP packets lost
+          during loss bursts.
+
+       *  Method of Measurement or Calculation: See Section 3.2, Packets
+          Lost in Bursts definition.
+
+       *  Units of Measurement: See Section 3.2, Packets lost in bursts
+          definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+       *  Use and Applications: See Section 1.4.
+
+       *  Reporting Model: See RFC 3611.
+
+   d.  Total Packets Expected in Bursts Metric
+
+       *  Metric Name: Total RTP packets expected in bursts
+
+       *  Metric Description: The total number of RTP packets expected
+          during loss bursts (that is, the sum of received RTP packets
+          and lost RTP packets).
+
+       *  Method of Measurement or Calculation: See Section 3.2, Total
+          packets expected in bursts definition.
+
+       *  Units of Measurement: See Section 3.2, Total packets expected
+          in bursts definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+       *  Use and Applications: See Section 1.4.
+
+
+
+Clark, et al.                Standards Track                   [Page 14]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+       *  Reporting Model: See RFC 3611.
+
+   e.  Number of Bursts Metric
+
+       *  Metric Name: Number of bursts in RTP
+
+       *  Metric Description: The total duration of bursts of lost RTP
+          packets in the period of the report.
+
+       *  Method of Measurement or Calculation: See Section 3.2, Number
+          of bursts definition.
+
+       *  Units of Measurement: See Section 3.2, Number of bursts
+          definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+       *  Use and Applications: See Section 1.4.
+
+       *  Reporting Model: See RFC 3611.
+
+   f.  Sum of Squares of Burst Durations Metric
+
+       *  Metric Name: Sum of Squares of Burst Durations in RTP
+
+       *  Metric Description: The sum of the squares of burst durations
+          (where individual burst durations are expressed in ms) over in
+          the period of the report.
+
+       *  Method of Measurement or Calculation: See Section 3.2, Sum of
+          Squares of Burst Durations definition.
+
+       *  Units of Measurement: See Section 3.2, Sum of Squares of Burst
+          Durations definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: See
+          Section 3, 1st paragraph.
+
+       *  Measurement Timing: See Section 3, 2nd paragraph for
+          measurement timing and Section 3.2 for Interval Metric flag.
+
+       *  Use and Applications: See Section 1.4.
+
+       *  Reporting Model: See RFC 3611.
+
+
+
+Clark, et al.                Standards Track                   [Page 15]
+
+RFC 6958                 RTCP XR Burst/Gap Loss                 May 2013
+
+
+Authors' Addresses
+
+   Alan Clark
+   Telchemy Incorporated
+   2905 Premiere Parkway, Suite 280
+   Duluth, GA  30097
+   USA
+
+   EMail: alan.d.clark@telchemy.com
+
+
+   Sunshine Zhang
+   Shanghai Research Institute of China Telecom Corporation Limited
+   No. 1835, South Pudong Road
+   Shanghai  200122
+   China
+
+   EMail: zhangyx@sttri.com.cn
+
+
+   Jing Zhao
+   Shanghai Research Institute of China Telecom Corporation Limited
+   No. 1835, South Pudong Road
+   Shanghai  200122
+   China
+
+   EMail: zhaojing@sttri.com.cn
+
+
+   Qin Wu (editor)
+   Huawei
+   101 Software Avenue, Yuhua District
+   Nanjing, Jiangsu  210012
+   China
+
+   EMail: sunseawq@huawei.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Clark, et al.                Standards Track                   [Page 16]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6958.txt](<www.ietf.org/rfc/rfc6958.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
