### PR TITLE
Archive rfc699.txt

### DIFF
--- a/www.ietf.org/rfc/rfc699.txt
+++ b/www.ietf.org/rfc/rfc699.txt
@@ -1,0 +1,531 @@
+
+
+Network Working Group                                          J. Postel
+Request for Comments: 699                                      J. Vernon
+                                                                     ISI
+                                                           November 1982
+
+
+
+
+                     Requests For Comments Summary
+                             Notes: 600-699
+
+
+
+This RFC is a slightly annotated list of the 100 RFCs from RFC 600
+through RFC 699.  This is a kind of status report on these RFCs.
+
+RFC     Author    Date           Title
+---     ------    ---------      -----
+
+699     Postel    10 Nov 82      Requests for Comments Summary
+                                 Notes:  600-699
+
+  This summary.
+
+698     Tovar     23 Jul 75      Telnet Extended ASCII Option
+
+  Describes an option to allow transmission of a special kind of
+  extended ASCII used at the Stanford AI and MIT AI Labs.
+
+697     Lieb      14 Jul 75      CWD Command of FTP
+
+  Discusses FTP login access to "files only" directories.
+
+696     Cerf      17 Jul 75      Comments on the IMP/HOST and
+                                 HOST/IMP Protocol Changes
+
+  Observations on current international standards recommendations from
+  IFIP working group 6.1; see also RFCs 692, 690 687.
+
+695   Krilanovich 5  Jul 75      Official Change in  Host-Host Protocol
+
+  Corrects ambiguity concerning the ERR command; changes NIC 8246 and
+  NIC 7104.
+
+694     Postel    18 Jun 75      Protocol Information
+
+  References to documents and contacts concerning the various protocols
+  used in the ARPANET, as well as recent developments; updates RFC 661.
+
+693     Not Issued
+
+692     Wolfe     20 Jun 75      Comments on IMP/Host Protocol Changes
+
+
+
+Postel & Vernon                                                 [page 1]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+  A proposed solution to the problem of combined length of IMP and Host
+  leaders; see also RFCs 696, 690 and 687.
+
+691     Harvey    28 May 75      One More Try on the FTP
+
+  Slight revision of RFC 686, on the subject of print files; see also
+  RFCs 640, 630, 542, 454, 448, 414, 385 and 354.
+
+690     Postel     6 Jun 75      Comments on the proposed Host/IMP
+                                 Protocol Changes
+
+  Comments on suggestions in RFC 687; see also RFCs 692 and 696.
+
+689     Clements  23 May 75      TENEX NCP Finite State Machine for
+                                 Connections
+
+  Describes the internal states of an NCP connection in the TENEX
+  implementation.
+
+688     Walden     4 Jun 75      Tentative Schedule for the New TELNET
+                                 Implementation for the TIP
+
+687     Walden     2 Jun 75      IMP/Host and Host/IMP Protocol Changes
+
+  Addressing hosts on more than 63 IMPs, and other backwards compatible
+  expansions; see also RFCs 690 and 692.
+
+686     Harvey    10 May 75      Leaving Well Enough Alone
+
+  Discusses difference between early and later versions of FTP; see also
+  RFCs 691, 640, 630, 542, 454, 448, 414, 385 and 354.
+
+685     Beeler    16 Apr 75      Response Time in Cross-network
+                                 Debugging
+
+  The contribution of ARPANET communication to response time.
+
+684     Schantz   15 Apr 75      A Commentary on Procedure Calling as a
+                                 Network Protocol
+
+  Issues in designing distributed computing systems.  Shortcomings of
+  RFC 674; see also RFCs 542 and 354.
+
+683     Clements   3 Apr 75      FTPSRV -- TENEX Extension for Paged
+                                 Files
+
+  Defines an extension to FTP for page-mode transfers between TENEX
+  systems; also discusses file transfer reliability.
+
+682     Not Issued
+
+
+Postel & Vernon                                                 [page 2]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+681     Holmgren  14 May 75      Network Unix
+
+  Capabilities as an ARPANET Mini-Host:  standard I/O, Telnet, NCP,
+  Hardware/Software requirements, reliability, availability.
+
+680     Myer      30 Apr 75      Message Transmission Protocol
+
+  Extends message field definition beyond RFC 561 attempts to establish
+  syntactic and semantic standards for ARPANET; see also RFCs 733 and
+  822.
+
+679     Dodds     21 Feb 75      February, 1975, Survey of  New-Protocol
+                                 Telnet Servers
+
+  An earlier poll of Telnet server implementation status.  Updates RFCs
+  701, 702 and 669; see also RFC 703.
+
+678     Postel    18 Dec 74      Standard File Formats
+
+  For transmission of documents across different environments.
+
+677     Johnson   27 Jan 75      The Maintenance of Duplicate Databases
+
+676     Not Issued
+
+675     Cerf      16 Dec 74      Specification of Internet Transmission
+                                 Control Program
+
+  The first detailed specification of TCP; see RFC 793.
+
+674     Postel    12 DEC 74      Procedure Call Documents--Version 2
+
+  Host level protocol used in the NSW--a slightly constrained version of
+  ARPANET Host-to-Host protocol, affecting allocation, RFNM wait, and
+  retransmission; see also RFC 684.
+
+673     Not Issued
+
+672     Schantz    6 Dec 74      A Multi-Site Data Collection Facility
+
+  Applicability of TIP/TENEX protocols beyond TIP accounting.
+
+671     Schantz    6 Dec 74      A Note on Reconnection Protocol
+
+  Experience with implementation in RSEXEC context.
+
+670     Not Issued
+
+
+
+
+
+Postel & Vernon                                                 [page 3]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+669     Dodds      4 Dec 74      November 1974, Survey of New-Protocol
+                                 Telnet Servers
+
+  An earlier poll of Telnet server implementation status. Updates RFC
+  702; see also RFCs 703 and 679.
+
+668     Not Issued
+
+667     Chipman      Dec 74      BBN Host Ports
+
+  Approved scheme to connect host ports to the network.
+
+666     Padlipsky 26 Nov 74      Specification of the Unified User-Level
+                                 Protocol
+
+  Discusses and proposes a common command language.
+
+665     Not Issued
+
+664     Not Issued
+
+663     Kanodia   29 Nov 74      A Lost Message Detection and Recovery
+                                 Protocol
+
+  Proposed extension of host-host protocol; see also RFCs 534, 516, 512,
+  492 and 467.
+
+662     Kanodia   26 Nov 74      Performance Improvement in ARPANET File
+                                 Transfers from Multics
+
+  Experimenting with host output buffers to improve throughput.
+
+661     Postel    23 Nov 74      Protocol Information
+
+  An old version; see RFC 694.
+
+660     Walden    23 Oct 74      Some Changes to the IMP and the
+                                 IMP/Host Interface
+
+  Decoupling of message number sequences of hosts; host-host access
+  control; message number window; messages outside normal mechanism; see
+  also BBN 1822.
+
+659     Postel    18 Oct 74      Announcing Additional Telnet Options
+
+  Options defined in RFCs 651-658.
+
+658     Crocker   25 Oct 74      Telnet Output Line Feed Disposition
+
+
+
+
+Postel & Vernon                                                 [page 4]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+657     Crocker   25 Oct 74      Telnet Output Vertical Tab Disposition
+                                 Option
+
+656     Crocker   25 Oct 74      Telnet Output Vertical Tab Stops Option
+
+655     Crocker   25 Oct 74      Telnet Output Form Feed Disposition
+                                 Option
+
+654     Crocker   25 Oct 74      Telnet Output Horizontal Tab
+                                 Disposition Option
+
+653     Crocker   25 Oct 74      Telnet Output Horizontal Tab Stops
+                                 Option
+
+652     Crocker   25 Oct 74      Telnet Output Carriage Return
+                                 Disposition Option
+
+651     Crocker   25 Oct 74      Revised Telnet Status Option
+
+650     Not Issued
+
+649     Not Issued
+
+648     Not Issued
+
+647     Padlipsky 12 Nov 74      A Proposed Protocol for Connecting Host
+                                 Computers to ARPA-Like Networks via
+                                 Front End Processors
+
+  Approaches to Front-End protocol processing using available hardware
+  and software.
+
+646     Not Issued
+
+645     Crocker   26 Jun 74      Network Standard Data Specification
+                                 Syntax
+
+  Providing a mechanism for specifying all attributes of a collection of
+  bits; see also RFC 615.
+
+644     Thomas    22 Jul 74      On The Problem of Signature
+                                 Authentication for Network Mail
+
+643     Mader      5 Jul 74      Network Debugging Protocol
+
+  To be used in an implementation of a PDP-11 network bootstrap device
+  and a cross-network debugger.
+
+642     Burchfiel  5 Jul 74      Ready Line Philosophy and
+                                 Implementation
+
+
+Postel & Vernon                                                 [page 5]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+641     Not Issued
+
+640     Postel     5 Jun 74      Revised FTP Reply Codes
+
+  Updates RFC 542.
+
+639     Not Issued
+
+638     McKenzie  25 Apr 74      IMP/TIP Preventive Maintenance Schedule
+
+  Corrects RFC 633.
+
+637     McKenzie  23 Apr 74      Change of Network Address for SU-DSL
+
+636     Burchfiel 10 Jun 74      TIP/TENEX Reliability Improvements
+
+  Obtaining/maintaining connections; recovery from lost connections;
+  connection-state changes.
+
+635     Cerf      22 Apr 74      An Assessment of ARPANET Protocols
+
+  Theoretical and practical motivation for redesign.  Multipacket
+  messages; host retransmission; duplicate detection; sequencing;
+  acknowledgement.
+
+634     McKenzie  10 Apr 74      Change in Network Address for Haskins
+                                 Lab.
+
+633     McKenzie  18 Mar 74      IMP/TIP Preventive Maintenance Schedule
+
+  An old version; see RFC 638.
+
+632     Opderbeck 20 May 74      Throughput Degradations for Single
+                                 Packet Messages
+
+631     Danthine  17 Apr 74      Call for Papers:  International Meeting
+                                 on Minicomputers and Data Communication
+
+630     Sussman   10 Apr 74      FTP Error Code Usage for More Reliable
+                                 Mail Service
+
+  Describes FTP reply-code usage in TENEX mail processing.
+
+629     North     27 Mar 74      Scenario for Using the  Network Journal
+
+628     Keeney    27 Mar 74      Status of RFC Numbers and a Note on
+                                 Pre-assigned Journal Numbers
+
+
+
+
+
+Postel & Vernon                                                 [page 6]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+627     Feinler   25 Mar 74      ASCII Text File of Hostnames
+
+  See also RFCs 606, 608, 623 and 625.
+
+626     Kleinrock 14 Mar 74      On a possible Lockup Condition in Imp
+                                 Subnet due to Message Sequencing
+
+625     Feinler    7 Mar 74      On Line Hostnames Service
+
+  See also RFCs 606, 608, 623 and 627.
+
+624   Krilanovich 28 Feb 74      Comments on the File Transfer Protocol
+
+  Design changes and slight modifications.  Replaces RFC 607; see also
+  RFCs 614, 542 and 640.
+
+623   Krilanovich 22 Feb 74      Comments on On-Line Host Name Service
+
+  See also RFCs 627, 625, 608 and 606.
+
+622     McKenzie  13 Mar 74      Scheduling IMP/TIP Down Time
+
+  Modification of previous policy.
+
+621     Kudlick    6 Mar 74      NIC User Directories at SRI-ARC
+
+  See also RFCs 620 and 609.
+
+620     Ferguson   1 Mar 74      Request for Monitor Host Table Updates
+
+  In conjunction with moving NIC users to OFFICE-1; see also RFCs 621
+  and 609.
+
+619     Naylor     7 Mar 74      Mean Round-Trip Times in the ARPANET
+
+  Actual measurements of round-trip times.
+
+618     Taft      19 Feb 74      A Few Observations on NCP Statistics
+
+  Distribution of NCP and IMP message types by actual measurement.
+
+617     Taft      19 Feb 74      A Note on Socket Number Assignment
+
+  Danger of imposing more fixed socket number requirements; see also
+  RFCs 542, 503 and 451.
+
+616     Walden    11 Feb 74      Latest Network Maps
+
+615     Crocker    1 Mar 74      Proposed Network Standard Data Pathname
+                                 Syntax
+
+
+Postel & Vernon                                                 [page 7]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+614     Pogran    28 Jan 74      Response to RFC 607 (NIC-21255),
+                                 "Comments on the FTP"
+
+  See also RFCs 624, 542 and 640.
+
+613     McKenzie  21 Jan 74   Network Connectivity: A Response to RFC603
+
+612     McKenzie  16 Jan 74      Traffic Statistics Dec. 1973
+
+611     Walden    14 Feb 74      Two Changes to the IMP/Host Protocol
+
+  Expansion of Host-Going-Down and addition of Dead-Host-Status Message.
+
+610     Winter    15 Dec 73      Further Datalanguage Design Concepts
+
+  Preliminary results of the language design; a model for data languagea
+  semantics; future considerations.
+
+609     Ferguson  10 Jan 74      Statement of Upcoming Move of NIC/NLS
+                                 Service
+
+  See also RFCs 621 and 620.
+
+608     Feinler   10 Jan 73      Host Names On-Line
+
+  Response to RFC 606; see also RFCs 627, 625 and 623.
+
+607   Krilanovich 7 Jan 73       NIC-21255 Comments on the File
+                                 Transfer Protocol
+
+  An old version; see RFC 624; see also RFCs 614, 542 and 640.
+
+606     Deutsch   29 Dec 73      Host Names On-Line
+
+  Resolving differences in hostname-address mappings; see also RFCs 627,
+  625, 623 and 608.
+
+605     Not Issued
+
+604     Postel    26 Dec 73      Assigned Link Numbers
+
+  Modifies official host-host protocol.  Replaces RFC 377.
+
+603     Burchfiel 31 Dec 73      Response to RFC 597: Host Status
+
+  Questions about the ARPANET topology described in RFC 597.
+
+
+
+
+
+
+Postel & Vernon                                                 [page 8]
+
+
+RFC 699                                                    November 1982
+ 
+
+
+602     Metcalfe  27 Dec 73      "The Stockings Were Hung by the Chimney
+                                 With Care"
+
+  Susceptibility of ARPANET to security violations.
+
+601     McKenzie  14 Dec 73      Traffic Statistics November 1973
+
+600     Berggreen 26 Nov 73      Interfacing an Illinois Plasma Terminal
+                                 to the ARPANET
+
+  Discusses some unusual interface issues for the Plato terminal.
+
+
+                                 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Postel & Vernon                                                 [page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc699.txt](<www.ietf.org/rfc/rfc699.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
