### PR TITLE
Archive rfc698.txt

### DIFF
--- a/www.ietf.org/rfc/rfc698.txt
+++ b/www.ietf.org/rfc/rfc698.txt
@@ -1,0 +1,221 @@
+Request for Comments: 698                                              Jul 1975
+NIC #32964
+
+
+
+                      TELNET EXTENDED ASCII OPTION
+
+
+1. Command Name and Code.
+
+EXTEND-ASCII 17
+
+2. Command Meanings.
+
+IAC WILL EXTEND-ASCII
+
+The sender of this command requests Permission to begin
+transmitting, or confirms that it may now begin transmitting
+extended ASCII, where additional 'control' bits are added to
+normal ASCII, which are treated sPecially by certain programs on
+the host computer.
+
+IAC WON'T EXTEND-ASCII
+
+If the connection is already being operated in extended ASCII
+mode, the sender of this command demands that the receiver begin
+transmitting data characters in standard NVT ASCII. If the
+connection is not already being operated in extended ASCII mode,
+The sender of this command refuses to begin transmitting extended
+ASCII.
+
+IAC DO EXTEND-ASCII
+
+The sender of this command requests that the receiver begin
+transmitting,or confirms that the receiver of this command is
+allowed to begin transmitting extended ASCII.
+
+IAC DON'T EXTEND-ASCII
+
+The sender of this command demands that the receiver of this
+command stop or not start transmitting data in extended ASCII
+mode.
+
+IAC SB EXTASC
+
+<high order bits (bits 15-8)><low order bits (bits 7-0)> IAC SE
+
+This command transmits an extended ASCII character in the form of
+two 8-bit bytes. Each 8-bit byte contains 8 data bits.
+
+
+
+
+
+
+                                  -1-
+
+TELNET EXTENDED ASCII OPTION
+RFC 698, NIC 32964 (July 23 1975)
+
+
+
+3. Default
+
+DON'T EXTEND-ASCII
+
+WON'T EXTEND-ASCII
+
+i.e., only use standard NVT ASCII
+
+4. Motivation.
+
+Several sites on the net, for example, SU-AI and MIT-AI, use
+keyboards which use almost all 128 characters as printable
+characters, and use one or more additional bits as "control' bits as
+command modifiers or to separate textual input from command input to
+programs. Without these additional bits, several characters cannot
+be entered as text because they are used for control purposes, such
+as the greek letter "beta' which on a TELNET connection is CONTROL-C
+and is used for stopping ones job. In addition there are several
+commonly used programs at these sites which require these additional
+bits to be run effectively. Hence it is necessary to provide some
+means of sending characters larger than 8 bits wide.
+
+5. Description of the option.
+
+This option is to allow the transmission of extended ASCII.
+
+Experience has shown that most of the time, 7-bit ASCII is typed,
+with an occasional "control' character used. Hence, it is expected
+normal NVT ASCII would be used for 7-bit ASCII and that
+extended-ASCII be sent as an escape character sequence.
+
+The exact meaning of these additional bits depends on the user
+program. At SU-AI and at MIT-AI, the first two bits beyond the
+normal 7-bit ASCII are passed on to the user program and are denoted
+as follows.
+
+Bit 8 (or 200 octal) is the CONTROL bit
+Bit 9 (or 400 octal) is the META bit
+
+(NOTE: "CONTROL' is used in a non-standard way here; that is, it
+usually refers to codes 0-37 in NVT ASCII. CONTROL and META are
+echoed by prefixing the normal character with 013 (integral symbol)
+for CONTROL and 014 (plus-minus) for META. If both are present, it
+is known as CONTROL-META and echoed as 013 014 7-bit character.)
+
+
+
+
+
+                                -2-
+
+TELNET EXTENDED ASCII OPTION
+RFC 698, NIC 32964 (July 23, 1975)
+
+
+
+6. Description of Stanford Extended ASCII Characters
+
+In this section, the extended graphic character set used at SU-AI is
+described for reference, although this specific character set is not
+required as part of the extended ASCII Telnet option. Characters
+described as "hidden" are alternate graphic interpretations of codes
+normally used as format effectors, used by certain typesetting
+programs.
+
+Code Graphic represented
+
+000 null (hidden vertically centered dot)
+001 downward arrow
+002 alpha (all Greek letters are lowercase)
+003 beta
+004 logical and (caret)
+005 logical not (dash with downward extension)
+006 epsilon
+007 pi
+010 lambda
+011 tab (hidden gamma)
+012 linefeed (hidden delta)
+013 vertical tab (hidden integral)
+014 formfeed (hidden plus-minus)
+015 carriage return (hidden circled-plus)
+016 infinity
+017 del (partial differential)
+020 proper subset (right-opening horseshoe)
+021 proper superset (left-opening horseshoe)
+022 intersection (down-opening horseshoe)
+023 union (up-opening horseshoe)
+024 universal quantifier (upside-down A)
+025 existential quantifier (backwards E)
+026 circled-times
+027 left-right double headed arrow
+030 underbar
+031 right pointing arrow
+032 tilde
+033 not-equal
+034 less-than-or-equal
+035 greater-than-or-equal
+036 equivalence (column of 3 horizontal bars)
+037 logical or (V shape)
+040-135 as in standard ASCII
+
+
+
+
+
+                               -3-
+
+TELNET EXTENDED ASCII OPTION
+RFC 698, NIC 32964 (July 23, 1975)
+
+
+
+136 upward pointing arrow
+137 left pointing arrow
+140-174 as in standard ASCII
+175 altmode (prints as lozenge)
+176 right brace
+177 rubout (hidden circumflex)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                                -4-


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc698.txt](<www.ietf.org/rfc/rfc698.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
