### PR TITLE
Archive rfc7135.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7135.txt
+++ b/www.ietf.org/rfc/rfc7135.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                           J. Polk
+Request for Comments: 7135                                 Cisco Systems
+Category: Informational                                         May 2014
+ISSN: 2070-1721
+
+
+     Registering a SIP Resource Priority Header Field Namespace for
+                     Local Emergency Communications
+
+Abstract
+
+   This document creates the new Session Initiation Protocol (SIP)
+   Resource Priority header field namespace 'esnet' and registers this
+   namespace with IANA.  The new header field namespace allows for local
+   emergency session establishment to a public safety answering point
+   (PSAP), between PSAPs, and between a PSAP and first responders and
+   their organizations.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Not all documents
+   approved by the IESG are a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7135.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+Polk                          Informational                     [Page 1]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  2
+   2.  Rules of Usage of the Resource Priority Header Field . . . . .  4
+   3.  "esnet" Namespace Definition . . . . . . . . . . . . . . . . .  6
+     3.1.  Namespace Definition Rules and Guidelines  . . . . . . . .  6
+     3.2.  The 'esnet' Namespace  . . . . . . . . . . . . . . . . . .  6
+   4.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . .  7
+     4.1.  IANA Resource-Priority Namespace Registration  . . . . . .  7
+     4.2.  IANA Priority-Value Registrations  . . . . . . . . . . . .  7
+   5.  Security Considerations  . . . . . . . . . . . . . . . . . . .  8
+   6.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . .  8
+   7.  Normative References . . . . . . . . . . . . . . . . . . . . .  9
+
+1.  Introduction
+
+   This document creates the new Session Initiation Protocol (SIP)
+   Resource Priority header (RPH) field namespace 'esnet' for local
+   emergency usage and registers this namespace with IANA.  The SIP
+   Resource-Priority header field is defined in RFC 4412 [RFC4412].  The
+   new 'esnet' namespace is to be used for inbound calls towards a
+   public safety answering point (PSAP), between PSAPs, and between a
+   PSAP and first responders or their organizations within managed IP
+   networks.  This namespace is not for use on the open public Internet
+   because it can be trivially forged.
+
+   Adding an RPH with the 'esnet' namespace can be differentiated from
+   the marking of an emergency call using a service URN as defined in
+   [RFC5031] in that the RPH specifically requests preferential
+   treatment in networks that honor it, while the marking merely
+   identifies an emergency call without necessarily affecting resources
+   allocated to it.  It is appropriate to use both where applicable.
+   RPH with 'esnet' may also be used within public safety networks for
+   SIP sessions that are not emergency calls and thus not marked per RFC
+   5031.
+
+   This new namespace is included in SIP requests to provide an explicit
+   priority indication within controlled environments, such as an IP
+   Multimedia Subsystem (IMS) infrastructure or Emergency Services
+   network (ESInet) where misuse can be reduced to an acceptable level
+   because these types of networks have controls in place.  The function
+   facilitates differing treatment of emergency SIP requests according
+   to local policy, or more likely, a contractual agreement between the
+   network organizations.  This indication is used solely to
+   differentiate certain SIP requests, transactions, or dialogs from
+   other SIP requests, transactions, or dialogs that do not have the
+   need for priority treatment.  If there are differing, yet still
+   understandable and valid Resource-Priority header values in separate
+
+
+
+Polk                          Informational                     [Page 2]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+   SIP requests, then this indication can be used by local policy to
+   determine which SIP request, transaction, or dialog receives which
+   treatment (likely better or worse than another).
+
+   Application Service Providers (ASPs) that are securely connected to
+   an ESInet may have sufficient controls policing the header, and a
+   trust relationship with the entities inside the ESInet.  SIP requests
+   from such ASPs could make use of this 'esnet' namespace for
+   appropriate treatment when requests are passed from the ASP to the
+   ESInet.
+
+   The 'esnet' namespace may also be used on calls from a PSAP or other
+   public safety agency on an ESInet towards a private or public
+   network, ASP or User Agent ("call back") when priority is needed.
+   Again, the request for priority is not for use on the public Internet
+   due to the ease of forging the header.
+
+   This document merely creates the namespace, per the rules within
+   [RFC4412] as updated by [RFC7134], which necessitates that new RPH
+   namespaces and their relative priority-value order be IETF reviewed
+   before being registered with IANA.
+
+   There is the possibility that within emergency services networks,
+   Multilevel Precedence and Preemption (MLPP)-like behavior can be
+   achieved (likely without the 'preemption' part), provided the local
+   policy supports enabling this function.  For example, calls placed
+   between law enforcement agents could be marked similarly to MLPP
+   systems used by military networks, and some of those calls could be
+   handled with higher priority than an emergency call from an ordinary
+   user.  Therefore, the 'esnet' namespace is given five priority-levels
+   instead of just one.  This document does not define MLPP-like SIP
+   signaling for emergency calls like those using emergency service
+   numbers (such as 911, 112, and 999), but it is not prevented either.
+
+   Within the ESInet, there will be emergency calls requiring different
+   treatments, according to the type of call.  Does a citizen's call to
+   a PSAP require the same, a higher, or a lower relative priority than
+   a PSAP's call to a police department or the police chief?  What about
+   either relative to a call from within the ESInet to a national
+   government's department responsible for public safety, disaster
+   relief, national security/defense, etc.?  For these additional
+   reasons, the 'esnet' namespace has multiple priority levels.
+
+   This document does not define any of these behaviors, outside of
+   reminding readers that the rules of RFC 4412 apply - though examples
+   of usage are included for completeness.  This document registers the
+   'esnet' RPH namespace with IANA for use within any emergency services
+   networks, not just of those from citizens to PSAPs.
+
+
+
+Polk                          Informational                     [Page 3]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  Rules of Usage of the Resource Priority Header field
+
+   This document retains the behaviors of the SIP Resource Priority
+   header field, defined in [RFC4412], when choosing between the
+   treatment options surrounding this new 'esnet' namespace.  Given the
+   environment this is to be used within (i.e., within an ESInet), the
+   usage of the 'esnet' namespace does not have a 'normal' or routine
+   call level; that is left for local jurisdictions to define within
+   their respective parts of the ESInet, which could be islands of local
+   administration.
+
+   The 'esnet' namespace MUST only be used where at least one end of the
+   signaling, setting aside the placement of B2BUAs (Back-to-Back User
+   Agents), is within a local emergency organization.  In other words,
+   if either the originating human caller's User Agent (UA) or the
+   destination human callee's UA is part of the local emergency
+   organization, this is a valid use of 'esnet'.
+
+   The 'esnet' namespace has 5 priority-values, in a specified relative
+   priority order, and is registered as a queue-based namespace in
+   compliance with [RFC4412].  SIP entities that support preemption
+   treatment (see Section 5 of [RFC4412]) can be configured according to
+   local policy.  Display names for the 'esnet' values displayed can
+   likewise be set according to local policy.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk                          Informational                     [Page 4]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+   The following network diagram provides one example of local policy
+   choices when using the 'esnet' namespace:
+
+                                                 |<-'esnet' namespace->|
+                                                 |        is used      |
+   'esnet' namespace                             |        ,-------.
+   usage out of scope                            |      ,'         `.
+      |<------------>|<---'esnet' namespace ---->|     /             \
+   +----+            |       can be used      +-----+ |    ESInet     |
+   | UA |---         |    --------------------|Proxy|-+    ------     |
+   +----+   \        |   /                    +-----+ |               |
+             \  ,-------+           ,-------.    |    |   +------+    |
+   +----+     ,'         `.       ,'         `.  |    |   |PSAP-1|    |
+   | UA |--- /  User       \     / Application \ |    |   +------+    |
+   +----+   (    Network    +---+    Service    )|    |               |
+             \             /     \   Provider  / |    |   +------+    |
+   +----+    /`.         ,'       `.         .+-----+ |   |PSAP-2|    |
+   | UA |----   '-------'           '-------' |Proxy|-+   +------+    |
+   +----+            |                        +-----+ |               |
+                     |                           |    |               |
+   +----+            |                        +-----+ |   +------+    |
+   | UA |---         |    --------------------|Proxy|-+   |PSAP-3|    |
+   +----+   \        |   /                    +-----+ |   +------+    |
+             \  ,-------+           ,-------.    |    |               |
+   +----+     ,'         `.       ,'         `.  |    |               |
+   | UA |--- /  User       \     / Application \ |    |   +------+    |
+   +----+   (    Network    +---+    Service    )|    |   |PSAP-4|    |
+             \             /     \   Provider  / |    |   +------+    |
+   +----+    /`.         ,'       `.         .+-----+ |               |
+   | UA |----   '-------'           '-------' |Proxy|-+    ANY can    |
+   +----+            |                        +-----+ |   xfer/call   |
+                     |                           |     \    | | |    /
+                                                        `.  | | |  ,'
+                                                          '-|-|-|-'
+                                                            | | |
+                                     Police  <--------------+ | |
+                                              Fire <----------+ |
+                                        National Agency <-------+
+
+        A Possible Network Architecture Using the 'esnet' Namespace
+
+   In the figure, the 'esnet' namespace is used within the ESInet on the
+   right side of the diagram.  How it is specifically utilized is out of
+   scope for this document and is left to local jurisdictions to define.
+   Whether preemption is implemented in the ESInet and the values
+   displayed to the ESInet users is likewise out of scope.  Adjacent
+   ASPs to the ESInet may have a trust relationship that includes
+   allowing this/these neighboring ASP(s) to use the 'esnet' namespace
+
+
+
+Polk                          Informational                     [Page 5]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+   to differentiate SIP requests and dialogs within the ASP's network.
+   The exact mapping between the internal and external sides of the edge
+   proxy at the ESInet boundaries is out of the scope of this document.
+
+3.  "esnet" Namespace Definition
+
+   The 'esnet' namespace is not generic for all emergencies because
+   there are a lot of different kinds of emergencies, some on a military
+   scale ([RFC4412] defines 3 of these), some on a national scale
+   ([RFC4412] defines 2 of these), and some on an international scale.
+   Each type of emergency can also have its own namespace(s); although
+   there are many defined for other uses, more are possible -- so using
+   the public emergency service number (such as 911, 112, or 999) to
+   call for police officers, firefighters, or emergency medical
+   technicians (etc.) does not have a monopoly on the word "emergency".
+
+   The namespace 'esnet' has been chosen, roughly to stand for
+   "Emergency Services NETwork", for a citizen's call for help from a
+   public authority type of organization.  This namespace will also be
+   used for communications between emergency authorities, and it MAY be
+   used by emergency authorities to call public citizens.  An example of
+   the latter is a PSAP operator calling back someone who previously
+   called an emergency service number (such as 911, 112, or 999) and the
+   communication was terminated before it -- in the PSAP operator's
+   judgment -- should have been.
+
+   Below is an example of a Resource-Priority header field using the
+   'esnet' namespace:
+
+         Resource-Priority: esnet.0
+
+3.1.  Namespace Definition Rules and Guidelines
+
+   This specification defines one unique namespace for emergency calling
+   scenarios, 'esnet' and registers this namespace with IANA.  This IANA
+   registration contains the facets defined in Section 9 of [RFC4412].
+
+3.2.  The 'esnet' Namespace
+
+   Per the rules of [RFC4412], each namespace has a finite set of
+   relative priority-value(s), listed (below) from lowest priority to
+   highest priority.  In an attempt to not limit this namespace's use in
+   the future, more than one priority-value is assigned to the 'esnet'
+   namespace.  This document does not recommend which Priority-value is
+   used where in which situation or scenario.  That is for another
+   document to specify.  To be effective, the choice within a national
+
+
+
+
+
+Polk                          Informational                     [Page 6]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+   jurisdiction needs to be coordinated by all sub-jurisdictions to
+   maintain uniform SIP behavior throughout an emergency calling system
+   of that nation.
+
+   The relative priority order for the 'esnet' namespace is as follows:
+
+         (lowest)  esnet.0
+                   esnet.1
+                   esnet.2
+                   esnet.3
+         (highest) esnet.4
+
+   The 'esnet' namespace will have priority queuing registrations for
+   these levels per Section 4.5.2 of [RFC4412].  Although no preemption
+   is specified in this document for any levels of 'esnet', local
+   jurisdiction(s) MAY configure their SIP infrastructure to use this
+   namespace with preemption, as defined in RFC 4412.
+
+   The remaining rules that originated in RFC 4412 apply with regard to
+   an RP actor who understands more than one namespace, and must
+   maintain its locally significant relative priority order.
+
+4.  IANA Considerations
+
+4.1.  IANA Resource-Priority Namespace Registration
+
+   The following entry has been added to the "Resource-Priority
+   Namespaces" registry of the sip-parameters section of IANA (created
+   by [RFC4412]):
+
+                                       Intended       New     New resp.
+      Namespace  Levels   Algorithm     Code      warn-code   Reference
+      ---------  ------  -----------  ---------   ---------   ---------
+        esnet      5       queue         no          no       RFC 7135
+
+4.2.  IANA Priority-Value Registrations
+
+   The following entry has been added to the "Resource-Priority
+   Priority-values" registry of the sip-parameters section of IANA:
+
+      Namespace: esnet
+      Reference: (this document)
+      Priority-Values (least to greatest): "0", "1","2", "3", "4"
+
+
+
+
+
+
+
+
+Polk                          Informational                     [Page 7]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+5.  Security Considerations
+
+   The Security considerations that apply to RFC 4412 [RFC4412] apply
+   here.
+
+   For networks that act on the SIP Resource-Priority header field,
+   incorrect use of namespaces can result in traffic that should have
+   been given preferential treatment not receiving it, and vice versa.
+   This document does not define a use case where an endpoint outside
+   the ESInet marks its call for preferential treatment.  Precautions
+   need to be taken to prevent granting preferential treatment to
+   unauthorized users not calling for emergency help even if they are in
+   the ESInet, as well as to prevent misuse by callers outside the
+   ESInet.
+
+   A simple means of preventing this usage is to not allow traffic
+   marked 'esnet' to get preferential treatment unless the destination
+   is towards the local/regional ESInet.  This is not a consideration
+   for internetwork traffic within the ESInet, or generated out of the
+   ESInet.  Calling an emergency service number (such as 911, 112, or
+   999) is fairly local in nature, with a finite number of URIs that are
+   likely to be considered valid within a portion of a network receiving
+   SIP signaling.
+
+   This namespace is not intended for use on the Internet because of the
+   difficulty in detecting abuse; specifically, it can trivially be
+   forged and used on a non-emergency session to obtain resource
+   priority.  Some networks may determine that it can reasonably prevent
+   abuse and/or that the consequences of undetected abuse is not
+   significant.  In such cases, use of 'esnet' on the Internet MAY be
+   allowed.
+
+6.  Acknowledgements
+
+   Thanks to Ken Carlberg, Janet Gunn, Fred Baker, and Keith Drage for
+   help and encouragement with this effort.  Thanks to Henning
+   Schulzrinne, Ted Hardie, Hannes Tschofenig, and Marc Linsner for
+   constructive comments.  A big thanks to Robert Sparks for being
+   patient with the author and Brian Rosen for completing the final
+   edits.
+
+
+
+
+
+
+
+
+
+
+
+Polk                          Informational                     [Page 8]
+
+RFC 7135                 Emergency RPH Namespace                May 2014
+
+
+7.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC4412]  Schulzrinne, H. and J. Polk, "Communications Resource
+              Priority for the Session Initiation Protocol (SIP)", RFC
+              4412, February 2006.
+
+   [RFC5031]  Schulzrinne, H., "A Uniform Resource Name (URN) for
+              Emergency and Other Well-Known Services", RFC 5031,
+              January 2008.
+
+   [RFC7134]  Rosen, B., "The Management Policy of the Resource Priority
+              Header (RPH) Registry Changed to "IETF Review"", RFC 7134,
+              March 2014.
+
+Author's Address
+
+   James Polk
+   Cisco Systems
+   3913 Treemont Circle
+   Colleyville, TX  76034
+   USA
+
+   Phone: +1-817-271-3552
+   EMail: jmpolk@cisco.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Polk                          Informational                     [Page 9]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7135.txt](<www.ietf.org/rfc/rfc7135.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
