### PR TITLE
Archive rfc706.txt

### DIFF
--- a/www.ietf.org/rfc/rfc706.txt
+++ b/www.ietf.org/rfc/rfc706.txt
@@ -1,0 +1,46 @@
+Network Working Group                                     Jon Postel  (SRI-ARC)
+Request for Comments: 706                                              Nov 1975
+NIC #33861
+
+
+
+                    On the Junk Mail Problem
+
+In the ARPA Network Host/IMP interface protocol there is no
+mechanism for the Host to selectively refuse messages. This means
+that a Host which desires to receive some particular messages must
+read all messages addressed to it. Such a Host could be sent many
+messages by a malfunctioning Host. This would constitute a denial of
+service to the normal users of this Host. Both the local users and
+the network communication could suffer. The services denied are the
+processor time consumed in examining the undesired messages and
+rejecting them, and the loss of network thruput or increased delay
+due to the unnecessary busyness of the network.
+
+It would be useful for a Host to be able to decline messages from
+sources it believes are misbehaving or are simply annoying. If the
+Host/IMP interface protocol allowed the Host to say to the IMP
+"refuse messages from Host X", the IMPs could discard the unwanted
+messages at their earliest opportunity returning a "refused" notice
+to the offending Host.
+
+How the IMPs might do this is an open issue -- here are two
+possibilities:
+
+The destination IMP would keep a list (per local Host) of sources
+to refuse (this has the disadvantage of keeping the network
+busy).
+
+The destination IMP on receiving the "refuse messages from Host
+X" message forwards the message to the source IMP (the IMP local
+to Host X). That IMP keeps a list (per local Host) of
+destinations that are refusing messages from this source Host.
+
+This restriction on messages might be removed by a destination Host
+either by sending a "accept messages from Host X" message to the
+IMP, or by resetting its Host/IMP interface.
+
+A Host might make use of such a facility by measuring, per source,
+the number of undesired messages per unit time, if this measure
+exceeds a threshold then the Host could issue the "refuse messages
+from Host X" message to the IMP.


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc706.txt](<www.ietf.org/rfc/rfc706.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
