### PR TITLE
Archive rfc7083.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7083.txt
+++ b/www.ietf.org/rfc/rfc7083.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          R. Droms
+Request for Comments: 7083                                 Cisco Systems
+Updates: 3315                                              November 2013
+Category: Standards Track
+ISSN: 2070-1721
+
+
+      Modification to Default Values of SOL_MAX_RT and INF_MAX_RT
+
+Abstract
+
+   This document updates RFC 3315 by redefining the default values for
+   SOL_MAX_RT and INF_MAX_RT and defining options through which a DHCPv6
+   server can override the client's default value for SOL_MAX_RT and
+   INF_MAX_RT with new values.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7083.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+Droms                        Standards Track                    [Page 1]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Requirements Language . . . . . . . . . . . . . . . . . . . .   2
+   3.  Updates to SOL_MAX_RT and INF_MAX_RT in RFC 3315  . . . . . .   2
+   4.  SOL_MAX_RT option . . . . . . . . . . . . . . . . . . . . . .   3
+   5.  INF_MAX_RT Option . . . . . . . . . . . . . . . . . . . . . .   4
+   6.  Updates for SOL_MAX_RT and INF_MAX_RT Options to RFC 3315 . .   4
+   7.  DHCPv6 Client Behavior  . . . . . . . . . . . . . . . . . . .   5
+   8.  DHCPv6 Server Behavior  . . . . . . . . . . . . . . . . . . .   6
+   9.  DHCPv6 Relay Agent Behavior . . . . . . . . . . . . . . . . .   6
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   11. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   7
+   12. IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   13. References  . . . . . . . . . . . . . . . . . . . . . . . . .   7
+     13.1.  Normative References . . . . . . . . . . . . . . . . . .   7
+     13.2.  Informative References . . . . . . . . . . . . . . . . .   7
+
+1.  Introduction
+
+   Section 5.5 of the DHCPv6 specification [RFC3315] defines the default
+   values of SOL_MAX_RT and INF_MAX_RT to be 120 seconds.  In some
+   circumstances, these defaults will lead to an unacceptably high
+   volume of aggregated traffic at a DHCPv6 server.
+
+   The change to SOL_MAX_RT is in response to DHCPv6 message rates
+   observed on a DHCPv6 server in a deployment in which many DHCPv6
+   clients are sending Solicit messages, but the DHCPv6 server has been
+   configured not to respond to those Solicit messages.  While no
+   explicit observations of traffic due to INF_MAX_RT have been
+   conducted, this document updates INF_MAX_RT for consistency with
+   SOL_MAX_RT.
+
+2.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Updates to SOL_MAX_RT and INF_MAX_RT in RFC 3315
+
+   This document changes Section 5.5 of RFC 3315 as follows:
+
+   OLD:
+      SOL_MAX_RT      120 secs  Max Solicit timeout value
+
+   NEW:
+      SOL_MAX_RT     3600 secs  Max Solicit timeout value
+
+
+
+Droms                        Standards Track                    [Page 2]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+   OLD:
+      INF_MAX_RT      120 secs  Max Information-request timeout value
+
+   NEW:
+      INF_MAX_RT     3600 secs  Max Information-request timeout value
+
+   With this change, a DHCPv6 client that does not receive a
+   satisfactory response will send Solicit or Information-request
+   messages with the same initial frequency and exponential backoff as
+   specified in Sections 17.1.2 and 18.1.5 of RFC 3315.  However, the
+   long-term behavior of these DHCPv6 clients will be to send a Solicit
+   or Information-request message every 3600 seconds rather than every
+   120 seconds, significantly reducing the aggregated traffic at the
+   DHCPv6 server.
+
+4.  SOL_MAX_RT option
+
+   A DHCPv6 server sends the SOL_MAX_RT option to a client to override
+   the default value of SOL_MAX_RT.  The value of SOL_MAX_RT in the
+   option replaces the default value defined in Section 3.  One use for
+   the SOL_MAX_RT option is to set a longer value for SOL_MAX_RT, which
+   reduces the Solicit traffic from a client that has not received a
+   response to its Solicit messages.
+
+   The format of the SOL_MAX_RT option is:
+
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |          option-code          |         option-len            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                       SOL_MAX_RT value                        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+         option-code          OPTION_SOL_MAX_RT (82)
+
+         option-len           4
+
+         SOL_MAX_RT value     Overriding value for SOL_MAX_RT
+                              in seconds; MUST be in range:
+                                60 <= "value" <= 86400 (1 day)
+
+                    Figure 1: SOL_MAX_RT Option Format
+
+
+
+
+
+
+
+
+Droms                        Standards Track                    [Page 3]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+5.  INF_MAX_RT Option
+
+   A DHCPv6 server sends the INF_MAX_RT option to a client to override
+   the default value of INF_MAX_RT.  The value of INF_MAX_RT in the
+   option replaces the default value defined in Section 3.  One use for
+   the INF_MAX_RT option is to set a longer value for INF_MAX_RT, which
+   reduces the Information-request traffic from a client that has not
+   received a response to its Information-request messages.
+
+   The format of the INF_MAX_RT option is:
+        0                   1                   2                   3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |          option-code          |         option-len            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |                       INF_MAX_RT value                        |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+         option-code          OPTION_INF_MAX_RT (83)
+
+         option-len           4
+
+         INF_MAX_RT value     Overriding value for INF_MAX_RT
+                              in seconds; MUST be in range:
+                                60 <= "value" <= 86400 (1 day)
+
+                    Figure 2: INF_MAX_RT Option Format
+
+6.  Updates for SOL_MAX_RT and INF_MAX_RT Options to RFC 3315
+
+   Update to RFC 3315, Section 17.1.3:
+
+   OLD:
+
+   The client MUST ignore any Advertise message that includes a Status
+   Code option containing the value NoAddrsAvail, with the exception
+   that the client MAY display the associated status message to the
+   user.
+
+   NEW:
+
+   The client MUST ignore any Advertise message that includes a Status
+   Code option containing the value NoAddrsAvail, with the exception
+   that the client MUST process an included SOL_MAX_RT option, MUST
+   process an included INF_MAX_RT option, and MAY display the
+   associated status message to the user.
+
+
+
+
+
+Droms                        Standards Track                    [Page 4]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+   Update to RFC 3315, Section 17.2.2:
+
+   OLD:
+
+   If the server will not assign any addresses to any IAs in a
+   subsequent Request from the client, the server MUST send an
+   Advertise message to the client that includes only a Status Code
+   option with code NoAddrsAvail and a status message for the user, a
+   Server Identifier option with the server's DUID, and a Client
+   Identifier option with the client's DUID.
+
+   NEW:
+
+   If the server will not assign any addresses to any IAs in a
+   subsequent Request from the client, the server MUST send an Advertise
+   message to the client that includes only a Status Code option with
+   code NoAddrsAvail and a status message for the user, a Server
+   Identifier option with the server's DUID, a Client Identifier option
+   with the client's DUID, and (optionally) SOL_MAX_RT and/or INF_MAX_RT
+   options.
+
+   Update to RFC 3315, Section 14 (Add text, clarifying client behavior
+   while waiting for a response from a server):
+
+   NEW:
+
+   A client is not expected to listen for a response during the entire
+   period between transmission of Solicit or Information-request
+   messages.
+
+7.  DHCPv6 Client Behavior
+
+   A DHCPv6 client MUST include the SOL_MAX_RT option code in any Option
+   Request option [RFC3315] it sends as required by RFC 3315.
+
+   A DHCPv6 client MUST include the INF_MAX_RT option code in any Option
+   Request option it sends as required by RFC 3315.
+
+   A DHCPv6 client MUST silently ignore any SOL_MAX_RT or INF_MAX_RT
+   option values that are less than 60 or more than 86400.
+
+   If a DHCPv6 client receives a message containing a SOL_MAX_RT option
+   that has a valid value for SOL_MAX_RT, the client MUST set its
+   internal SOL_MAX_RT parameter to the value contained in the
+   SOL_MAX_RT option.  This value of SOL_MAX_RT is then used by the
+   retransmission mechanism defined in Sections 14 and 17.1.2 of RFC
+   3315.
+
+
+
+
+Droms                        Standards Track                    [Page 5]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+   If a DHCPv6 client receives a message containing an INF_MAX_RT option
+   that has a valid value for INF_MAX_RT, the client MUST set its
+   internal INF_MAX_RT parameter to the value contained in the
+   INF_MAX_RT option.  This value of INF_MAX_RT is then used by the
+   retransmission mechanism defined in Sections 14 and 18.1.5 of RFC
+   3315.
+
+   Updated SOL_MAX_RT and INF_MAX_RT values apply only to the network
+   interface on which the client received SOL_MAX_RT and/or INF_MAX_RT
+   options.
+
+8.  DHCPv6 Server Behavior
+
+   Sections 17.2.2 and 18.2 of RFC 3315 govern server operation in
+   regard to option assignment.  As a convenience to the reader, we
+   mention here that the server will send options SOL_MAX_RT and
+   INF_MAX_RT only if configured with specific values for them, and the
+   client requested those options using the Option Request option.
+
+   The DHCPv6 server MAY include the SOL_MAX_RT option in any response
+   it sends to a client that has included the SOL_MAX_RT option code in
+   an Option Request option.  The SOL_MAX_RT option is sent in the main
+   body of the message to client, not as an encapsulated option in,
+   e.g., an IA_NA, IA_TA [RFC3315], or IA_PD [RFC3633] option.
+
+   The DHCPv6 server MAY include the INF_MAX_RT option in any response
+   it sends to a client that has included the INF_MAX_RT option code in
+   an Option Request option.  The INF_MAX_RT option is sent in the main
+   body of the message to client, not as an encapsulated option in,
+   e.g., an IA_NA, IA_TA, or IA_PD option.
+
+9.  DHCPv6 Relay Agent Behavior
+
+   There are no additional requirements for relays.
+
+10.  Security Considerations
+
+   This document introduces one security consideration beyond those
+   described in RFC 3315.  A malicious DHCPv6 server might cause a
+   client to set its SOL_MAX_RT and INF_MAX_RT parameters to an
+   unreasonably high value with the SOL_MAX_RT and INF_MAX_RT options,
+   which may cause an undue delay in a client completing its DHCPv6
+   protocol transaction in the case no other valid response is received.
+   Assuming the client also receives a response from a valid DHCPv6
+   server, large values for SOL_MAX_RT and INF_MAX_RT will not have any
+   effect.
+
+
+
+
+
+Droms                        Standards Track                    [Page 6]
+
+RFC 7083                DHCPv6 SOL_MAX_RT Option           November 2013
+
+
+11.  Acknowledgments
+
+   Tomek Mrugalski edited the text for compliance with "Guidelines for
+   Creating New DHCPv6 Options" [DHC-OPTION] and added important details
+   to the Security Considerations section.
+
+12.  IANA Considerations
+
+   IANA has assigned one option code each for OPTION_SOL_MAX_RT (82) and
+   OPTION_INF_MAX_RT (83) from the "DHCP Option Codes" table of the
+   "Dynamic Host Configuration Protocol for IPv6 (DHCPv6)" registry.
+
+13.  References
+
+13.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3315]  Droms, R., Bound, J., Volz, B., Lemon, T., Perkins, C.,
+              and M. Carney, "Dynamic Host Configuration Protocol for
+              IPv6 (DHCPv6)", RFC 3315, July 2003.
+
+13.2.  Informative References
+
+   [DHC-OPTION]
+              Hankins, D., Mrugalski, T., Siodelski, M., Jiang, S., and
+              S. Krishnan, "Guidelines for Creating New DHCPv6 Options",
+              Work in Progress, September 2013.
+
+   [RFC3633]  Troan, O. and R. Droms, "IPv6 Prefix Options for Dynamic
+              Host Configuration Protocol (DHCP) version 6", RFC 3633,
+              December 2003.
+
+Author's Address
+
+   Ralph Droms
+   Cisco Systems
+   1414 Massachusetts Avenue
+   Boxborough, MA  01719
+   USA
+
+   Phone: +1 978 936 1674
+   EMail: rdroms@cisco.com
+
+
+
+
+
+
+
+Droms                        Standards Track                    [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7083.txt](<www.ietf.org/rfc/rfc7083.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
