### PR TITLE
Archive rfc7134.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7134.txt
+++ b/www.ietf.org/rfc/rfc7134.txt
@@ -1,0 +1,115 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          B. Rosen
+Request for Comments: 7134                                       NeuStar
+Updates: 4412                                                 March 2014
+Category: Standards Track
+ISSN: 2070-1721
+
+
+  The Management Policy of the Resource Priority Header (RPH) Registry
+                        Changed to "IETF Review"
+
+Abstract
+
+   RFC 4412 defines the "Resource-Priority Namespaces" and "Resource-
+   Priority Priority-values" registries.  The management policy of these
+   registries is "Standards Action".  This document normatively updates
+   RFC 4412 to change the management policy of these registries to "IETF
+   Review".
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7134.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Rosen                        Standards Track                    [Page 1]
+
+RFC 7134                 RPH Registry Management              March 2014
+
+
+1.  Introduction
+
+   [RFC4412] defines the "Resource-Priority Namespaces" and "Resource-
+   Priority Priority-values" registries.  The management policy of these
+   registries is "Standards Action" [RFC5226].  Experience suggests that
+   a document that only defines a new namespace with its priorities, and
+   does not create new protocol semantics, should not be a Standards-
+   Track document.  Therefore, this document updates [RFC4412] to change
+   the management policy of the registries to "IETF Review".
+
+2.  Security Considerations
+
+   This document does not introduce any security considerations beyond
+   those discussed in [RFC4412].
+
+3.  IANA Considerations
+
+   IANA has changed the management policy of the "Resource-Priority
+   Namespaces" and "Resource-Priority Priority-values" registries to
+   "IETF Review" [RFC5226].
+
+4.  Normative References
+
+   [RFC4412]  Schulzrinne, H. and J. Polk, "Communications Resource
+              Priority for the Session Initiation Protocol (SIP)", RFC
+              4412, February 2006.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+Author's Address
+
+   Brian Rosen
+   NeuStar
+   470 Conrad Dr.
+   Mars, PA  16046
+   US
+
+   Phone: +1 724 382 1051
+   EMail: br@brianrosen.net
+
+
+
+
+
+
+
+
+
+
+Rosen                        Standards Track                    [Page 2]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7134.txt](<www.ietf.org/rfc/rfc7134.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
