### PR TITLE
Archive rfc7097.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7097.txt
+++ b/www.ietf.org/rfc/rfc7097.txt
@@ -1,0 +1,619 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                            J. Ott
+Request for Comments: 7097                                 V. Singh, Ed.
+Category: Standards Track                               Aalto University
+ISSN: 2070-1721                                                I. Curcio
+                                                   Nokia Research Center
+                                                            January 2014
+
+
+            RTP Control Protocol (RTCP) Extended Report (XR)
+                      for RLE of Discarded Packets
+
+Abstract
+
+   The RTP Control Protocol (RTCP) is used in conjunction with the Real-
+   time Transport Protocol (RTP) in order to provide a variety of short-
+   term and long-term reception statistics.  The available reporting may
+   include aggregate information across longer periods of time as well
+   as individual packet reporting.  This document specifies a per-packet
+   report metric capturing individual packets discarded from the de-
+   jitter buffer after successful reception.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7097.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 1]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................3
+   2. Terminology .....................................................4
+   3. RTCP XR Discard RLE Report Block ................................4
+   4. Protocol Operation ..............................................6
+      4.1. Reporting Node (Receiver) ..................................6
+      4.2. Media Sender ...............................................6
+   5. SDP Signaling ...................................................6
+   6. Security Considerations .........................................7
+   7. IANA Considerations .............................................7
+      7.1. XR Report Block Registration ...............................7
+      7.2. SDP Parameter Registration .................................8
+      7.3. Contact Information for IANA Registrations .................8
+   8. Acknowledgments .................................................8
+   9. References ......................................................8
+      9.1. Normative References .......................................8
+      9.2. Informative References .....................................9
+   Appendix A. Metrics Represented Using the Template from RFC 6390 ..10
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 2]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+1.  Introduction
+
+   RTP [RFC3550] provides a transport for real-time media flows such as
+   audio and video together with the RTP Control Protocol (RTCP), which
+   provides periodic feedback about the media streams received in a
+   specific duration.  In addition, RTCP can be used for timely feedback
+   about individual events to report (e.g., packet loss) [RFC4585].
+   Both long-term and short-term feedback enable a media sender to adapt
+   its media transmission and/or encoding dynamically to the observed
+   path characteristics.
+
+   RFC 3611 [RFC3611] defines RTCP Extended Reports as a detailed
+   reporting framework to provide more than just the coarse Receiver
+   Report (RR) statistics.  The detailed reporting may enable a media
+   sender to react more appropriately to the observed networking
+   conditions as these can be characterized better, although at the
+   expense of extra overhead.
+
+   Among many other report blocks, RFC 3611 specifies the Loss Run
+   Length Encoding (RLE) block, which reports runs of packets received
+   and lost with the granularity of individual packets.  This can help
+   both error recovery and path loss characterization.  In addition to
+   lost packets, RFC 3611 defines the notion of "discarded" packets:
+   packets that were received but dropped from the de-jitter buffer
+   because they were either too early (for buffering) or too late (for
+   playout).  The "discard rate" metric is part of the Voice over IP
+   (VoIP) metrics report block even though it is not just applicable to
+   audio: it is specified as the fraction of discarded packets since the
+   beginning of the session (see Section 4.7.1 of RFC 3611 [RFC3611]).
+   The discard metric is believed to be applicable to a large class of
+   RTP applications that use a de-jitter buffer [RFC5481].
+
+   Recently proposed extensions to the Extended Reports (XRs) reporting
+   suggest enhancing this discard metric:
+
+   o  Reporting the number of discarded packets in a measurement
+      interval, i.e., either during the last reporting interval or since
+      the beginning of the session, as indicated by a flag in the
+      suggested XR [RFC7002].  If an endpoint needs to report packet
+      discard due to reasons other than early and late arrival (for
+      example, discard due to duplication, redundancy, etc.), then it
+      should consider using the Discarded Packets report block
+      [RFC7002].
+
+   o  Reporting gaps and bursts of discarded packets during a
+      measurement interval, i.e., the last reporting interval or the
+      duration of the session [RFC7003].
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 3]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+   o  Reporting the sum of payload bytes discarded during a measurement
+      interval, i.e., the last reporting interval or the duration of the
+      session [DISCARD-METRIC].
+
+   However, none of these metrics allow a receiver to report precisely
+   which packets were discarded.  While this information could in theory
+   be derived from high-frequency reporting on the number of discarded
+   packets [RFC7002] or from the gap/burst report [RFC7003], these two
+   mechanisms do not appear feasible: the former would require an unduly
+   high amount of reporting, which still might not be sufficient due to
+   the non-deterministic scheduling of RTCP packets.  The latter incurs
+   significant complexity and reporting overhead and might still not
+   deliver the desired accuracy.
+
+   This document defines a discard report block following the idea of
+   the run-length encoding applied for lost and received packets in
+   [RFC3611].
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in BCP 14, RFC 2119
+   [RFC2119].
+
+   The terminology defined in RTP [RFC3550] and in the extensions for XR
+   reporting [RFC3611] applies.
+
+3.  RTCP XR Discard RLE Report Block
+
+   The RTCP XR Discard RLE report block uses the same format as
+   specified for the loss and duplicate report blocks in RFC 3611
+   [RFC3611].  Figure 1 describes the packet format.  The fields "BT",
+   "T", "block length", "SSRC of source", "begin_seq", and "end_seq"
+   have the same semantics and representation as defined in [RFC3611],
+   with the addition of the "E" flag to indicate the reason for discard.
+   The "chunks" encoding the run length have the same representation as
+   in RFC 3611, but encode discarded packets.  A definition of a
+   discarded packet is given in RFC 7002 [RFC7002].
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 4]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+       0               1               2               3
+       0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     BT=25     |rsvd |E|   T   |         block length          |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |                        SSRC of source                         |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |          begin_seq            |             end_seq           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |          chunk 1              |             chunk 2           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      :                              ...                              :
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |          chunk n-1            |             chunk n           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+                Figure 1: RTCP XR Discard RLE Report Block
+
+   Block Type (BT, 8 bits): A Discard RLE report block is identified by
+   the constant 25.
+
+   rsvd (3 bits): This field is reserved for future definition.  In the
+   absence of such definition, the bits in this field MUST be set to
+   zero and MUST be ignored by the receiver.
+
+   The 'E' bit is introduced to distinguish between packets discarded
+   due to early arrival and those discarded due to late arrival.  The
+   'E' bit is set to '1' if the chunks represent packets discarded due
+   to arriving too early and is set to '0' otherwise.
+
+   In case both early and late discarded packets shall be reported, two
+   Discard RLE report blocks MUST be included; their sequence number
+   range MAY overlap, but individual packets MUST only be reported as
+   either early or late and not appear marked in both.  If packets
+   appear in both report blocks, the conflicting packets will be
+   ignored.  Packets not reported in either block are considered to be
+   properly received and not discarded.
+
+   Discard RLE report blocks SHOULD be sent in conjunction with an RTCP
+   RR as a compound RTCP packet.
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 5]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+4.  Protocol Operation
+
+   This section describes the behavior of the reporting node (= media
+   receiver) and the media sender.
+
+4.1.  Reporting Node (Receiver)
+
+   Transmission of RTCP XR Discard RLE report blocks is up to the
+   discretion of the media receiver, as is the reporting granularity.
+   However, it is RECOMMENDED that the media receiver signal all
+   discarded packets using the method defined in this document.  If all
+   packets over a reporting period are discarded, the media receiver MAY
+   use the Discard Report Block [RFC7002] instead.  In case of limited
+   available reporting bandwidth, it is up to the receiver whether or
+   not to include RTCP XR Discard RLE report blocks.
+
+   The media receiver MAY send the Discard RLE report blocks as part of
+   the regularly scheduled RTCP packets, as per RFC 3550.  It MAY also
+   include Discard RLE report blocks in immediate or early feedback
+   packets, as per RFC 4585.
+
+4.2.  Media Sender
+
+   The media sender MUST be prepared to operate without receiving any
+   Discard RLE report blocks.  If Discard RLE report blocks are
+   generated by the media receiver, the media sender cannot rely on all
+   these reports being received, nor can the media sender rely on a
+   regular generation pattern from the media receiver.
+
+   However, if the media sender receives RTCP XR reports but the reports
+   contain no Discard RLE report blocks and is aware that the media
+   receiver supports Discard RLE report blocks, it MAY assume that no
+   packets were discarded at the media receiver.
+
+5.  SDP Signaling
+
+   A participant of a media session MAY use SDP to signal its support
+   for the report block specified in this document or use them without
+   any prior signaling (see Section 5 of RFC 3611 [RFC3611]).
+
+   For signaling in SDP, the RTCP XR attribute as defined in RFC 3611
+   [RFC3611] MUST be used.  The SDP [RFC4566] attribute 'xr-format'
+   defined in RFC 3611 is augmented as described in the following to
+   indicate the discard RLE metric.
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 6]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+      rtcp-xr-attrib = "a=" "rtcp-xr" ":" [xr-format *(SP xr-format)]
+                       CRLF   ; defined in [RFC3611]
+
+      xr-format      =/ xr-discard-rle
+
+      xr-discard-rle = "discard-rle"
+
+   The parameter 'discard-rle' is used to indicate support for the
+   Discard RLE report block defined in Section 3.
+
+   When SDP is used in Offer/Answer context, the mechanism defined in
+   RFC 3611 [RFC3611] for unilateral "rtcp-xr" attribute parameters
+   applies (see Section 5.2 of RFC 3611 [RFC3611]).
+
+6.  Security Considerations
+
+   The Discard RLE report block provides per-packet statistics so the
+   risk to confidentiality documented in Section 7, Paragraph 3, of RFC
+   3611 [RFC3611] applies.  In some situations, returning very detailed
+   error information (e.g., over-range measurement or measurement
+   unavailable) using this report block can provide an attacker with
+   insight into the security processing.  Implementers should consider
+   the guidance in [NO-SRTP] for using appropriate security mechanisms,
+   i.e., where security is a concern, the implementation should apply
+   encryption and authentication to the report block.  For example, this
+   can be achieved by using the AVPF profile together with the Secure
+   RTP profile as defined in RFC 3711 [RFC3711]; an appropriate
+   combination of the two profiles (an "SAVPF") is specified in RFC 5124
+   [RFC5124].  However, other mechanisms also exist [SRTP-OPTIONS] and
+   might be more suitable.
+
+   Additionally, The security considerations of RFC 3550 [RFC3550], RFC
+   3611 [RFC3611], and RFC 4585 [RFC4585] apply.
+
+7.  IANA Considerations
+
+   New block types for RTCP XR are subject to IANA registration.  For
+   general guidelines on IANA considerations for RTCP XR, refer to RFC
+   3611.
+
+7.1.  XR Report Block Registration
+
+   This document extends the IANA "RTP Control Protocol Extended Reports
+   (RTCP XR) Block Type Registry" by assigning value 25 to DRLE (Discard
+   RLE Report).
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 7]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+7.2.  SDP Parameter Registration
+
+   This document registers 'discard-rle' in the "RTCP XR SDP
+   Parameters".
+
+7.3.  Contact Information for IANA Registrations
+
+   Joerg Ott (jo@comnet.tkk.fi)
+
+   Aalto University Comnet, Otakaari 5A, 02150 Espoo, Finland.
+
+8.  Acknowledgments
+
+   The authors would like to thank Alan Clark, Roni Even, Sam Hartman,
+   Colin Perkins, Dan Romascanu, Dan Wing, and Qin Wu for providing
+   valuable feedback on earlier draft versions of this document.
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3550]  Schulzrinne, H., Casner, S., Frederick, R., and V.
+              Jacobson, "RTP: A Transport Protocol for Real-Time
+              Applications", STD 64, RFC 3550, July 2003.
+
+   [RFC3611]  Friedman, T., Caceres, R., and A. Clark, "RTP Control
+              Protocol Extended Reports (RTCP XR)", RFC 3611, November
+              2003.
+
+   [RFC4585]  Ott, J., Wenger, S., Sato, N., Burmeister, C., and J. Rey,
+              "Extended RTP Profile for Real-time Transport Control
+              Protocol (RTCP)-Based Feedback (RTP/AVPF)", RFC 4585, July
+              2006.
+
+   [RFC4566]  Handley, M., Jacobson, V., and C. Perkins, "SDP: Session
+              Description Protocol", RFC 4566, July 2006.
+
+   [RFC7002]  Clark, A., Zorn, G., and Q. Wu, "RTP Control Protocol
+              (RTCP) Extended Report (XR) Block for Discard Count Metric
+              Reporting", RFC 7002, September 2013.
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 8]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+9.2.  Informative References
+
+   [RFC7003]  Clark, A., Huang, R., and Q. Wu, "RTP Control Protocol
+              (RTCP) Extended Report (XR) Block for Burst/Gap Discard
+              Metric Reporting", RFC 7003, September 2013.
+
+   [RFC5481]  Morton, A. and B. Claise, "Packet Delay Variation
+              Applicability Statement", RFC 5481, March 2009.
+
+   [RFC3711]  Baugher, M., McGrew, D., Naslund, M., Carrara, E., and K.
+              Norrman, "The Secure Real-time Transport Protocol (SRTP)",
+              RFC 3711, March 2004.
+
+   [RFC5124]  Ott, J. and E. Carrara, "Extended Secure RTP Profile for
+              Real-time Transport Control Protocol (RTCP)-Based Feedback
+              (RTP/SAVPF)", RFC 5124, February 2008.
+
+   [NO-SRTP]  Perkins, C. and M. Westerlund, "Securing the RTP Protocol
+              Framework: Why RTP Does Not Mandate a Single Media
+              Security Solution", Work in Progress, October 2013.
+
+   [SRTP-OPTIONS]
+              Westerlund, M. and C. Perkins, "Options for Securing RTP
+              Sessions", Work in Progress, November 2013.
+
+   [DISCARD-METRIC]
+              Singh, V., Ed., Ott, J., and I. Curcio, "RTP Control
+              Protocol (RTCP) Extended Report (XR) for Bytes Discarded
+              Metric", Work in Progress, November 2013.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                    [Page 9]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+Appendix A.  Metrics Represented Using the Template from RFC 6390
+
+   a.  RLE of Discarded RTP Packets Metric
+
+       *  Metric Name: RLE - Run-length encoding of Discarded RTP
+          Packets Metric.
+
+       *  Metric Description: Instances of RTP packets discarded over
+          the period covered by this report.
+
+       *  Method of Measurement or Calculation: See Section 3 for the
+          definition of Discard RLE, and Section 4.1 of RFC 3611 for
+          RLE.
+
+       *  Units of Measurement: Every RTP packet in the interval is
+          reported as discarded or not.  See Section 3 for the
+          definition.
+
+       *  Measurement Point(s) with Potential Measurement Domain: The
+          measurement of these metrics is made at the receiving end of
+          the RTP stream.
+
+       *  Measurement Timing: Each RTP packet between a beginning
+          sequence number (begin_seq) and ending sequence number
+          (end_seq) is reported as discarded or not.  See Section 3 for
+          the definition of Discard RLE.
+
+       *  Use and applications: See Section 1, paragraph 1.
+
+       *  Reporting model: See RFC 3611.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                   [Page 10]
+
+RFC 7097                   RTCP XR Discard RLE              January 2014
+
+
+Authors' Addresses
+
+   Joerg Ott
+   Aalto University
+   School of Electrical Engineering
+   Otakaari 5 A
+   Espoo, FIN  02150
+   Finland
+
+   EMail: jo@comnet.tkk.fi
+
+
+   Varun Singh (editor)
+   Aalto University
+   School of Electrical Engineering
+   Otakaari 5 A
+   Espoo, FIN  02150
+   Finland
+
+   EMail: varun@comnet.tkk.fi
+   URI:   http://www.netlab.tkk.fi/~varun/
+
+
+   Igor D.D. Curcio
+   Nokia Research Center
+   P.O. Box 1000 (Visiokatu 3)
+   Tampere, FIN  33721
+   Finland
+
+   EMail: igor.curcio@nokia.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Ott, et al.                  Standards Track                   [Page 11]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7097.txt](<www.ietf.org/rfc/rfc7097.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
