### PR TITLE
Archive rfc71.txt

### DIFF
--- a/www.ietf.org/rfc/rfc71.txt
+++ b/www.ietf.org/rfc/rfc71.txt
@@ -1,0 +1,42 @@
+
+
+
+
+Network Working Group                                   Tjaart Schipper
+Request for Comments #71                                25 September 1970
+                                                        UCLA-CCN
+
+
+            Reallocation in Case of Input Error
+
+
+In case of reading a message from the IMP, it may be impossible for the
+receiving NCP to determine the length of the message if an input error
+occurs. The following protocol will be used at the CCN-Host at UCLA to
+resynchronize flow control.
+
+If an input error is detected and the NCP can find the intended link
+number, it will send a GVB with frac = O to the sending Host and disregard
+further incoming messages on that link. When the RET has been received, a
+new ALL will be sent.
+
+If the sending Host is not waiting for a RFNM when the GVB arrives, it will
+send the RET immediately. If it is waiting for a RFNM corresponding to the
+message with the error or a RFNM corresponding to a following message, it
+will send the RET after the RFNM has been received.
+
+In this way, the receiving Host will know that the link is clear before it
+issues a new ALL.
+
+TS/rb.
+
+
+
+
+     [ This RFC was put into machine readable form for entry ]
+     [ into the online RFC archives by Alexandra Weikert 7/97]
+
+
+
+
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc71.txt](<www.ietf.org/rfc/rfc71.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
