### PR TITLE
Archive rfc6993.txt

### DIFF
--- a/www.ietf.org/rfc/rfc6993.txt
+++ b/www.ietf.org/rfc/rfc6993.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                    P. Saint-Andre
+Request for Comments: 6993                           Cisco Systems, Inc.
+Category: Informational                                        July 2013
+ISSN: 2070-1721
+
+
+             Instant Messaging and Presence Purpose for the
+    Call-Info Header Field in the Session Initiation Protocol (SIP)
+
+Abstract
+
+   This document defines and registers a value of "impp" ("instant
+   messaging and presence protocol") for the "purpose" header field
+   parameter of the Call-Info header field in the Session Initiation
+   Protocol (SIP).
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6993.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 1]
+
+RFC 6993                 Call-Info Purpose: IMPP               July 2013
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Security Considerations . . . . . . . . . . . . . . . . . . .   2
+   3.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   3
+   4.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     4.1.  Normative References  . . . . . . . . . . . . . . . . . .   3
+     4.2.  Informative References  . . . . . . . . . . . . . . . . .   3
+   5.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   4
+
+1.  Introduction
+
+   Some real-time communication endpoints support the combined use of
+   the Session Initiation Protocol (SIP) [RFC3261] and the Extensible
+   Messaging and Presence Protocol (XMPP) [RFC6120].  To improve
+   interoperability among such "CUSAX" endpoints [CUSAX], it can be
+   helpful to advertise each endpoint's SIP address over XMPP and each
+   endpoint's XMPP address over SIP, thus providing hints about the
+   communication capabilities of the endpoints.  The former feature is
+   enabled by an XMPP extension protocol called Reachability Addresses
+   [XEP-0152].  As to the latter feature, discussion in the SIP
+   community led to the conclusion that it would be best to use the
+   Call-Info header field [RFC3261] with a value of "impp" ("instant
+   messaging and presence protocol") for the "purpose" header field
+   parameter.  An example follows.
+
+   Call-Info: <xmpp:juliet@example.com> ;purpose=impp
+
+   Although CUSAX endpoints constitute the primary use case for the
+   "impp" purpose, a Uniform Resource Identifier (URI) [RFC3986] for an
+   instant messaging and presence protocol other than XMPP could be
+   included in the Call-Info header field.
+
+2.  Security Considerations
+
+   Advertising an endpoint's XMPP address over SIP could inform
+   malicious entities about an alternative attack vector.  Because the
+   "purpose" header field parameter could be spoofed, the receiving
+   endpoint ought to check the value against an authoritative source
+   such as a user directory.  Clients can integrity protect and encrypt
+   this header field using end-to-end mechanisms such as S/MIME or hop-
+   by-hop mechanisms such as Transport Layer Security (TLS).
+
+   This specification provides a new way to correlate otherwise possibly
+   unconnected identifiers.  Because such correlations can be privacy
+   sensitive, user agents ought to provide a means for users to control
+   whether or not these values are sent.
+
+
+
+
+Saint-Andre                   Informational                     [Page 2]
+
+RFC 6993                 Call-Info Purpose: IMPP               July 2013
+
+
+3.  IANA Considerations
+
+   This document defines and registers a new predefined value "impp" for
+   the "purpose" header field parameter of the Call-Info header field.
+   The IANA has completed this action by adding this RFC as a reference
+   to the line for the header field "Call-Info" and parameter name
+   "purpose" in the "Header Field Parameters and Parameter Values"
+   section of the "Session Initiation Protocol (SIP) Parameters"
+   registry as follows:
+
+     Header Field: Call-Info
+     Parameter Name: purpose
+     Predefined Values: Yes
+     Reference: [RFC3261][RFC5367][RFC6910][RFC6993]
+
+4.  References
+
+4.1.  Normative References
+
+   [RFC3261]  Rosenberg, J., Schulzrinne, H., Camarillo, G., Johnston,
+              A., Peterson, J., Sparks, R., Handley, M., and E.
+              Schooler, "SIP: Session Initiation Protocol", RFC 3261,
+              June 2002.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66, RFC
+              3986, January 2005.
+
+   [RFC6120]  Saint-Andre, P., "Extensible Messaging and Presence
+              Protocol (XMPP): Core", RFC 6120, March 2011.
+
+4.2.  Informative References
+
+   [CUSAX]    Ivov, E., Saint-Andre, P., and E. Marocco, "CUSAX:
+              Combined Use of the Session Initiation Protocol (SIP) and
+              the Extensible Messaging and Presence Protocol (XMPP)",
+              Work in Progress, June 2013.
+
+   [XEP-0152] Saint-Andre, P. and J. Hildebrand, "Reachability
+              Addresses", XSF XEP 0152, February 2013.
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 3]
+
+RFC 6993                 Call-Info Purpose: IMPP               July 2013
+
+
+5.  Acknowledgements
+
+   Thanks to Gonzalo Camarillo, Keith Drage, Saul Ibarra, Emil Ivov,
+   Cullen Jennings, Olle Johanssen, Paul Kyzivat, Gonzalo Salgueiro,
+   Dean Willis, and Dale Worley for their input.  Elwyn Davies,
+   Salvatore Loreto, Glen Zorn, and Mehmet Ersue completed reviews on
+   behalf of the General Area Review Team, Applications Area
+   Directorate, Security Directorate, and Operations and Management
+   Directorate, respectively.  Stephen Farrell and Pete Resnick provided
+   substantive feedback during IESG review.  Thanks to Yana Stamcheva
+   for her helpful comments and for shepherding the document.
+
+Author's Address
+
+   Peter Saint-Andre
+   Cisco Systems, Inc.
+   1899 Wynkoop Street, Suite 600
+   Denver, CO  80202
+   USA
+
+   Phone: +1-303-308-3282
+   EMail: psaintan@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc6993.txt](<www.ietf.org/rfc/rfc6993.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
