### PR TITLE
Archive rfc7100.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7100.txt
+++ b/www.ietf.org/rfc/rfc7100.txt
@@ -1,0 +1,171 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        P. Resnick
+Request for Comments: 7100                   Qualcomm Technologies, Inc.
+BCP: 9                                                     December 2013
+Obsoletes: 5000
+Updates: 2026
+Category: Best Current Practice
+ISSN: 2070-1721
+
+
+        Retirement of the "Internet Official Protocol Standards"
+                            Summary Document
+
+Abstract
+
+   This document updates RFC 2026 to no longer use STD 1 as a summary of
+   "Internet Official Protocol Standards".  It obsoletes RFC 5000 and
+   requests the IESG to move RFC 5000 (and therefore STD 1) to Historic
+   status.
+
+Status of This Memo
+
+   This memo documents an Internet Best Current Practice.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It has been approved for publication by the Internet
+   Engineering Steering Group (IESG).  Further information on BCPs is
+   available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7100.
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Resnick                   Best Current Practice                 [Page 1]
+
+RFC 7100                   Retirement of STD 1             December 2013
+
+
+1.  Retiring STD 1
+
+   RFC 2026 [RFC2026] and its predecessors call for the publication of
+   an RFC describing the status of IETF protocols:
+
+      The RFC Editor shall publish periodically an "Internet Official
+      Protocol Standards" RFC [1], summarizing the status of all
+      Internet protocol and service specifications.
+
+   The "Internet Official Protocol Standards" document, now as RFC 5000
+   [RFC5000], has always been listed in the Internet Standard series as
+   STD 1.  However, the document has not been kept up to date in recent
+   years, and it has fallen out of use in favor of the online list
+   produced by the RFC Editor [STDS-TRK].  The IETF no longer sees the
+   need for the document to be maintained.  Therefore, this document
+   updates RFC 2026 [RFC2026], effectively removing the above-mentioned
+   paragraph from Section 6.1.3, along with the paragraph from
+   Section 2.1 that states:
+
+      The status of Internet protocol and service specifications is
+      summarized periodically in an RFC entitled "Internet Official
+      Protocol Standards" [1].  This RFC shows the level of maturity and
+      other helpful information for each Internet protocol or service
+      specification (see section 3).
+
+   and the paragraph from Section 3.3 that states:
+
+      The "Official Protocol Standards" RFC (STD1) lists a general
+      requirement level for each TS, using the nomenclature defined in
+      this section.  This RFC is updated periodically.  In many cases,
+      more detailed descriptions of the requirement levels of particular
+      protocols and of individual features of the protocols will be
+      found in appropriate ASs.
+
+   Additionally, this document obsoletes RFC 5000 [RFC5000], the current
+   incarnation of that document, and requests that the IESG move that
+   document (and therefore STD 1) to Historic status.
+
+   Finally, RFC 2026 [RFC2026] Section 6.1.3 also calls for the
+   publication of an "official summary of standards actions completed
+   and pending" in the Internet Society's newsletter.  This has also not
+   been done in recent years, and the "publication of record" for
+   standards actions has for some time been the minutes of the IESG
+   [IESG-MINUTES].  Therefore, that paragraph is also effectively
+   removed from Section 6.1.3.
+
+
+
+
+
+
+Resnick                   Best Current Practice                 [Page 2]
+
+RFC 7100                   Retirement of STD 1             December 2013
+
+
+2.  Security Considerations
+
+   This document does not impact the security of the Internet.
+
+3.  Normative References
+
+   [IESG-MINUTES] Internet Engineering Steering Group, "IESG Telechat
+                  Minutes", <http://www.ietf.org/iesg/minutes.html>.
+
+   [RFC2026]      Bradner, S., "The Internet Standards Process --
+                  Revision 3", BCP 9, RFC 2026, October 1996.
+
+   [RFC5000]      RFC Editor, "Internet Official Protocol Standards",
+                  RFC 5000, May 2008.
+
+   [STDS-TRK]     RFC Editor, "Official Internet Protocol Standards",
+                  <http://www.rfc-editor.org/rfcxx00.html>.
+
+Author's Address
+
+   Pete Resnick
+   Qualcomm Technologies, Inc.
+   5775 Morehouse Drive
+   San Diego, CA  92121
+   US
+
+   Phone: +1 858 6511 4478
+   EMail: presnick@qti.qualcomm.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Resnick                   Best Current Practice                 [Page 3]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7100.txt](<www.ietf.org/rfc/rfc7100.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
