### PR TITLE
Archive rfc7007.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7007.txt
+++ b/www.ietf.org/rfc/rfc7007.txt
@@ -1,0 +1,227 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                     T. Terriberry
+Request for Comments: 7007                           Mozilla Corporation
+Updates: 3551                                                August 2013
+Category: Standards Track
+ISSN: 2070-1721
+
+
+ Update to Remove DVI4 from the Recommended Codecs for the RTP Profile
+     for Audio and Video Conferences with Minimal Control (RTP/AVP)
+
+Abstract
+
+   The RTP Profile for Audio and Video Conferences with Minimal Control
+   (RTP/AVP) is the basis for many other profiles, such as the Secure
+   Real-time Transport Protocol (RTP/SAVP), the Extended RTP Profile for
+   Real-time Transport Control Protocol (RTCP)-Based Feedback
+   (RTP/AVPF), and the Extended Secure RTP Profile for RTCP-Based
+   Feedback (RTP/SAVPF).  This document updates RFC 3551, the RTP/AVP
+   profile (and by extension, the profiles that build upon it), to
+   reflect changes in audio codec usage since that document was
+   originally published.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7007.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Terriberry                   Standards Track                    [Page 1]
+
+RFC 7007                     RTP/AVP Codecs                  August 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. Terminology .....................................................2
+   3. Updates to RFC 3551 .............................................3
+      3.1. Updates to Section 6 of RFC 3551 ...........................3
+   4. Security Considerations .........................................3
+   5. Acknowledgments .................................................3
+   6. References ......................................................4
+      6.1. Normative References .......................................4
+      6.2. Informative References .....................................4
+
+1.  Introduction
+
+   [RFC3551] says that audio applications operating under the RTP/AVP
+   profile SHOULD be able to send and receive PCMU and DVI4.  However,
+   in practice, many RTP deployments do not support DVI4, and there is
+   little reason to use it when much more modern codecs are available.
+   This document updates the recommended audio codec selection for the
+   RTP/AVP profile and removes the SHOULD for DVI4.  By extension, this
+   also updates the profiles that build on RTP/AVP, including RTP/SAVP
+   [RFC3711], RTP/AVPF [RFC4585], and RTP/SAVPF [RFC5124].
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+
+
+
+
+
+
+
+Terriberry                   Standards Track                    [Page 2]
+
+RFC 7007                     RTP/AVP Codecs                  August 2013
+
+
+3.  Updates to RFC 3551
+
+   The following text of [RFC3551] is hereby updated as set forth in
+   Section 3.1:
+
+      Audio applications operating under this profile SHOULD, at a
+      minimum, be able to send and/or receive payload types 0 (PCMU)
+      and 5 (DVI4).  This allows interoperability without format
+      negotiation and ensures successful negotiation with a conference
+      control protocol.
+
+3.1.  Updates to Section 6 of RFC 3551
+
+   This document updates the final paragraph of Section 6 of RFC 3551 by
+   replacing "payload types 0 (PCMU) and 5 (DVI4)" with "payload
+   type 0 (PCMU)".  We also add a final sentence to that paragraph that
+   states, "Some environments necessitate support for PCMU".  This
+   results in the following paragraph:
+
+      Audio applications operating under this profile SHOULD, at a
+      minimum, be able to send and/or receive payload type 0 (PCMU).
+      This allows interoperability without format negotiation and
+      ensures successful negotiation with a conference control protocol.
+      Some environments necessitate support for PCMU.
+
+4.  Security Considerations
+
+   This document does not introduce any new security considerations for
+   [RFC3551].
+
+5.  Acknowledgments
+
+   Thanks to Colin Perkins for suggesting this update.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Terriberry                   Standards Track                    [Page 3]
+
+RFC 7007                     RTP/AVP Codecs                  August 2013
+
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3551]  Schulzrinne, H. and S. Casner, "RTP Profile for Audio and
+              Video Conferences with Minimal Control", STD 65, RFC 3551,
+              July 2003.
+
+6.2.  Informative References
+
+   [RFC3711]  Baugher, M., McGrew, D., Naslund, M., Carrara, E., and K.
+              Norrman, "The Secure Real-time Transport Protocol (SRTP)",
+              RFC 3711, March 2004.
+
+   [RFC4585]  Ott, J., Wenger, S., Sato, N., Burmeister, C., and J. Rey,
+              "Extended RTP Profile for Real-time Transport Control
+              Protocol (RTCP)-Based Feedback (RTP/AVPF)", RFC 4585, July
+              2006.
+
+   [RFC5124]  Ott, J. and E. Carrara, "Extended Secure RTP Profile for
+              Real-time Transport Control Protocol (RTCP)-Based Feedback
+              (RTP/SAVPF)", RFC 5124, February 2008.
+
+Author's Address
+
+   Timothy B. Terriberry
+   Mozilla Corporation
+   650 Castro Street
+   Mountain View, CA  94041
+   USA
+
+   Phone: +1 650 903-0800
+   EMail: tterribe@xiph.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Terriberry                   Standards Track                    [Page 4]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7007.txt](<www.ietf.org/rfc/rfc7007.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
