### PR TITLE
Archive rfc702.txt

### DIFF
--- a/www.ietf.org/rfc/rfc702.txt
+++ b/www.ietf.org/rfc/rfc702.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Network Working Group                                 D.W. Dodds
+RFC # 702                                             BBN-TENEXA
+                                                      September 25, 1974
+
+
+         SEPTEMBER, 1974, SURVEY OF NEW-PROTOCOL TELNET SERVERS
+
+
+LAST MONTH'S SURVEY PRODUCED A GRATIFYING AMOUNT OF FEEDBACK CLARIFYING
+THE STATUS OF SEVERAL SITES; HOWEVER THERE HAVE BEEN VERY FEW CHANGES IN
+THE STATUS OF HOST SERVERS.  THE CHANGES IN THIS MONTH'S LIST, IN
+NUMERICAL ORDER (HOST NUMBER THROUGHOUT ARE OCTAL):
+
+UCLA-NMC IS NO LONGER A SERVER;
+HOST 205 IS NOW BBN-TENEXD, A NEW SYSTEM (BBNB) IS NOW HOST 61;
+RAND-RCC WAS ACCIDENTALLY OMITTED FROM THE PREVIOUS LIST;
+SDC-LAB HAS BEEN TEMPORARILY ELIMINATED FROM THE LIST UNTIL IT RETURNS
+    TO THE NET;
+I4-TENEXA (117) IS NOT A SERVER--KI4B-TENEX (217) IS, AND HAS BEEN ADDED
+    TO THE LIST;
+AMES-67 FIXED A BUG, REVEALING TO THE WORLD THE NEW-PROTOCOL SERVER (NO
+    OPTIONS) THAT WAS THERE ALL ALONG;
+ISI-DEVTENEX (226) AND USC-ECL (327) HAVE BEEN ADDED.
+
+WHAT FOLLOWS IS AN UPDATE OF THE SUMMARY AND TABULATION THAT APPEARED
+LAST MONTH.*  THERE IS STILL A LONG WAY TO GO TO 100% NEW-PROTOCOL
+IMPLEMENTATION.
+
+        TOTAL SERVER HOSTS            34             100%
+        NO NEW-PROT SERVER            21              62%
+        TOTAL NEW-PROT IMPLEM.        13              38%
+          NEW-PROT ON SOCKET 27,
+          OLD ON SOCKET 1 (2)          6              18%
+          NEW-PROT ON 1 AND 27 (3)     6              18%
+          NEW-PROT ON 1 ONLY           1               3%
+
+NOTES:
+*   ALL DATA IN THIS REPORT WERE GATHERED VIA A SURVEYING PROGRAM RUN AT
+    VARIOUS TIMES, PLUS A FEW MANUAL CHECKS TO FILL OUT THE DATA.  WHAT
+    IS REPORTED HERE IS THE WAY THE VARIOUS SERVERS WORK AS SEEN BY THE
+    NEW-PROTOCOL USER TELNET AT BBNA, AS OF 23 SEPT. 1974.
+(2) THESE ARE THE SITES WHOSE OPERATION IS 100% CORRECT ACCORDING TO ALL
+    PROTOCOL AND CONVENTIONS, AS I UNDERSTAND THEM.
+(3) WE REALIZE THAT SOME OF THE SERVERS THAT APPEAR HERE AS NEW-PROTOCOL
+    SERVERS ON SOCKET 1 ARE ACTUALLY SERVERS WHICH ATTEMPT TO
+    COMMUNICATE WITH BOTH OLD- AND NEW-PROTOCOL USER TELNETS ACCORDING
+    TO WHAT CONTROL SEQUENCES ARE RECEIVED.
+
+
+
+
+Dodds                                                           [Page 1]
+
+RFC 702          SURVEY OF NEW-PROTOCOL TELNET SERVERS    September 1974
+
+
+           TABULATION OF SERVER STATUS FOR ALL SERVER SITES:
+
+
+HOST    HOST            SOCKET         SOCKET    NEW-PROT, OPTIONS
+ NO.    NAME              1             27       IMPLETMENTED(IF ANY)
+
+101     UCLA-CCN        OLD             X
+201     UCLA-CCBS       OLD             X
+  2     SRI-ARC         OLD             X
+102     SRI-AI          OLD             X
+  3     UCSB-MOD75      OLD             X
+  4     UTAH-10         OLD             X
+105     BBN-TENEX       OLD             NEW      I1, 3, 6; O3
+205     BBN TENEXD      OLD             NEW      I1, 3, 6; O3
+305     BBN-TENEXA      OLD             NEW      I1, 3, 6; O3
+106     MIT-DMS         NEW             NEW      I1, 3; O3
+206     MIT-AI          OLD             X
+306     MIT-ML          OLD             X
+  7     RAND-RCC        OLD             X
+ 11     HARV-10         NEW             X        I1, 3; O3
+ 12     LL-67           OLD             X
+112     LL-TX-2         OLD             X
+ 13     SU-AI           NEW*            NEW*     I1, 3
+ 15     CASE-10         OLD             X
+ 16     CMU-10B         NEW             NEW      I1, 3; O3
+116     CMU-10A         NEW             NEW      I1, 3; O3
+ 17     I4-TENEX        OLD             X
+217     KI4B-TENEX      OLD             X
+ 20     AMES-67         NEW             NEW      NONE
+126     USC-ISI         OLD             X
+226     ISI-DEVTENEX    OLD             X
+ 27     USC-44          OLD             X
+327     USC-ECL         OLD             X
+ 32     SDAC-44         OLD             X
+ 37     CCA-TENEX       OLD             X
+ 40     PARC-MAXC       OLD             NEW     I1,3,6; O3
+ 43     UCSD-CC         OLD             NEW     I0(!), 3; O0, 3
+ 53     OFFICE-1        OLD             X
+ 54     MIT-MULTICS     NEW             NEW     NONE
+ 61     BBN-TENEXB      OLD             NEW     I1, 3, 6; O3
+
+
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 2]
+
+RFC 702          SURVEY OF NEW-PROTOCOL TELNET SERVERS    September 1974
+
+
+KEY TO SERVER STATUS TABLE:
+
+        X       NO SERVER AT THIS SOCKET
+
+        I#      OPTION # IMPLEMENTED INCOMING TO USER
+                    (SERVER SAYS "WILL #")
+
+        O#      OPTION # IMPLEMENTED OUTGOING FROM USER
+                    (SERVER SAYS "DO #")
+                (# IS OPTION NUMBER IN NEW PROTOCOL.  ALL OPTIONS
+                IMPLEMENTED BY ANYONE ARE:
+                        0       TRANSMIT-BINARY
+                        1       ECHO
+                        3       SUPPRESS-GO-AHEAD
+                        6       TIMING-MARK)
+
+
+NOTE: * THERE APPEARS TO BE A MINOR BUG IN SU-AI'S SERVER: IT SEEMS TO
+        SEND AN IMPROPER RESPONSE TO A REQUEST FOR OPTION 0.
+
+
+
+
+
+
+
+
+
+
+       [ This RFC was put into machine readable form for entry ]
+       [ into the online RFC archives by Alex McKenzie with    ]
+       [ support from GTE, formerly BBN Corp.            11/99 ]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dodds                                                           [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc702.txt](<www.ietf.org/rfc/rfc702.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
