### PR TITLE
Archive rfc7147.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7147.txt
+++ b/www.ietf.org/rfc/rfc7147.txt
@@ -1,0 +1,5155 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          M. Bakke
+Request for Comments: 7147                                          Dell
+Obsoletes: 4544                                            P. Venkatesen
+Category: Standards Track                               HCL Technologies
+ISSN: 2070-1721                                               April 2014
+
+
+                     Definitions of Managed Objects
+        for the Internet Small Computer System Interface (iSCSI)
+
+Abstract
+
+   This document defines a portion of the Management Information Base
+   (MIB) for use with network management protocols.  In particular, it
+   defines objects for managing a client using the Internet Small
+   Computer System Interface (iSCSI) protocol (SCSI over TCP).
+
+   This document obsoletes RFC 4544.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by
+   the Internet Engineering Steering Group (IESG).  Further
+   information on Internet Standards is available in Section 2 of
+   RFC 5741.
+
+   Information about the current status of this document, any
+   errata, and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7147.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 1]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 2]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+Table of Contents
+
+   1. The Internet-Standard Management Framework ......................4
+   2. Introduction ....................................................4
+   3. Relationship to Other MIB Modules ...............................4
+   4. Relationship to SNMP Contexts ...................................5
+   5. Differences from RFC 4544 .......................................5
+   6. Discussion ......................................................6
+      6.1. iSCSI MIB Object Model .....................................7
+      6.2. iSCSI MIB Table Structure ..................................8
+      6.3. iscsiInstance ..............................................9
+      6.4. iscsiPortal ................................................9
+      6.5. iscsiTargetPortal .........................................10
+      6.6. iscsiInitiatorPortal ......................................11
+      6.7. iscsiNode .................................................12
+      6.8. iscsiTarget ...............................................12
+      6.9. iscsiTgtAuthorization .....................................12
+      6.10. iscsiInitiator ...........................................13
+      6.11. iscsiIntrAuthorization ...................................13
+      6.12. iscsiSession .............................................13
+      6.13. iscsiConnection ..........................................14
+      6.14. IP Addresses and TCP Port Numbers ........................14
+      6.15. Descriptors: Using OIDs in Place of Enumerated Types .....15
+      6.16. Notifications ............................................15
+   7. MIB Definition .................................................16
+   8. Security Considerations ........................................88
+   9. IANA Considerations ............................................89
+   10. References ....................................................89
+      10.1. Normative References .....................................89
+      10.2. Informative References ...................................91
+   11. Acknowledgments ...............................................91
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 3]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+1.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to section 7 of
+   RFC 3410 [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB are defined using the mechanisms defined in the
+   Structure of Management Information (SMI).  This memo specifies a MIB
+   module that is compliant to the SMIv2, which is described in STD 58,
+   RFC 2578 [RFC2578], STD 58, RFC 2579 [RFC2579] and STD 58, RFC 2580
+   [RFC2580].
+
+2.  Introduction
+
+   This document defines a MIB module for iSCSI [RFC7143], used to
+   manage devices that implement the iSCSI protocol.  It obsoletes RFC
+   4544 [RFC4544].
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   [RFC2119].
+
+3.  Relationship to Other MIB Modules
+
+   The iSCSI MIB module is normally layered between the SCSI MIB module
+   [RFC4455] and the TCP MIB module [RFC4022], and it makes use of the
+   IP Storage (IPS) Identity Authentication MIB module [RFC4545].  Here
+   is how these modules are related:
+
+   SCSI MIB    Within systems where a SCSI layer is present, each
+               iscsiNode, whether it has an initiator role, target role,
+               or both, is related to one SCSI device within the SCSI
+               MIB module.  In this case, the iscsiNodeTransportType
+               attribute points to the SCSI transport object within the
+               SCSI MIB module, which in turn contains an attribute that
+               points back to the iscsiNode.  In this way, a management
+               station can navigate between the two MIB modules.  In
+               systems where a SCSI layer is not present, such as within
+               an iSCSI proxy device, the iscsiNodeTransportType
+               attribute points to the appropriate corresponding object
+               within the appropriate MIB or is left blank.
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 4]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   TCP MIB     Each iSCSI connection is related to one transport-level
+               connection.  Currently, iSCSI uses only TCP; the iSCSI
+               connection is related to a TCP connection using its
+               normal (protocol, source address, source port,
+               destination address, destination port) 5-tuple.
+
+   AUTH MIB    Each iSCSI node that serves a target role can have a list
+               of authorized initiators.  Each of the entries in this
+               list points to an identity within the IPS Identity
+               Authentication MIB module that will be allowed to access
+               the target.  iSCSI nodes that serve in an initiator role
+               can also have a list of authorized targets.  Each of the
+               entries in this list points to an identity within the
+               IPS-AUTH MIB module to which the initiator should attempt
+               to establish sessions.  The IPS-AUTH MIB module includes
+               information used to identify initiators and targets by
+               their iSCSI name, IP address, and/or credentials.
+
+   This MIB module imports objects from RFCs 2578 [RFC2578], 2579
+   [RFC2579], 2580 [RFC2580], and 3411 [RFC3411].  It also imports
+   textual conventions from the INET-ADDRESS-MIB [RFC4001].
+
+4.  Relationship to SNMP Contexts
+
+   Each non-scalar object in the iSCSI MIB module is indexed first by an
+   iSCSI instance.  Each instance is a collection of nodes, portals,
+   sessions, etc., that can define a physical or virtual partitioning of
+   an iSCSI-capable device.  The use of an instance works well with
+   partitionable or hierarchical storage devices and fits in logically
+   with other management schemes.  Instances do not replace SNMP
+   contexts; however, they do provide a very simple way to assign a
+   virtual or physical partition of a device to one or more SNMP
+   contexts, without having to do so for each individual node, portal,
+   and session row.
+
+5.  Differences from RFC 4544
+
+   [RFC7143] updates several RFCs, including [RFC3720].  This document
+   updates the iSCSI MIB correspondingly.  The document uses
+   iSCSIProtocolLevel as defined in [RFC7144].  It obsoletes [RFC4544].
+   Below is a brief description of the changes.
+
+   -  Added iscsiInstXNodeArchitecture to InstanceAttributes.
+   -  Added iscsiSsnTaskReporting of type BITS to SessionAttributes.
+   -  Added iscsiSsnProtocolLevel to SessionAttributes.
+   -  Deprecated the marker objects.
+   -  Fixed the errata to [RFC4544].
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 5]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   -  Added NOP counters at iSCSI session scope for heartbeat tracking.
+   -  Added port number to the iscsiTgtLoginFailure and
+      iscsiIntrLoginFailure notifications, and to the last failure info
+      in iscsiInitiatorAttributesEntry.
+   -  Added description string to the iSCSI portal.
+   -  Added iscsiInstSsnTgtUnmappedErrors to support "Target Unmapped"
+      session failure reporting in the iscsiInstSessionFailure
+      notification.
+   -  Added iscsiTgtLogoutCxnClosed and iscsiTgtLogoutCxnRemoved, which
+      maintain the count of Logout Command PDUs received by the target
+      with reason codes 1 and 2, respectively.
+   -  Changed the conformance statements to match the above.
+
+6.  Discussion
+
+   This MIB module structure supplies configuration, fault, and
+   statistics information for iSCSI devices [RFC7143].  It is structured
+   around the well-known iSCSI objects, such as targets, initiators,
+   sessions, connections, and the like.
+
+   This MIB module may also be used to configure access to iSCSI
+   targets, by creating iSCSI portals and authorization list entries.
+
+   It is worthwhile to note that this is an iSCSI MIB module and as such
+   reflects only iSCSI objects.  This module does not contain
+   information about the SCSI-layer attributes of a device.  If a SCSI
+   layer is present, the SCSI MIB module [RFC4455] may be used to manage
+   SCSI information for a device.
+
+   The iSCSI MIB module consists of several "objects", each of which is
+   represented by one or more tables.  This section contains a brief
+   description of the object hierarchy and a description of each object,
+   followed by a discussion of the actual table structure within the
+   objects.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 6]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+6.1.  iSCSI MIB Object Model
+
+   The top-level object in this structure is the iSCSI instance, which
+   "contains" all of the other objects.
+
+      iscsiInstance
+         -- A distinct iSCSI entity within the managed system.
+         iscsiPortal
+            -- An IP address used by this instance.
+            iscsiTargetPortal
+               -- Contains portal information relevant when the portal
+               -- is used to listen for connections to its targets.
+            iscsiInitiatorPortal
+               -- Contains portal information relevant when the portal
+               -- is used to initiate connections to other targets.
+         iscsiNode
+            -- An iSCSI node can act as an initiator, a target, or both.
+            -- Contains generic (non-role-specific) information.
+            iscsiTarget
+               -- Target-specific iSCSI node information.
+               iscsiTgtAuth
+                  -- A list of initiator identities that are allowed
+                  -- access to this target.
+            iscsiInitiator
+               -- Initiator-specific iSCSI node information.
+               iscsiIntrAuth
+                  -- A list of target identities to which this initiator
+                  -- is configured to establish sessions.
+            iscsiSession
+               -- An active iSCSI session between an initiator and
+               -- target.  The session's direction may be Inbound
+               -- (an outside initiator to the target represented by
+               -- this node) or Outbound (the initiator represented by
+               -- this node to an outside target).
+               iscsiConnection
+                  -- An active TCP connection within an iSCSI session.
+
+   An iSCSI node can be an initiator, a target, or both.  The iSCSI
+   node's portals may be used to initiate connections (initiator) or
+   listen for connections (target), depending on whether the iSCSI node
+   is acting as an initiator or target.  The iSCSI MIB module assumes
+   that any target may be accessed via any portal that can take on a
+   target role, although other access controls not reflected in the
+   module might limit this.
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 7]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+6.2.  iSCSI MIB Table Structure
+
+   Each iSCSI object exports one or more tables: an attributes table,
+   and zero or more statistics tables, which augment the attributes
+   table.  Since iSCSI is an evolving standard, it is much cleaner to
+   provide statistics and attributes as separate tables, allowing
+   attributes and statistics to be added independently.  In a few cases,
+   there are multiple categories of statistics that will likely grow; in
+   this case, an object will contain multiple statistics tables.
+
+      iscsiObjects
+        iscsiDescriptors
+        iscsiInstance
+          iscsiInstanceAttributesTable
+          iscsiInstanceSsnErrorStatsTable
+            -- Counts abnormal session terminations
+        iscsiPortal
+          iscsiPortalAttributesTable
+        iscsiTargetPortal
+          iscsiTgtPortalAttributesTable
+        iscsiInitiatorPortal
+          iscsiIntrPortalAttributesTable
+        iscsiNode
+          iscsiNodeAttributesTable
+        iscsiTarget
+          iscsiTargetAttributesTable
+          iscsiTargetLoginStatsTable
+            -- Counts successful and unsuccessful logins
+          iscsiTargetLogoutStatsTable
+            -- Counts normal and abnormal logouts
+        iscsiTgtAuthorization
+          iscsiTgtAuthAttributesTable
+        iscsiInitiator
+          iscsiInitiatorAttributesTable
+          iscsiInitiatorLoginStatsTable
+            -- Counts successful and unsuccessful logins
+          iscsiInitiatorLogoutStatsTable
+            -- Counts normal and abnormal logouts
+        iscsiIntrAuthorization
+          iscsiIntrAuthAttributesTable
+        iscsiSession
+          iscsiSessionAttributesTable
+          iscsiSessionStatsTable
+            -- Performance-related counts (requests, responses, bytes)
+          iscsiSessionCxnErrorStatsTable
+            -- Counts digest errors, connection errors, etc.
+        iscsiConnection
+          iscsiConnectionAttributesTable
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 8]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   Note that this module does not attempt to count everything that could
+   be counted; it is designed to include only those counters that would
+   be useful for identifying performance, security, and fault problems
+   from a management station.
+
+6.3.  iscsiInstance
+
+   The iscsiInstanceAttributesTable is the primary table of the iSCSI
+   MIB module.  Every table entry in this module is "owned" by exactly
+   one iSCSI instance; all other table entries in the module include
+   this table's index as their primary index.
+
+   Most implementations will include just one iSCSI instance row in this
+   table.  However, this table exists to allow for multiple virtual
+   instances.  For example, many IP routing products now allow multiple
+   virtual routers.  The iSCSI MIB module has the same premise; a large
+   system could be "partitioned" into multiple, distinct virtual
+   systems.
+
+   This also allows a single SNMP agent to proxy for multiple
+   subsystems, perhaps a set of stackable devices, each of which has one
+   or even more instances.
+
+   The instance attributes include the iSCSI vendor and version, as well
+   as information on the last target or initiator at the other end of a
+   session that caused a session failure.
+
+   The iscsiInstanceSsnErrorStatsTable augments the attributes table and
+   provides statistics on session failures due to digest, connection, or
+   iSCSI format errors.
+
+6.4.  iscsiPortal
+
+   The iscsiPortalAttributesTable lists iSCSI portals that can be used
+   to listen for connections to targets, to initiate connections to
+   other targets, or to do both.
+
+   Each row in the table includes an IP address (either v4 or v6), and a
+   transport protocol (currently only TCP is defined).  Each portal may
+   have additional attributes, depending on whether it is an initiator
+   portal, a target portal, or both.  Initiator portals also have portal
+   tags; these are placed in corresponding rows in the
+   iscsiIntrPortalAttributesTable.  Target portals have both portal tags
+   and ports (e.g., TCP listen ports if the transport protocol is TCP);
+   these are placed in rows in the iscsiTgtPortalAttributesTable.
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                    [Page 9]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   Portal rows, along with their initiator and target portal
+   counterparts, may be created and destroyed through this MIB module by
+   a management station.  Rows in the initiator and target portal tables
+   are created and destroyed automatically by the agent when a row is
+   created or destroyed in the iscsiPortalAttributesTable or when the
+   value of iscsiPortalRoles changes.  Attributes in these tables may
+   then be modified by the management station if the agent
+   implementation allows.
+
+   When created by a management station, the iscsiPortalRoles attribute
+   is used to control row creation in the initiator and target portal
+   tables.  Creating a row with the targetTypePortal bit set in
+   iscsiPortalRoles will cause the implementation to start listening for
+   iSCSI connections on the portal.  Creating a row with the
+   initiatorTypePortal bit set in iscsiPortalRoles will not necessarily
+   cause connections to be established; it is left to the implementation
+   whether and when to make use of the portal.  Both bits may be set if
+   the portal is to be used by both initiator and target nodes.
+
+   When deleting a row in the iscsiPortalAttibutesTable, all connections
+   associated with that row are terminated.  The implementation may
+   either terminate the connection immediately or request a clean
+   shutdown as specified in [RFC7143].  An outbound connection (when an
+   iscsiInitiatorPortal is deleted) matches the portal if its
+   iscsiCxnLocalAddr matches the iscsiPortalAddr.  An inbound connection
+   (when an iscsiTargetPortal is deleted) matches the portal if its
+   iscsiCxnLocalAddr matches the iscsiPortalAddr and if its
+   iscsiCxnLocalPort matches the iscsiTargetPortalPort.
+
+   Individual objects within a row in this table may not be modified
+   while the row is active.  For instance, changing the IP address of a
+   portal requires that the rows associated with the old IP address be
+   deleted and that new rows be created (in either order).
+
+6.5.  iscsiTargetPortal
+
+   The iscsiTgtPortalAttributesTable contains target-specific attributes
+   for iSCSI portals.  Rows in this table use the same indices as their
+   corresponding rows in the iscsiPortalAttributesTable, with the
+   addition of iscsiNodeIndex.
+
+   Rows in this table are created when the targetTypePortal bit is set
+   in the iscsiPortalRoles attribute of the corresponding
+   iscsiPortalAttributesEntry; they are destroyed when this bit is
+   cleared.
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 10]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   This table contains the TCP (or other protocol) port on which the
+   socket is listening for incoming connections.  It also includes a
+   portal group aggregation tag; iSCSI target portals that are within
+   this instance and share the same tag can contain connections within
+   the same session.
+
+   This table will be empty for iSCSI instances that contain only
+   initiators (such as iSCSI host driver implementations).
+
+   Many implementations use the same Target Portal Group Tag and
+   protocol port for all nodes accessed via a portal.  These
+   implementations will create a single row in the
+   iscsiTgtPortalAttributeTable, with an iscsiNodeIndex of zero.
+
+   Other implementations do not use the same tag and/or port for all
+   nodes; these implementations will create a row in this table for each
+   (portal, node) tuple, using iscsiNodeIndex to designate the node for
+   this portal tag and port.
+
+6.6.  iscsiInitiatorPortal
+
+   The iscsiIntrPortalAttributesTable contains initiator-specific
+   objects for iSCSI portals.  Rows in this table use the same indices
+   as their corresponding entries in the iscsiPortalAttributesTable.  A
+   row in this table is created when the initiatorTypePortal bit is set
+   in the iscsiPortalRoles attribute; it is destroyed when this bit is
+   cleared.
+
+   Each row in this table contains a portal group aggregation tag,
+   indicating which portals an initiator may use together within a
+   multiple-connection session.
+
+   This table will be empty for iSCSI instances that contain only
+   targets (such as most iSCSI devices).
+
+   Many implementations use the same initiator tag for all nodes
+   accessing targets via a given portal.  These implementations will
+   create a single row in iscsiIntrPortalAttributeTable, with an
+   iscsiNodeIndex of zero.
+
+   Other implementations do not use the same tag and/or port for all
+   nodes; these implementations will create a row in this table for each
+   (portal, node) tuple, using iscsiNodeIndex to designate the node for
+   this portal tag and port.
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 11]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+6.7.  iscsiNode
+
+   The iscsiNodeAttributesTable contains a list of iSCSI nodes, each of
+   which may have an initiator role, a target role, or both.
+
+   This table contains the node's attributes that are common to both
+   roles, such as its iSCSI name and alias string.  Attributes specific
+   to initiators or targets are available in the iscsiTarget and
+   iscsiInitiator objects.  Each row in this table that can fulfill a
+   target role has a corresponding row in the iscsiTarget table; each
+   entry that fulfills an initiator role has a row in the iscsiInitiator
+   table.  Nodes such as copy managers that can take on both roles have
+   a corresponding row in each table.
+
+   This table also contains the login negotiations preferences for this
+   node.  These objects indicate the values this node will offer or
+   prefer in the operational negotiation phase of the login process.
+
+   For most implementations, each entry in the table also contains a
+   RowPointer to the transport table entry in the SCSI MIB module that
+   this iSCSI node represents.  For implementations without a standard
+   SCSI layer above iSCSI, such as an iSCSI proxy or gateway, this
+   RowPointer can point to a row in an implementation-specific table
+   that this iSCSI node represents.
+
+6.8.  iscsiTarget
+
+   The iscsiTargetAttributesTable contains target-specific attributes
+   for iSCSI nodes.  Each entry in this table uses the same index values
+   as its corresponding iscsiNode entry.
+
+   This table contains attributes used to indicate the last failure that
+   was (or should have been) sent as a notification.
+
+   This table is augmented by the iscsiTargetLoginStatsTable and the
+   iscsiTargetLogoutStatsTable, which count the numbers of normal and
+   abnormal logins and logouts to this target.
+
+6.9.  iscsiTgtAuthorization
+
+   The iscsiTgtAuthAttributesTable contains an entry for each initiator
+   identifier that will be allowed to access the target under which it
+   appears.  Each entry contains a RowPointer to a user identity in the
+   IPS Authorization MIB module, which contains the name, address, and
+   credential information necessary to authenticate the initiator.
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 12]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+6.10.  iscsiInitiator
+
+   The iscsiInitiatorAttributesTable contains a list of initiator-
+   specific attributes for iSCSI nodes.  Each entry in this table uses
+   the same index values as its corresponding iscsiNode entry.
+
+   Most implementations will include a single entry in this table,
+   regardless of the number of physical interfaces the initiator may
+   use.
+
+   This table is augmented by the iscsiInitiatorLoginStatsTable and the
+   iscsiInitiatorLogoutStatsTable, which count the numbers of normal and
+   abnormal logins and logouts from this initiator.
+
+6.11.  iscsiIntrAuthorization
+
+   The iscsiIntrAuthAttributesTable contains an entry for each target
+   identifier to which the initiator is configured to establish a
+   session.
+
+   Each entry contains a RowPointer to a user identity in the IPS
+   Authorization MIB module, which contains the name, address, and
+   credential information necessary to identify (for discovery purposes)
+   and authenticate the target.
+
+6.12.  iscsiSession
+
+   The iscsiSessionAttributesTable contains a set of rows that list the
+   sessions known to exist locally for each node in each iSCSI instance.
+
+   The session type for each session indicates whether the session is
+   used for normal SCSI commands or for discovery using the SendTargets
+   text command.  Discovery sessions that do not belong to any
+   particular node have a node index attribute of zero.
+
+   The session direction for each session indicates whether it is an
+   Inbound session or an Outbound session.  Inbound sessions are from
+   some other initiator to the target node under which the session
+   appears.  Outbound sessions are from the initiator node under which
+   the session appears to a target outside this iSCSI instance.
+
+   Many attributes may be negotiated when starting an iSCSI session.
+   Most of these attributes are included in the session object.
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 13]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   Some attributes, such as the integrity and authentication schemes,
+   have some standard values that can be extended by vendors to include
+   their own schemes.  These contain an object identifier, rather than
+   the expected enumerated type, to allow these values to be extended by
+   other MIB modules, such as an enterprise MIB module.
+
+   The iscsiSessionStatsTable includes statistics related to
+   performance; it counts iSCSI data bytes and PDUs.
+
+   For implementations that support error recovery without terminating a
+   session, the iscsiSessionCxnErrorStatsTable contains counters for the
+   numbers of digest and connection errors that have occurred within the
+   session.
+
+6.13.  iscsiConnection
+
+   The iscsiConnectionAttributesTable contains a list of active
+   connections within each session.  It contains the IP addresses and
+   TCP (or other protocol) ports of both the local and remote sides of
+   the connection.  These may be used to locate other connection-related
+   information and statistics in the TCP MIB module [RFC4022].
+
+   The attributes table also contains a connection state.  This state is
+   not meant to directly map to the state tables included within the
+   iSCSI specification; they are meant to be simplified, higher-level
+   definitions of connection state that provide information more useful
+   to a user or network manager.
+
+   No statistics are kept for connections.
+
+6.14.  IP Addresses and TCP Port Numbers
+
+   The IP addresses in this module are represented by two attributes,
+   one of type InetAddressType, and the other of type InetAddress.
+   These are taken from [RFC4001], which specifies how to support
+   addresses that may be either IPv4 or IPv6.
+
+   The TCP port numbers that appear in a few of the structures are
+   described as simply port numbers, with a protocol attribute
+   indicating whether they are TCP ports or something else.  This will
+   allow the module to be compatible with iSCSI over transports other
+   than TCP in the future.
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 14]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+6.15.  Descriptors: Using OIDs in Place of Enumerated Types
+
+   The iSCSI MIB module has a few attributes, namely, the digest method
+   attributes, where an enumerated type would work well, except that an
+   implementation may need to extend the attribute and add types of its
+   own.  To make this work, this MIB module defines a set of object
+   identities within the iscsiDescriptors subtree.  Each of these object
+   identities is basically an enumerated type.
+
+   Attributes that make use of these object identities have a value that
+   is an Object Identifier (OID) instead of an enumerated type.  These
+   OIDs can indicate either the object identities defined in this module
+   or object identities defined elsewhere, such as in an enterprise MIB
+   module.  Those implementations that add their own digest methods
+   should also define a corresponding object identity for each of these
+   methods within their own enterprise MIB module, and return its OID
+   whenever one of these attributes is using that method.
+
+6.16.  Notifications
+
+   Three notifications are provided.  One is sent by an initiator
+   detecting a critical login failure, another is sent by a target
+   detecting a critical login failure, and the third is sent upon a
+   session being terminated due to an abnormal connection or digest
+   failure.  Critical failures are defined as those that may expose
+   security-related problems that may require immediate action, such as
+   failures due to authentication, authorization, or negotiation
+   problems.  Attributes in the initiator, target, and instance objects
+   provide the information necessary to send in the notification, such
+   as the initiator or target name and IP address at the other end that
+   may have caused the failure.
+
+   To avoid sending an excessive number of notifications due to multiple
+   errors counted, an SNMP agent implementing the iSCSI MIB module
+   SHOULD NOT send more than three iSCSI notifications in any 10-second
+   period.
+
+   The 3-in-10 rule was chosen because one notification every three
+   seconds was deemed often enough, but should two or three different
+   notifications happen at the same time, it would not be desirable to
+   suppress them.  Three notifications in 10 seconds is a happy medium,
+   where a short burst of notifications is allowed, without inundating
+   the network and/or notification host with a large number of
+   notifications.
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 15]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+7.  MIB Definition
+
+ISCSI-MIB DEFINITIONS  ::= BEGIN
+
+    IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, OBJECT-IDENTITY, NOTIFICATION-TYPE,
+    Unsigned32, Counter32, Counter64, Gauge32,
+    mib-2
+    FROM SNMPv2-SMI
+
+    TEXTUAL-CONVENTION, TruthValue, RowPointer, TimeStamp, RowStatus,
+    AutonomousType, StorageType
+    FROM SNMPv2-TC
+
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+    FROM SNMPv2-CONF
+
+    SnmpAdminString
+    FROM SNMP-FRAMEWORK-MIB -- RFC 3411
+
+    InetAddressType, InetAddress, InetPortNumber
+    FROM INET-ADDRESS-MIB -- RFC 4001
+    ;
+
+iscsiMibModule MODULE-IDENTITY
+    LAST-UPDATED "201402180000Z" -- February 18, 2014
+    ORGANIZATION "IETF STORage Maintenance (STORM) Working Group"
+
+    CONTACT-INFO "
+        Working Group Email: storm@ietf.org
+        Attn: Mark Bakke
+              Dell
+              Email: mark_bakke@dell.com
+
+              Prakash Venkatesen
+              HCL Technologies
+              Email: prakashvn@hcl.com"
+
+    DESCRIPTION
+        "This module defines management information specific
+         to the iSCSI protocol.
+
+         Copyright (c) 2014 IETF Trust and the persons identified as
+         authors of the code.  All rights reserved.
+
+         Redistribution and use in source and binary forms, with or
+         without modification, is permitted pursuant to, and subject
+         to the license terms contained in, the Simplified BSD
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 16]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+         License set forth in Section 4.c of the IETF Trust's Legal
+         Provisions Relating to IETF Documents
+         (http://trustee.ietf.org/license-info)."
+    REVISION    "201402180000Z"
+    DESCRIPTION
+        "Second version of the iSCSI Protocol MIB Module.
+         RFC 7143 makes several updates to [RFC3720].  This
+         version makes corresponding updates to the MIB module.
+         This MIB module published as RFC 7147."
+    REVISION "200605220000Z"
+    DESCRIPTION
+        "Initial version of the iSCSI Protocol MIB module.
+         This MIB module published as RFC 4544."
+
+::= { mib-2 142 }
+
+iscsiNotifications OBJECT IDENTIFIER ::= { iscsiMibModule 0 }
+iscsiObjects       OBJECT IDENTIFIER ::= { iscsiMibModule 1 }
+iscsiConformance   OBJECT IDENTIFIER ::= { iscsiMibModule 2 }
+iscsiAdmin         OBJECT IDENTIFIER ::= { iscsiMibModule 3 }
+
+-- Textual Conventions
+
+IscsiTransportProtocol ::= TEXTUAL-CONVENTION
+
+    DISPLAY-HINT  "d"
+    STATUS        current
+    DESCRIPTION
+        "This data type is used to define the transport
+        protocols that will carry iSCSI PDUs.
+        Protocol numbers are assigned by IANA.  A
+        current list of all assignments is available from
+        <http://www.iana.org/assignments/protocol-numbers/>."
+    SYNTAX        Unsigned32 (0..255)
+
+IscsiDigestMethod ::= TEXTUAL-CONVENTION
+    STATUS        current
+    DESCRIPTION
+        "This data type represents the methods possible
+        for digest negotiation.
+        none     - a placeholder for a secondary digest method
+                   that means only the primary method can be
+                   used.
+        other    - a digest method other than those defined below.
+        noDigest - does not support digests (will operate without
+                   a digest (Note: implementations must support
+                   digests to be compliant with RFC 7143).
+        CRC32c   - require a CRC32C digest."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 17]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+    SYNTAX        INTEGER {
+                      none(1),
+                      other(2),
+                      noDigest(3),
+                      crc32c(4)
+                  }
+
+IscsiName ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT  "223t"
+    STATUS        current
+    DESCRIPTION
+        "This data type is used for objects whose value is an
+        iSCSI name with the properties described in RFC 7143,
+        Section 4.2.7.1, and encoded as specified in RFC 7143,
+        Section 4.2.7.2.  A zero-length string indicates the
+        absence of an iSCSI name."
+    REFERENCE
+        "RFC 7143, Section 4.2.7, iSCSI Names."
+    SYNTAX        OCTET STRING (SIZE(0 | 16..223))
+
+--**********************************************************************
+
+iscsiDescriptors OBJECT IDENTIFIER ::= { iscsiAdmin 1 }
+
+iscsiHeaderIntegrityTypes OBJECT IDENTIFIER ::= { iscsiDescriptors 1 }
+
+iscsiHdrIntegrityNone OBJECT-IDENTITY
+    STATUS      current
+    DESCRIPTION
+        "The authoritative identifier when no integrity
+        scheme for the header is being used."
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+::= { iscsiHeaderIntegrityTypes 1 }
+
+iscsiHdrIntegrityCrc32c OBJECT-IDENTITY
+    STATUS      current
+    DESCRIPTION
+        "The authoritative identifier when the integrity
+        scheme for the header is CRC32c."
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+::= { iscsiHeaderIntegrityTypes 2 }
+
+iscsiDataIntegrityTypes OBJECT IDENTIFIER ::= { iscsiDescriptors 2 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 18]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiDataIntegrityNone OBJECT-IDENTITY
+    STATUS      current
+    DESCRIPTION
+        "The authoritative identifier when no integrity
+        scheme for the data is being used."
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+::= { iscsiDataIntegrityTypes 1 }
+
+iscsiDataIntegrityCrc32c OBJECT-IDENTITY
+    STATUS      current
+    DESCRIPTION
+        "The authoritative identifier when the integrity
+        scheme for the data is CRC32c."
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+::= { iscsiDataIntegrityTypes 2 }
+
+--**********************************************************************
+
+iscsiInstance OBJECT IDENTIFIER ::= { iscsiObjects 1 }
+
+-- Instance Attributes Table
+
+iscsiInstanceAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiInstanceAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of iSCSI instances present on the system."
+::= { iscsiInstance 1 }
+
+iscsiInstanceAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiInstanceAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular iSCSI instance."
+    INDEX { iscsiInstIndex }
+::= { iscsiInstanceAttributesTable 1 }
+
+IscsiInstanceAttributesEntry ::= SEQUENCE {
+    iscsiInstIndex                 Unsigned32,
+    iscsiInstDescr                 SnmpAdminString,
+    iscsiInstVersionMin            Unsigned32,
+    iscsiInstVersionMax            Unsigned32,
+    iscsiInstVendorID              SnmpAdminString,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 19]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiInstVendorVersion         SnmpAdminString,
+    iscsiInstPortalNumber          Unsigned32,
+    iscsiInstNodeNumber            Unsigned32,
+    iscsiInstSessionNumber         Unsigned32,
+    iscsiInstSsnFailures           Counter32,
+    iscsiInstLastSsnFailureType    AutonomousType,
+    iscsiInstLastSsnRmtNodeName    IscsiName,
+    iscsiInstDiscontinuityTime     TimeStamp,
+    iscsiInstXNodeArchitecture     SnmpAdminString
+}
+
+iscsiInstIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a particular
+        iSCSI instance.  This index value must not be modified or
+        reused by an agent unless a reboot has occurred.  An agent
+        should attempt to keep this value persistent across reboots."
+::= { iscsiInstanceAttributesEntry 1 }
+
+iscsiInstDescr OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string, determined by the implementation to
+        describe the iSCSI instance.  When only a single instance
+        is present, this object may be set to the zero-length
+        string; with multiple iSCSI instances, it may be used in
+        an implementation-dependent manner to describe the purpose
+        of the respective instance."
+
+::= { iscsiInstanceAttributesEntry 2 }
+
+iscsiInstVersionMin OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..255)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The minimum version number of the iSCSI specification
+        such that this iSCSI instance supports this minimum
+        value, the maximum value indicated by the corresponding
+        instance in iscsiInstVersionMax, and all versions in
+        between."
+    REFERENCE
+        "RFC 7143, Section 11.12, Login Request"
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 20]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+::= { iscsiInstanceAttributesEntry 3 }
+
+iscsiInstVersionMax OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..255)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum version number of the iSCSI specification
+        such that this iSCSI instance supports this maximum
+        value, the minimum value indicated by the corresponding
+        instance in iscsiInstVersionMin, and all versions in
+        between."
+    REFERENCE
+        "RFC 7143, Section 11.12, Login Request"
+::= { iscsiInstanceAttributesEntry 4 }
+
+iscsiInstVendorID OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string describing the manufacturer of the
+        implementation of this instance."
+::= { iscsiInstanceAttributesEntry 5 }
+
+iscsiInstVendorVersion OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string set by the manufacturer describing the
+        version of the implementation of this instance.  The
+        format of this string is determined solely by the
+        manufacturer; the string is for informational purposes only.
+        It is unrelated to the iSCSI specification version numbers."
+::= { iscsiInstanceAttributesEntry 6 }
+
+iscsiInstPortalNumber OBJECT-TYPE
+    SYNTAX        Unsigned32
+    UNITS         "transport endpoints"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of rows in the iscsiPortalAttributesTable
+        that are currently associated with this iSCSI instance."
+::= { iscsiInstanceAttributesEntry 7 }
+
+iscsiInstNodeNumber OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 21]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        Unsigned32
+    UNITS         "iSCSI nodes"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of rows in the iscsiNodeAttributesTable
+        that are currently associated with this iSCSI instance."
+::= { iscsiInstanceAttributesEntry 8 }
+
+iscsiInstSessionNumber OBJECT-TYPE
+    SYNTAX        Unsigned32
+    UNITS         "sessions"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of rows in the iscsiSessionAttributesTable
+        that are currently associated with this iSCSI instance."
+::= { iscsiInstanceAttributesEntry 9 }
+
+iscsiInstSsnFailures  OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "sessions"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object counts the number of times a session belonging
+        to this instance has failed.  If this counter has
+        suffered a discontinuity, the time of the last discontinuity
+        is indicated in iscsiInstDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 13.1, HeaderDigest and DataDigest"
+::= { iscsiInstanceAttributesEntry 10 }
+
+iscsiInstLastSsnFailureType  OBJECT-TYPE
+    SYNTAX        AutonomousType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The counter object in the iscsiInstanceSsnErrorStatsTable
+        that was incremented when the last session failure occurred.
+
+        If the reason for failure is not found in the
+        iscsiInstanceSsnErrorStatsTable, the value { 0.0 } is
+        used instead."
+::= { iscsiInstanceAttributesEntry 11 }
+
+iscsiInstLastSsnRmtNodeName  OBJECT-TYPE
+    SYNTAX        IscsiName
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 22]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The iSCSI name of the remote node from the failed
+        session."
+::= { iscsiInstanceAttributesEntry 12 }
+
+iscsiInstDiscontinuityTime  OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The value of SysUpTime on the most recent occasion
+        at which any one or more of this instance's counters
+        suffered a discontinuity.
+
+        If no such discontinuities have occurred since the last
+        re-initialization of the local management subsystem,
+        then this object contains a zero value."
+::= { iscsiInstanceAttributesEntry 13 }
+
+iscsiInstXNodeArchitecture OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string set by the manufacturer declaring the
+        details of its iSCSI node architecture to the remote
+        endpoint.  These details may include, but are not limited
+        to, iSCSI vendor software, firmware, or hardware versions,
+        the OS version, or hardware architecture.
+        The format of this string is determined solely by the
+        manufacturer; the string is for informational purposes only.
+        It is unrelated to the iSCSI specification version numbers."
+    REFERENCE
+        "RFC 7143, Section 13.26, X#NodeArchitecture"
+::= { iscsiInstanceAttributesEntry 14 }
+
+-- Instance Session Failure Stats Table
+
+iscsiInstanceSsnErrorStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiInstanceSsnErrorStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "Statistics regarding the occurrences of error types
+        that result in a session failure."
+::= { iscsiInstance 2 }
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 23]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiInstanceSsnErrorStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiInstanceSsnErrorStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular iSCSI instance."
+    AUGMENTS { iscsiInstanceAttributesEntry }
+::= { iscsiInstanceSsnErrorStatsTable 1 }
+
+IscsiInstanceSsnErrorStatsEntry ::= SEQUENCE {
+    iscsiInstSsnDigestErrors       Counter32,
+    iscsiInstSsnCxnTimeoutErrors   Counter32,
+    iscsiInstSsnFormatErrors       Counter32,
+    iscsiInstSsnTgtUnmappedErrors  Counter32
+}
+
+iscsiInstSsnDigestErrors OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "sessions"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of sessions that failed due to receipt of
+        a PDU containing header or data digest errors.  If this
+        counter has suffered a discontinuity, the time of the last
+        discontinuity is indicated in iscsiInstDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 7.8, Digest Errors"
+::= { iscsiInstanceSsnErrorStatsEntry 1 }
+
+iscsiInstSsnCxnTimeoutErrors OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "sessions"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of sessions that failed due to a sequence
+        exceeding a time limit.  If this counter has suffered a
+        discontinuity, the time of the last discontinuity
+        is indicated in iscsiInstDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 7.5, Connection Timeout Management"
+::= { iscsiInstanceSsnErrorStatsEntry 2 }
+
+iscsiInstSsnFormatErrors OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "sessions"
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 24]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of sessions that failed due to receipt of
+        a PDU that contained a format error.  If this counter has
+        suffered a discontinuity, the time of the last discontinuity
+        is indicated in iscsiInstDiscontinuityTime."
+    REFERENCE
+        "RFC 7143 Section 7.7, Format Errors"
+::= { iscsiInstanceSsnErrorStatsEntry 3 }
+
+iscsiInstSsnTgtUnmappedErrors OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "sessions"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of sessions that failed due to the target
+        becoming unmapped.  If this counter has
+        suffered a discontinuity, the time of the last discontinuity
+        is indicated in iscsiInstDiscontinuityTime."
+::= { iscsiInstanceSsnErrorStatsEntry 4 }
+--**********************************************************************
+
+iscsiPortal OBJECT IDENTIFIER ::= { iscsiObjects 2 }
+
+-- Portal Attributes Table
+
+iscsiPortalAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of transport endpoints (using TCP or another transport
+        protocol) used by this iSCSI instance.  An iSCSI instance may
+        use a portal to listen for incoming connections to its targets,
+        to initiate connections to other targets, or both."
+::= { iscsiPortal 1 }
+
+iscsiPortalAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular portal instance."
+    INDEX { iscsiInstIndex, iscsiPortalIndex  }
+::= { iscsiPortalAttributesTable 1 }
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 25]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+IscsiPortalAttributesEntry ::= SEQUENCE {
+    iscsiPortalIndex                 Unsigned32,
+    iscsiPortalRowStatus             RowStatus,
+    iscsiPortalRoles                 BITS,
+    iscsiPortalAddrType              InetAddressType,
+    iscsiPortalAddr                  InetAddress,
+    iscsiPortalProtocol              IscsiTransportProtocol,
+    iscsiPortalMaxRecvDataSegLength  Unsigned32,
+    iscsiPortalPrimaryHdrDigest      IscsiDigestMethod,
+    iscsiPortalPrimaryDataDigest     IscsiDigestMethod,
+    iscsiPortalSecondaryHdrDigest    IscsiDigestMethod,
+    iscsiPortalSecondaryDataDigest   IscsiDigestMethod,
+    iscsiPortalRecvMarker            TruthValue,
+    iscsiPortalStorageType           StorageType,
+    iscsiPortalDescr                 SnmpAdminString
+}
+
+iscsiPortalIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a particular
+        transport endpoint within this iSCSI instance.  This index
+        value must not be modified or reused by an agent unless a
+        reboot has occurred.  An agent should attempt to keep this
+        value persistent across reboots."
+::= { iscsiPortalAttributesEntry 1 }
+
+iscsiPortalRowStatus OBJECT-TYPE
+    SYNTAX        RowStatus
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "This field allows entries to be dynamically added and
+        removed from this table via SNMP.  When adding a row to
+        this table, all non-Index/RowStatus objects must be set.
+        When the value of this object is 'active', the values of
+        the other objects in this table cannot be changed.
+        Rows may be discarded using RowStatus.
+
+        Note that creating a row in this table will typically
+        cause the agent to create one or more rows in the
+        iscsiTgtPortalAttributesTable and/or the
+        iscsiIntrPortalAttributesTable."
+::= { iscsiPortalAttributesEntry 2 }
+
+iscsiPortalRoles OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 26]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        BITS {
+                      targetTypePortal(0),
+                      initiatorTypePortal(1)
+                  }
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "A portal can operate in one or both of two roles:
+        as a target portal and/or an initiator portal.  If
+        the portal will operate in both roles, both bits
+        must be set.
+
+        This object will define a corresponding row that
+        will exist or must be created in the
+        iscsiTgtPortalAttributesTable, the
+        iscsiIntrPortalAttributesTable, or both.  If the
+        targetTypePortal bit is set, one or more corresponding
+        iscsiTgtPortalAttributesEntry rows will be found or
+        created.  If the initiatorTypePortal bit is set,
+        one or more corresponding iscsiIntrPortalAttributesEntry
+        rows will be found or created.  If both bits are set, one
+        or more corresponding rows will be found or created in
+        one of the above tables."
+::= { iscsiPortalAttributesEntry 3 }
+
+iscsiPortalAddrType OBJECT-TYPE
+    SYNTAX        InetAddressType
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The type of Internet Network Address contained in the
+        corresponding instance of the iscsiPortalAddr."
+    DEFVAL        { ipv4 }
+::= { iscsiPortalAttributesEntry 4 }
+
+iscsiPortalAddr OBJECT-TYPE
+    SYNTAX        InetAddress
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The portal's Internet Network Address, of the type
+        specified by the object iscsiPortalAddrType.  If
+        iscsiPortalAddrType has the value 'dns', this address
+        gets resolved to an IP address whenever a new iSCSI
+        connection is established using this portal."
+::= { iscsiPortalAttributesEntry 5 }
+
+iscsiPortalProtocol OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 27]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        IscsiTransportProtocol
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The portal's transport protocol."
+    DEFVAL        { 6 } -- TCP
+::= { iscsiPortalAttributesEntry 6 }
+
+iscsiPortalMaxRecvDataSegLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The maximum PDU length this portal can receive.
+        This may be constrained by hardware characteristics,
+        and individual implementations may choose not to
+        allow this object to be changed."
+    REFERENCE
+        "RFC 7143, Section 13.12, MaxRecvDataSegmentLength"
+    DEFVAL { 8192 }
+::= { iscsiPortalAttributesEntry 7 }
+
+iscsiPortalPrimaryHdrDigest OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The preferred header digest for this portal."
+    DEFVAL        { crc32c }
+::= { iscsiPortalAttributesEntry 8 }
+
+iscsiPortalPrimaryDataDigest OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The preferred data digest method for this portal."
+    DEFVAL        { crc32c }
+::= { iscsiPortalAttributesEntry 9 }
+
+iscsiPortalSecondaryHdrDigest OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "An alternate header digest preference for this portal."
+    DEFVAL        { noDigest }
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 28]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+::= { iscsiPortalAttributesEntry 10 }
+
+iscsiPortalSecondaryDataDigest OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "An alternate data digest preference for this portal."
+    DEFVAL        { noDigest }
+::= { iscsiPortalAttributesEntry 11 }
+
+iscsiPortalRecvMarker OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-create
+    STATUS        deprecated
+    DESCRIPTION
+        "This object indicates whether or not this portal will
+        request markers in its incoming data stream."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+    DEFVAL        { false }
+::= { iscsiPortalAttributesEntry 12 }
+
+iscsiPortalStorageType OBJECT-TYPE
+    SYNTAX        StorageType
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The storage type for this row.  Rows in this table that were
+         created through an external process (e.g., not created via
+         this MIB) may have a storage type of readOnly or permanent.
+
+         Conceptual rows having the value 'permanent' need not
+         allow write access to any columnar objects in the row."
+    DEFVAL        { nonVolatile }
+::= { iscsiPortalAttributesEntry 13 }
+
+iscsiPortalDescr OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string, determined by the implementation to
+        describe the iSCSI portal.  When only a single instance
+        is present, this object may be set to the zero-length
+        string; with multiple iSCSI portals, it may be used in
+        an implementation-dependent manner to describe the
+        respective portal, and could include information such as
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 29]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        Host Bus Adapter (HBA) model, description, and version, or
+        software driver and version."
+::= { iscsiPortalAttributesEntry 14 }
+
+--**********************************************************************
+iscsiTargetPortal OBJECT IDENTIFIER ::= { iscsiObjects 3 }
+
+-- Target Portal Attributes Table
+
+iscsiTgtPortalAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiTgtPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of transport endpoints (using TCP or another transport
+        protocol) on which this iSCSI instance listens for incoming
+        connections to its targets."
+::= { iscsiTargetPortal 1 }
+
+iscsiTgtPortalAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiTgtPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular portal instance that is used to listen for
+        incoming connections to local targets.  One or more rows in
+        this table is populated by the agent for each
+        iscsiPortalAttributesEntry row that has the bit
+        targetTypePortal set in its iscsiPortalRoles column."
+    INDEX { iscsiInstIndex, iscsiPortalIndex,
+            iscsiTgtPortalNodeIndexOrZero  }
+::= { iscsiTgtPortalAttributesTable 1 }
+
+IscsiTgtPortalAttributesEntry ::= SEQUENCE {
+    iscsiTgtPortalNodeIndexOrZero  Unsigned32,
+    iscsiTgtPortalPort             InetPortNumber,
+    iscsiTgtPortalTag              Unsigned32
+}
+
+iscsiTgtPortalNodeIndexOrZero OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular node within an iSCSI instance present
+        on the local system.
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 30]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        For implementations where each {portal, node} tuple
+        can have a different portal tag, this value will
+        map to the iscsiNodeIndex.
+
+        For implementations where the portal tag is the
+        same for a given portal regardless of which node
+        is using the portal, the value 0 (zero) is used."
+::= { iscsiTgtPortalAttributesEntry 1 }
+
+iscsiTgtPortalPort OBJECT-TYPE
+    SYNTAX        InetPortNumber (1..65535)
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The portal's transport protocol port number on which the
+        portal listens for incoming iSCSI connections when the
+        portal is used as a target portal.  This object's storage
+        type is specified in iscsiPortalStorageType."
+::= { iscsiTgtPortalAttributesEntry 2 }
+
+iscsiTgtPortalTag OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The portal's aggregation tag when the portal is used as
+        a target portal.  Multiple-connection sessions may
+        be aggregated over portals sharing an identical
+        aggregation tag.  This object's storage type is
+        specified in iscsiPortalStorageType."
+    REFERENCE
+        "RFC 7143, Section 4.4.1, iSCSI Architecture Model"
+::= { iscsiTgtPortalAttributesEntry 3 }
+
+--**********************************************************************
+
+iscsiInitiatorPortal OBJECT IDENTIFIER ::= { iscsiObjects 4 }
+
+-- Initiator Portal Attributes Table
+
+iscsiIntrPortalAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiIntrPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of Internet Network Addresses (using TCP or another
+        transport protocol) from which this iSCSI instance may
+        initiate connections to other targets."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 31]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+::= { iscsiInitiatorPortal 1 }
+
+iscsiIntrPortalAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiIntrPortalAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular portal instance that is used to initiate
+        connections to iSCSI targets.  One or more rows in
+        this table is populated by the agent for each
+        iscsiPortalAttributesEntry row that has the bit
+        initiatorTypePortal set in its iscsiPortalRoles column."
+    INDEX { iscsiInstIndex, iscsiPortalIndex,
+            iscsiIntrPortalNodeIndexOrZero  }
+::= { iscsiIntrPortalAttributesTable 1 }
+
+IscsiIntrPortalAttributesEntry ::= SEQUENCE {
+    iscsiIntrPortalNodeIndexOrZero Unsigned32,
+    iscsiIntrPortalTag             Unsigned32
+}
+
+iscsiIntrPortalNodeIndexOrZero OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular node within an iSCSI instance present
+        on the local system.
+
+        For implementations where each {portal, node} tuple
+        can have a different portal tag, this value will
+        map to the iscsiNodeIndex.
+
+        For implementations where the portal tag is the
+        same for a given portal regardless of which node
+        is using the portal, the value 0 (zero) is used."
+::= { iscsiIntrPortalAttributesEntry 1 }
+
+iscsiIntrPortalTag OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The portal's aggregation tag when the portal is used as
+        an initiator portal.  Multiple-connection sessions may
+        be aggregated over portals sharing an identical
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 32]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        aggregation tag.  This object's storage type is
+        specified in iscsiPortalStorageType."
+    REFERENCE
+        "RFC 7143, Section 4.4.1, iSCSI Architecture Model"
+::= { iscsiIntrPortalAttributesEntry 2 }
+
+--**********************************************************************
+
+iscsiNode OBJECT IDENTIFIER ::= { iscsiObjects 5 }
+
+-- Node Attributes Table
+
+iscsiNodeAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiNodeAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of iSCSI nodes belonging to each iSCSI instance
+        present on the local system.  An iSCSI node can act as
+        an initiator, a target, or both."
+::= { iscsiNode 1 }
+
+iscsiNodeAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiNodeAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A conceptual row containing management information
+        applicable to a particular iSCSI node."
+    INDEX { iscsiInstIndex, iscsiNodeIndex }
+::= { iscsiNodeAttributesTable 1 }
+
+IscsiNodeAttributesEntry ::= SEQUENCE {
+    iscsiNodeIndex                  Unsigned32,
+    iscsiNodeName                   IscsiName,
+    iscsiNodeAlias                  SnmpAdminString,
+    iscsiNodeRoles                  BITS,
+    iscsiNodeTransportType          RowPointer,
+    iscsiNodeInitialR2T             TruthValue,
+    iscsiNodeImmediateData          TruthValue,
+    iscsiNodeMaxOutstandingR2T      Unsigned32,
+    iscsiNodeFirstBurstLength       Unsigned32,
+    iscsiNodeMaxBurstLength         Unsigned32,
+    iscsiNodeMaxConnections         Unsigned32,
+    iscsiNodeDataSequenceInOrder    TruthValue,
+    iscsiNodeDataPDUInOrder         TruthValue,
+    iscsiNodeDefaultTime2Wait       Unsigned32,
+    iscsiNodeDefaultTime2Retain     Unsigned32,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 33]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiNodeErrorRecoveryLevel     Unsigned32,
+    iscsiNodeDiscontinuityTime      TimeStamp,
+    iscsiNodeStorageType            StorageType
+}
+
+iscsiNodeIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a particular
+        node within an iSCSI instance.  This index value must not be
+        modified or reused by an agent unless a reboot has occurred.
+        An agent should attempt to keep this value persistent across
+        reboots."
+::= { iscsiNodeAttributesEntry 1 }
+
+iscsiNodeName OBJECT-TYPE
+    SYNTAX        IscsiName
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This node's iSCSI name, which is independent of the location
+        of the node, and can be resolved into a set of addresses
+        through various discovery services."
+::= { iscsiNodeAttributesEntry 2 }
+
+iscsiNodeAlias OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A character string that is a human-readable name or
+        description of the iSCSI node.  If configured, this alias
+        may be communicated to the initiator or target node at
+        the remote end of the connection during a Login Request
+        or Response message.  This string is not used as an
+        identifier, but it can be displayed by the system's user
+        interface in a list of initiators and/or targets to
+        which it is connected.
+
+        If no alias exists, the value is a zero-length string."
+    REFERENCE
+        "RFC 7143, Sections 13.6 (TargetAlias) and 13.7
+        (InitiatorAlias)"
+::= { iscsiNodeAttributesEntry 3 }
+
+iscsiNodeRoles OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 34]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        BITS {
+                      targetTypeNode(0),
+                      initiatorTypeNode(1)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A node can operate in one or both of two roles:
+        a target role and/or an initiator role.  If the node
+        will operate in both roles, both bits must be set.
+
+        This object will also define the corresponding rows that
+        will exist in the iscsiTargetAttributesTable, the
+        iscsiInitiatorAttributesTable, or both.  If the
+        targetTypeNode bit is set, there will be a corresponding
+        iscsiTargetAttributesEntry.  If the initiatorTypeNode bit
+        is set, there will be a corresponding
+        iscsiInitiatorAttributesEntry.  If both bits are set,
+        there will be a corresponding iscsiTgtPortalAttributesEntry
+        and iscsiPortalAttributesEntry."
+::= { iscsiNodeAttributesEntry 4 }
+
+iscsiNodeTransportType OBJECT-TYPE
+    SYNTAX        RowPointer
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A pointer to the corresponding row in the appropriate
+        table for this SCSI transport, thereby allowing management
+        stations to locate the SCSI-level device that is represented
+        by this iscsiNode.  For example, it will usually point to the
+        corresponding scsiTrnspt object in the SCSI MIB module.
+        If no corresponding row exists, the value 0.0 must be
+        used to indicate this."
+    REFERENCE
+        "SCSI-MIB, RFC 4455, Section 9, Object Definitions,
+        scsiTransportTypes"
+::= { iscsiNodeAttributesEntry 5 }
+
+iscsiNodeInitialR2T OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object indicates the InitialR2T preference for this
+        node:
+        true = YES,
+        false = will try to negotiate NO, will accept YES "
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 35]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    REFERENCE
+        "RFC 7143, Section 13.10, InitialR2T"
+::= { iscsiNodeAttributesEntry 6 }
+
+iscsiNodeImmediateData OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "This object indicates ImmediateData preference for this
+        node:
+        true = YES (but will accept NO),
+        false = NO "
+    REFERENCE
+        "RFC 7143, Section 13.11, ImmediateData"
+    DEFVAL        { true }
+::= { iscsiNodeAttributesEntry 7 }
+
+iscsiNodeMaxOutstandingR2T OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    UNITS         "R2Ts"
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "Maximum number of outstanding requests-to-transmit (R2Ts)
+        allowed per iSCSI task."
+    REFERENCE
+        "RFC 7143, Section 13.17, MaxOutstandingR2T"
+    DEFVAL        { 1 }
+::= { iscsiNodeAttributesEntry 8 }
+
+iscsiNodeFirstBurstLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The maximum length (bytes) supported for unsolicited data
+        to/from this node."
+    REFERENCE
+        "RFC 7143, Section 13.14, FirstBurstLength"
+    DEFVAL        { 65536 }
+::= { iscsiNodeAttributesEntry 9 }
+
+iscsiNodeMaxBurstLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-write
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 36]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    STATUS        current
+    DESCRIPTION
+     "The maximum number of bytes that can be sent within
+     a single sequence of Data-In or Data-Out PDUs."
+    REFERENCE
+        "RFC 7143, Section 13.13, MaxBurstLength"
+    DEFVAL        { 262144 }
+::= { iscsiNodeAttributesEntry 10 }
+
+iscsiNodeMaxConnections OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    UNITS         "connections"
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The maximum number of connections allowed in each
+        session to and/or from this node."
+    REFERENCE
+        "RFC 7143, Section 13.2, MaxConnections"
+    DEFVAL        { 1 }
+::= { iscsiNodeAttributesEntry 11 }
+
+iscsiNodeDataSequenceInOrder OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The DataSequenceInOrder preference of this node.
+        False (=No) indicates that iSCSI data PDU sequences may
+        be transferred in any order.  True (=Yes) indicates that
+        data PDU sequences must be transferred using
+        continuously increasing offsets, except during
+        error recovery."
+    REFERENCE
+        "RFC 7143, Section 13.19, DataSequenceInOrder"
+    DEFVAL        { true }
+::= { iscsiNodeAttributesEntry 12 }
+
+iscsiNodeDataPDUInOrder OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The DataPDUInOrder preference of this node.
+        False (=No) indicates that iSCSI data PDUs within sequences
+        may be in any order.  True (=Yes) indicates that data PDUs
+        within sequences must be at continuously increasing
+        addresses, with no gaps or overlay between PDUs."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 37]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    REFERENCE
+        "RFC 7143, Section 13.18, DataPDUInOrder"
+    DEFVAL        { true }
+::= { iscsiNodeAttributesEntry 13 }
+
+iscsiNodeDefaultTime2Wait OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..3600)
+    UNITS         "seconds"
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The DefaultTime2Wait preference of this node.  This is the
+        minimum time, in seconds, to wait before attempting an
+        explicit/implicit logout or active iSCSI task reassignment
+        after an unexpected connection termination or a connection
+        reset."
+    REFERENCE
+        "RFC 7143, Section 13.15, DefaultTime2Wait"
+    DEFVAL        { 2 }
+::= { iscsiNodeAttributesEntry 14 }
+
+iscsiNodeDefaultTime2Retain OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..3600)
+    UNITS         "seconds"
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The DefaultTime2Retain preference of this node.  This is
+        the maximum time, in seconds after an initial wait
+        (Time2Wait), before which an active iSCSI task reassignment
+        is still possible after an unexpected connection termination
+        or a connection reset."
+    REFERENCE
+        "RFC 7143, Section 13.16, DefaultTime2Retain"
+    DEFVAL        { 20 }
+::= { iscsiNodeAttributesEntry 15 }
+
+iscsiNodeErrorRecoveryLevel OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..255)
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The ErrorRecoveryLevel preference of this node.
+        Currently, only 0-2 are valid.
+
+        This object is designed to accommodate future error-recovery
+        levels.
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 38]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        Higher error-recovery levels imply support in addition to
+        support for the lower error level functions.  In other words,
+        error level 2 implies support for levels 0-1, since those
+        functions are subsets of error level 2."
+    REFERENCE
+        "RFC 7143, Section 13.20, ErrorRecoveryLevel"
+    DEFVAL        { 0 }
+::= { iscsiNodeAttributesEntry 16 }
+
+iscsiNodeDiscontinuityTime  OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The value of SysUpTime on the most recent occasion
+        at which any one or more of this node's counters
+        suffered a discontinuity.
+
+        If no such discontinuities have occurred since the last
+        re-initialization of the local management subsystem,
+        then this object contains a zero value."
+::= { iscsiNodeAttributesEntry 17 }
+
+iscsiNodeStorageType OBJECT-TYPE
+    SYNTAX        StorageType
+    MAX-ACCESS    read-write
+    STATUS        current
+    DESCRIPTION
+        "The storage type for all read-write objects within this
+        row.  Rows in this table are always created via an
+        external process (e.g., not created via this MIB module).
+        Conceptual rows having the value 'permanent' need not allow
+        Write access to any columnar objects in the row.
+
+        If this object has the value 'volatile', modifications
+        to read-write objects in this row are not persistent
+        across reboots.  If this object has the value
+        'nonVolatile', modifications to objects in this row
+        are persistent.
+
+        An implementation may choose to allow this object
+        to be set to either 'nonVolatile' or 'volatile',
+        allowing the management application to choose this
+        behavior."
+    DEFVAL        { volatile }
+::= { iscsiNodeAttributesEntry 18 }
+
+--**********************************************************************
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 39]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiTarget OBJECT IDENTIFIER ::= { iscsiObjects 6 }
+
+-- Target Attributes Table
+
+iscsiTargetAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiTargetAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of iSCSI nodes that can take on a target role,
+        belonging to each iSCSI instance present on the local
+        system."
+::= { iscsiTarget 1 }
+
+iscsiTargetAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiTargetAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular node that can take on a target role."
+    INDEX { iscsiInstIndex, iscsiNodeIndex }
+::= { iscsiTargetAttributesTable 1 }
+
+IscsiTargetAttributesEntry ::= SEQUENCE {
+    iscsiTgtLoginFailures           Counter32,
+    iscsiTgtLastFailureTime         TimeStamp,
+    iscsiTgtLastFailureType         AutonomousType,
+    iscsiTgtLastIntrFailureName     IscsiName,
+    iscsiTgtLastIntrFailureAddrType InetAddressType,
+    iscsiTgtLastIntrFailureAddr     InetAddress,
+    iscsiTgtLastIntrFailurePort     InetPortNumber
+}
+
+iscsiTgtLoginFailures OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed login attempts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object counts the number of times a login attempt to this
+        local target has failed.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetAttributesEntry 1 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 40]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiTgtLastFailureTime OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The timestamp of the most recent failure of a login attempt
+        to this target.  A value of zero indicates that no such
+        failures have occurred since the last system boot."
+::= { iscsiTargetAttributesEntry 2 }
+
+iscsiTgtLastFailureType  OBJECT-TYPE
+    SYNTAX        AutonomousType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The type of the most recent failure of a login attempt
+        to this target, represented as the OID of the counter
+        object in iscsiTargetLoginStatsTable for which the
+        relevant instance was incremented.  If no such failures
+        have occurred since the last system boot, this attribute
+        will have the value 0.0.  A value of 0.0 may also be used
+        to indicate a type that is not represented by any of
+        the counters in iscsiTargetLoginStatsTable."
+::= { iscsiTargetAttributesEntry 3 }
+
+iscsiTgtLastIntrFailureName  OBJECT-TYPE
+    SYNTAX        IscsiName
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The iSCSI name of the initiator that failed the last
+        login attempt.  If no such failures have occurred since
+        the last system boot, this value is a zero-length string."
+::= { iscsiTargetAttributesEntry 4 }
+
+iscsiTgtLastIntrFailureAddrType OBJECT-TYPE
+    SYNTAX        InetAddressType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The type of Internet Network Address contained in the
+        corresponding instance of the iscsiTgtLastIntrFailureAddr.
+        The value 'dns' is not allowed.  If no such failures have
+        occurred since the last system boot, this value is zero."
+::= { iscsiTargetAttributesEntry 5 }
+
+iscsiTgtLastIntrFailureAddr OBJECT-TYPE
+    SYNTAX        InetAddress
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 41]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "An Internet Network Address, of the type specified by
+        the object iscsiTgtLastIntrFailureAddrType, giving the
+        host address of the initiator that failed the last login
+        attempt.  If no such failures have occurred since the last
+        system boot, this value is a zero-length string."
+::= { iscsiTargetAttributesEntry 6 }
+
+iscsiTgtLastIntrFailurePort OBJECT-TYPE
+    SYNTAX        InetPortNumber
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The transport protocol port number used by the initiator
+        that failed the last login attempt.  If no such failures
+        have occurred since the last system boot, this value is a
+        zero-length string."
+::= { iscsiTargetAttributesEntry 7 }
+
+-- Target Login Stats Table
+
+iscsiTargetLoginStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiTargetLoginStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A table of counters that keep a record of the results
+        of initiators' login attempts to this target."
+::= { iscsiTarget 2 }
+
+iscsiTargetLoginStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiTargetLoginStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing counters for each result of
+        a login attempt to this target."
+    AUGMENTS { iscsiTargetAttributesEntry }
+::= { iscsiTargetLoginStatsTable 1 }
+
+IscsiTargetLoginStatsEntry ::= SEQUENCE {
+    iscsiTgtLoginAccepts           Counter32,
+    iscsiTgtLoginOtherFails        Counter32,
+    iscsiTgtLoginRedirects         Counter32,
+    iscsiTgtLoginAuthorizeFails    Counter32,
+    iscsiTgtLoginAuthenticateFails Counter32,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 42]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiTgtLoginNegotiateFails    Counter32
+}
+
+iscsiTgtLoginAccepts OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "successful logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status
+        0x0000, Accept Login, transmitted by this
+        target.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetLoginStatsEntry 1 }
+
+iscsiTgtLoginOtherFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of Login Response PDUs that were transmitted
+        by this target and that were not counted by any other
+        object in the row.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetLoginStatsEntry 2 }
+
+iscsiTgtLoginRedirects OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "redirected logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status class 0x01,
+        Redirection, transmitted by this target.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetLoginStatsEntry 3 }
+
+iscsiTgtLoginAuthorizeFails OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 43]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status 0x0202,
+        Forbidden Target, transmitted by this target.
+
+        If this counter is incremented, an iscsiTgtLoginFailure
+        notification should be generated.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetLoginStatsEntry 4 }
+
+iscsiTgtLoginAuthenticateFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status 0x0201,
+        Authentication Failed, transmitted by this target.
+
+        If this counter is incremented, an iscsiTgtLoginFailure
+        notification should be generated.
+
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiTargetLoginStatsEntry 5 }
+
+iscsiTgtLoginNegotiateFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of times a target has effectively refused a
+        login because the parameter negotiation failed.
+        If this counter is incremented, an iscsiTgtLoginFailure
+        notification should be generated.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+::= { iscsiTargetLoginStatsEntry 6 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 44]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+-- Target Logout Stats Table
+
+iscsiTargetLogoutStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiTargetLogoutStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "When a target receives a Logout command, it responds
+        with a Logout Response that carries a status code.
+        This table contains counters for both normal and
+        abnormal Logout Requests received by this target."
+::= { iscsiTarget 3 }
+
+iscsiTargetLogoutStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiTargetLogoutStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing counters of Logout Response
+        PDUs that were received by this target."
+    AUGMENTS { iscsiTargetAttributesEntry }
+::= { iscsiTargetLogoutStatsTable 1 }
+
+IscsiTargetLogoutStatsEntry ::= SEQUENCE {
+    iscsiTgtLogoutNormals          Counter32,
+    iscsiTgtLogoutOthers           Counter32,
+    iscsiTgtLogoutCxnClosed        Counter32,
+    iscsiTgtLogoutCxnRemoved       Counter32
+}
+
+iscsiTgtLogoutNormals OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "normal logouts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs received by this target,
+        with reason code 0 (closes the session).
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+::= { iscsiTargetLogoutStatsEntry 1 }
+
+iscsiTgtLogoutOthers OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "abnormal logouts"
+    MAX-ACCESS    read-only
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 45]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs received by this target,
+        with any reason code other than 0.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+::= { iscsiTargetLogoutStatsEntry 2 }
+
+iscsiTgtLogoutCxnClosed OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "abnormal logouts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs received by this target,
+        with reason code 1 (closes the connection).
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+::= { iscsiTargetLogoutStatsEntry 3 }
+
+iscsiTgtLogoutCxnRemoved OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "abnormal logouts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs received by this target,
+        with reason code 2 (removes the connection).
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+::= { iscsiTargetLogoutStatsEntry 4 }
+
+--**********************************************************************
+
+iscsiTgtAuthorization OBJECT IDENTIFIER ::= { iscsiObjects 7 }
+
+-- Target Authorization Attributes Table
+
+iscsiTgtAuthAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiTgtAuthAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 46]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    DESCRIPTION
+        "A list of initiator identities that are authorized to
+        access each target node within each iSCSI instance
+        present on the local system."
+::= { iscsiTgtAuthorization 1 }
+
+iscsiTgtAuthAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiTgtAuthAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information
+        applicable to a particular target node's authorized
+        initiator identity."
+    INDEX { iscsiInstIndex, iscsiNodeIndex, iscsiTgtAuthIndex }
+::= { iscsiTgtAuthAttributesTable 1 }
+
+IscsiTgtAuthAttributesEntry ::= SEQUENCE {
+    iscsiTgtAuthIndex              Unsigned32,
+    iscsiTgtAuthRowStatus          RowStatus,
+    iscsiTgtAuthIdentity           RowPointer,
+    iscsiTgtAuthStorageType        StorageType
+}
+
+iscsiTgtAuthIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a particular
+        target's authorized initiator identity within an iSCSI
+        instance present on the local system.  This index value must
+        not be modified or reused by an agent unless a reboot has
+        occurred.  An agent should attempt to keep this value
+        persistent across reboots."
+::= { iscsiTgtAuthAttributesEntry 1 }
+
+iscsiTgtAuthRowStatus OBJECT-TYPE
+    SYNTAX        RowStatus
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "This field allows entries to be dynamically added and
+        removed from this table via SNMP.  When adding a row to
+        this table, all non-Index/RowStatus objects must be set.
+        When the value of this object is 'active', the values of
+        the other objects in this table cannot be changed.
+        Rows may be discarded using RowStatus."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 47]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+::= { iscsiTgtAuthAttributesEntry 2 }
+
+iscsiTgtAuthIdentity OBJECT-TYPE
+    SYNTAX        RowPointer
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "A pointer to the corresponding user entry in the IPS-AUTH
+        MIB module that will be allowed to access this iSCSI target."
+    REFERENCE
+        "IPS-AUTH MIB, RFC 4545, Section 7.3, ipsAuthIdentity"
+::= { iscsiTgtAuthAttributesEntry 3 }
+
+iscsiTgtAuthStorageType OBJECT-TYPE
+    SYNTAX        StorageType
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The storage type for this row.  Rows in this table that were
+         created through an external process (e.g., not created via
+         this MIB) may have a storage type of readOnly or permanent.
+
+         Conceptual rows having the value 'permanent' need not
+         allow write access to any columnar objects in the row."
+    DEFVAL        { nonVolatile }
+::= { iscsiTgtAuthAttributesEntry 4 }
+
+--**********************************************************************
+
+iscsiInitiator OBJECT IDENTIFIER ::= { iscsiObjects 8 }
+
+-- Initiator Attributes Table
+
+iscsiInitiatorAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiInitiatorAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of iSCSI nodes that can take on an initiator
+        role, belonging to each iSCSI instance present on
+        the local system."
+::= { iscsiInitiator 1 }
+
+iscsiInitiatorAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiInitiatorAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 48]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "An entry (row) containing management information
+        applicable to a particular iSCSI node that has
+        initiator capabilities."
+    INDEX  { iscsiInstIndex, iscsiNodeIndex }
+::= { iscsiInitiatorAttributesTable 1 }
+
+IscsiInitiatorAttributesEntry ::= SEQUENCE {
+    iscsiIntrLoginFailures           Counter32,
+    iscsiIntrLastFailureTime         TimeStamp,
+    iscsiIntrLastFailureType         AutonomousType,
+    iscsiIntrLastTgtFailureName      IscsiName,
+    iscsiIntrLastTgtFailureAddrType  InetAddressType,
+    iscsiIntrLastTgtFailureAddr      InetAddress,
+    iscsiIntrLastTgtFailurePort      InetPortNumber
+}
+
+iscsiIntrLoginFailures OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object counts the number of times a login attempt from
+        this local initiator has failed.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorAttributesEntry 1 }
+
+iscsiIntrLastFailureTime OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The timestamp of the most recent failure of a login attempt
+        from this initiator.  A value of zero indicates that no such
+        failures have occurred since the last system boot."
+::= { iscsiInitiatorAttributesEntry 2 }
+
+iscsiIntrLastFailureType  OBJECT-TYPE
+    SYNTAX        AutonomousType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The type of the most recent failure of a login attempt
+        from this initiator, represented as the OID of the counter
+        object in iscsiInitiatorLoginStatsTable for which the
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 49]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        relevant instance was incremented.  If no such failures have
+        occurred since the last system boot, this attribute will
+        have the value 0.0.  A value of 0.0 may also be used to
+        indicate a type that is not represented by any of
+        the counters in iscsiInitiatorLoginStatsTable."
+::= { iscsiInitiatorAttributesEntry 3 }
+
+iscsiIntrLastTgtFailureName  OBJECT-TYPE
+    SYNTAX        IscsiName
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string giving the name of the target that failed
+        the last login attempt.  If no such failures have occurred
+        since the last system boot, this value is a zero-length string."
+::= { iscsiInitiatorAttributesEntry 4 }
+
+iscsiIntrLastTgtFailureAddrType OBJECT-TYPE
+    SYNTAX        InetAddressType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The type of Internet Network Address contained in the
+        corresponding instance of the iscsiIntrLastTgtFailureAddr.
+        The value 'dns' is not allowed.  If no such failures have
+        occurred since the last system boot, this value is zero."
+::= { iscsiInitiatorAttributesEntry 5 }
+
+iscsiIntrLastTgtFailureAddr OBJECT-TYPE
+    SYNTAX        InetAddress
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "An Internet Network Address, of the type specified by the
+        object iscsiIntrLastTgtFailureAddrType, giving the host
+        address of the target that failed the last login attempt.
+        If no such failures have occurred since the last system boot,
+        this value is a zero-length string."
+::= { iscsiInitiatorAttributesEntry 6 }
+
+iscsiIntrLastTgtFailurePort OBJECT-TYPE
+    SYNTAX        InetPortNumber
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The transport protocol port number used by the target
+        that failed the last login attempt.
+        If no such failures have occurred since the last system boot,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 50]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        this value is a zero-length string."
+::= { iscsiInitiatorAttributesEntry 7 }
+
+-- Initiator Login Stats Table
+
+iscsiInitiatorLoginStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiInitiatorLoginStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A table of counters that keep track of the results of
+        this initiator's login attempts."
+::= { iscsiInitiator 2 }
+
+iscsiInitiatorLoginStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiInitiatorLoginStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing counters of each result
+        of this initiator's login attempts."
+    AUGMENTS { iscsiInitiatorAttributesEntry }
+::= { iscsiInitiatorLoginStatsTable 1 }
+
+IscsiInitiatorLoginStatsEntry ::= SEQUENCE {
+    iscsiIntrLoginAcceptRsps         Counter32,
+    iscsiIntrLoginOtherFailRsps      Counter32,
+    iscsiIntrLoginRedirectRsps       Counter32,
+    iscsiIntrLoginAuthFailRsps       Counter32,
+    iscsiIntrLoginAuthenticateFails  Counter32,
+    iscsiIntrLoginNegotiateFails     Counter32,
+    iscsiIntrLoginAuthorizeFails     Counter32
+}
+
+iscsiIntrLoginAcceptRsps OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "successful logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status
+        0x0000, Accept Login, received by this initiator.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 1 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 51]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiIntrLoginOtherFailRsps OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs received by this
+        initiator with any status code not counted in the
+        objects below.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 2 }
+
+iscsiIntrLoginRedirectRsps OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status class 0x01,
+        Redirection, received by this initiator.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 3 }
+
+iscsiIntrLoginAuthFailRsps OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status class 0x201,
+        Authentication Failed, received by this initiator.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 4 }
+
+iscsiIntrLoginAuthenticateFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 52]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    DESCRIPTION
+        "The number of times the initiator has aborted a
+        login because the target could not be authenticated.
+
+        No response is generated.
+
+        If this counter is incremented, an iscsiIntrLoginFailure
+        notification should be generated.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 5 }
+
+iscsiIntrLoginNegotiateFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of times the initiator has aborted a
+        login because parameter negotiation with the target
+        failed.
+
+        No response is generated.
+
+        If this counter is incremented, an iscsiIntrLoginFailure
+        notification should be generated.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 7.12, Negotiation Failures"
+::= { iscsiInitiatorLoginStatsEntry 6 }
+
+iscsiIntrLoginAuthorizeFails OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "failed logins"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Login Response PDUs with status 0x0202,
+        Forbidden Target, received by this initiator.
+
+        If this counter is incremented, an iscsiIntrLoginFailure
+        notification should be generated.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 53]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "RFC 7143, Section 11.13.5, Status-Class and Status-Detail"
+::= { iscsiInitiatorLoginStatsEntry 7 }
+
+-- Initiator Logout Stats Table
+
+iscsiInitiatorLogoutStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiInitiatorLogoutStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "When an initiator attempts to send a Logout command, the target
+        responds with a Logout Response that carries a status code.
+        This table contains a list of counters of Logout Response
+        PDUs of each status code that was received by each
+        initiator belonging to this iSCSI instance present on this
+        system."
+::= { iscsiInitiator 3 }
+
+iscsiInitiatorLogoutStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiInitiatorLogoutStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing counters of Logout Response
+        PDUs of each status code that was generated by this
+        initiator."
+    AUGMENTS { iscsiInitiatorAttributesEntry }
+::= { iscsiInitiatorLogoutStatsTable 1 }
+
+IscsiInitiatorLogoutStatsEntry ::= SEQUENCE {
+    iscsiIntrLogoutNormals         Counter32,
+    iscsiIntrLogoutOthers          Counter32
+}
+
+iscsiIntrLogoutNormals OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "normal logouts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs generated by this initiator
+        with reason code 0 (closes the session).
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+::= { iscsiInitiatorLogoutStatsEntry 1 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 54]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiIntrLogoutOthers OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "abnormal logouts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Logout Command PDUs generated by this initiator
+        with any status code other than 0.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiNodeDiscontinuityTime."
+    REFERENCE
+        "RFC 7143, Section 11.14.1, Reason Code"
+
+::= { iscsiInitiatorLogoutStatsEntry 2 }
+
+--**********************************************************************
+
+iscsiIntrAuthorization OBJECT IDENTIFIER ::= { iscsiObjects 9 }
+
+-- Initiator Authorization Attributes Table
+
+iscsiIntrAuthAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiIntrAuthAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of target identities that each initiator
+        on the local system may access."
+::= { iscsiIntrAuthorization 1 }
+
+iscsiIntrAuthAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiIntrAuthAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular initiator node's authorized target identity."
+    INDEX { iscsiInstIndex, iscsiNodeIndex, iscsiIntrAuthIndex }
+::= { iscsiIntrAuthAttributesTable 1 }
+
+IscsiIntrAuthAttributesEntry ::= SEQUENCE {
+    iscsiIntrAuthIndex              Unsigned32,
+    iscsiIntrAuthRowStatus          RowStatus,
+    iscsiIntrAuthIdentity           RowPointer,
+    iscsiIntrAuthStorageType        StorageType
+}
+
+iscsiIntrAuthIndex OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 55]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular initiator node's authorized target
+        identity within an iSCSI instance present on the
+        local system.  This index value must not be modified
+        or reused by an agent unless a reboot has occurred.
+        An agent should attempt to keep this value persistent
+        across reboots."
+::= { iscsiIntrAuthAttributesEntry 1 }
+
+iscsiIntrAuthRowStatus OBJECT-TYPE
+    SYNTAX        RowStatus
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "This field allows entries to be dynamically added and
+        removed from this table via SNMP.  When adding a row to
+        this table, all non-Index/RowStatus objects must be set.
+        When the value of this object is 'active', the values of
+        the other objects in this table cannot be changed.
+        Rows may be discarded using RowStatus."
+::= { iscsiIntrAuthAttributesEntry 2 }
+
+iscsiIntrAuthIdentity OBJECT-TYPE
+    SYNTAX        RowPointer
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "A pointer to the corresponding user entry in the IPS-AUTH
+        MIB module to which this initiator node should attempt to
+        establish an iSCSI session."
+    REFERENCE
+        "IPS-AUTH MIB, RFC 4545, Section 7.3, ipsAuthIdentity"
+::= { iscsiIntrAuthAttributesEntry 3 }
+
+iscsiIntrAuthStorageType OBJECT-TYPE
+    SYNTAX        StorageType
+    MAX-ACCESS    read-create
+    STATUS        current
+    DESCRIPTION
+        "The storage type for this row.  Rows in this table that were
+        created through an external process (e.g., not created via
+        this MIB) may have a storage type of readOnly or permanent.
+
+        Conceptual rows having the value 'permanent' need not
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 56]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        allow write access to any columnar objects in the row."
+    DEFVAL        { nonVolatile }
+::= { iscsiIntrAuthAttributesEntry 4 }
+
+--**********************************************************************
+
+iscsiSession OBJECT IDENTIFIER ::= { iscsiObjects 10 }
+
+-- Session Attributes Table
+
+iscsiSessionAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiSessionAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of sessions belonging to each iSCSI instance
+        present on the system."
+::= { iscsiSession 1 }
+
+iscsiSessionAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiSessionAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular session.
+
+        If this session is a discovery session that is not attached
+        to any particular node, the iscsiSsnNodeIndex will be zero.
+        Otherwise, the iscsiSsnNodeIndex will have the same value as
+        iscsiNodeIndex."
+    INDEX  { iscsiInstIndex, iscsiSsnNodeIndex, iscsiSsnIndex }
+::= { iscsiSessionAttributesTable 1 }
+
+IscsiSessionAttributesEntry ::= SEQUENCE {
+    iscsiSsnNodeIndex              Unsigned32,
+    iscsiSsnIndex                  Unsigned32,
+    iscsiSsnDirection              INTEGER,
+    iscsiSsnInitiatorName          IscsiName,
+    iscsiSsnTargetName             IscsiName,
+    iscsiSsnTSIH                   Unsigned32,
+    iscsiSsnISID                   OCTET STRING,
+    iscsiSsnInitiatorAlias         SnmpAdminString,
+    iscsiSsnTargetAlias            SnmpAdminString,
+    iscsiSsnInitialR2T             TruthValue,
+    iscsiSsnImmediateData          TruthValue,
+    iscsiSsnType                   INTEGER,
+    iscsiSsnMaxOutstandingR2T      Unsigned32,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 57]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiSsnFirstBurstLength       Unsigned32,
+    iscsiSsnMaxBurstLength         Unsigned32,
+    iscsiSsnConnectionNumber       Gauge32,
+    iscsiSsnAuthIdentity           RowPointer,
+    iscsiSsnDataSequenceInOrder    TruthValue,
+    iscsiSsnDataPDUInOrder         TruthValue,
+    iscsiSsnErrorRecoveryLevel     Unsigned32,
+    iscsiSsnDiscontinuityTime      TimeStamp,
+    iscsiSsnProtocolLevel          Unsigned32,
+    iscsiSsnTaskReporting          BITS
+}
+
+iscsiSsnNodeIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular node within an iSCSI instance present
+        on the local system.  For normal, non-discovery
+        sessions, this value will map to the iscsiNodeIndex.
+        For discovery sessions that do not have a node
+        associated, the value 0 (zero) is used."
+::= { iscsiSessionAttributesEntry 1 }
+
+iscsiSsnIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular session within an iSCSI instance present
+        on the local system.  An agent should attempt to
+        not reuse index values unless a reboot has occurred.
+        iSCSI sessions are destroyed during a reboot; rows
+        in this table are not persistent across reboots."
+::= { iscsiSessionAttributesEntry 2 }
+
+iscsiSsnDirection OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      inboundSession(1),
+                      outboundSession(2)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Direction of iSCSI session:
+        inboundSession  - session is established from an external
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 58]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+                          initiator to a target within this iSCSI
+                          instance.
+        outboundSession - session is established from an initiator
+                          within this iSCSI instance to an external
+                          target."
+::= { iscsiSessionAttributesEntry 3 }
+
+iscsiSsnInitiatorName OBJECT-TYPE
+    SYNTAX        IscsiName
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "If iscsiSsnDirection is Inbound, this object is a
+        UTF-8 string that will contain the name of the remote
+        initiator.  If this session is a discovery session that
+        does not specify a particular initiator, this object
+        will contain a zero-length string.
+
+        If iscsiSsnDirection is Outbound, this object will
+        contain a zero-length string."
+::= { iscsiSessionAttributesEntry 4 }
+
+iscsiSsnTargetName OBJECT-TYPE
+    SYNTAX        IscsiName
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "If iscsiSsnDirection is Outbound, this object is a
+        UTF-8 string that will contain the name of the remote
+        target.  If this session is a discovery session that
+        does not specify a particular target, this object will
+        contain a zero-length string.
+
+        If iscsiSsnDirection is Inbound, this object will
+        contain a zero-length string."
+::= { iscsiSessionAttributesEntry 5 }
+
+iscsiSsnTSIH OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The target-defined identification handle for this session."
+    REFERENCE
+        "RFC 7143, Section 11.12.6, TSIH"
+::= { iscsiSessionAttributesEntry 6 }
+
+iscsiSsnISID OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 59]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        OCTET STRING (SIZE(6))
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The initiator-defined portion of the iSCSI Session ID."
+    REFERENCE
+        "RFC 7143, Section 11.12.5, ISID"
+::= { iscsiSessionAttributesEntry 7 }
+
+iscsiSsnInitiatorAlias OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string that gives the alias communicated by the
+        initiator end of the session during the login phase.
+
+        If no alias exists, the value is a zero-length string."
+    REFERENCE
+        "RFC 7143, Section 13.7, InitiatorAlias"
+::= { iscsiSessionAttributesEntry 8 }
+
+iscsiSsnTargetAlias OBJECT-TYPE
+    SYNTAX        SnmpAdminString
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A UTF-8 string that gives the alias communicated by the
+        target end of the session during the login phase.
+
+        If no alias exists, the value is a zero-length string."
+    REFERENCE
+        "RFC 7143, Section 13.6, TargetAlias"
+::= { iscsiSessionAttributesEntry 9 }
+
+iscsiSsnInitialR2T OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "If set to true, indicates that the initiator must wait
+        for an R2T before sending to the target.  If set to false,
+        the initiator may send data immediately, within limits set
+        by iscsiSsnFirstBurstLength and the expected data transfer
+        length of the request."
+    REFERENCE
+        "RFC 7143, Section 13.10, InitialR2T"
+::= { iscsiSessionAttributesEntry 10 }
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 60]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiSsnImmediateData OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Indicates whether the initiator and target have agreed to
+        support immediate data on this session."
+    REFERENCE
+        "RFC 7143, Section 13.11, ImmediateData"
+::= { iscsiSessionAttributesEntry 11 }
+
+iscsiSsnType OBJECT-TYPE
+
+    SYNTAX        INTEGER {
+                      normalSession(1),
+                      discoverySession(2)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Type of iSCSI session:
+        normalSession    - session is a normal iSCSI session
+        discoverySession - session is being used only for discovery."
+    REFERENCE
+        "RFC 7143, Section 13.21, SessionType"
+::= { iscsiSessionAttributesEntry 12 }
+
+iscsiSsnMaxOutstandingR2T OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    UNITS         "R2Ts"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum number of outstanding requests-to-transmit
+        (R2Ts) per iSCSI task within this session."
+    REFERENCE
+        "RFC 7143, Section 13.17, MaxOutstandingR2T"
+::= { iscsiSessionAttributesEntry 13 }
+
+iscsiSsnFirstBurstLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum length supported for unsolicited data sent
+        within this session."
+    REFERENCE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 61]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "RFC 7143, Section 13.14, FirstBurstLength"
+::= { iscsiSessionAttributesEntry 14 }
+
+iscsiSsnMaxBurstLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum number of bytes that can be sent within
+        a single sequence of Data-In or Data-Out PDUs."
+    REFERENCE
+        "RFC 7143, Section 13.13, MaxBurstLength"
+::= { iscsiSessionAttributesEntry 15 }
+
+iscsiSsnConnectionNumber OBJECT-TYPE
+    SYNTAX        Gauge32 (1..65535)
+    UNITS         "connections"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The number of transport protocol connections that currently
+        belong to this session."
+::= { iscsiSessionAttributesEntry 16 }
+
+iscsiSsnAuthIdentity OBJECT-TYPE
+    SYNTAX        RowPointer
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object contains a pointer to a row in the
+        IPS-AUTH MIB module that identifies the authentication
+        identity being used on this session, as communicated
+        during the login phase."
+    REFERENCE
+        "IPS-AUTH MIB, RFC 4545, Section 7.3, ipsAuthIdentity"
+::= { iscsiSessionAttributesEntry 17 }
+
+ iscsiSsnDataSequenceInOrder OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "False indicates that iSCSI data PDU sequences may
+        be transferred in any order.  True indicates that
+        data PDU sequences must be transferred using
+        continuously increasing offsets, except during
+        error recovery."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 62]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    REFERENCE
+        "RFC 7143, Section 13.19, DataSequenceInOrder"
+::= { iscsiSessionAttributesEntry 18 }
+
+iscsiSsnDataPDUInOrder OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "False indicates that iSCSI data PDUs within sequences
+        may be in any order.  True indicates that data PDUs
+        within sequences must be at continuously increasing
+        addresses, with no gaps or overlay between PDUs.
+        Default is true."
+    REFERENCE
+        "RFC 7143, Section 13.18, DataPDUInOrder"
+::= { iscsiSessionAttributesEntry 19 }
+
+iscsiSsnErrorRecoveryLevel OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..255)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The level of error recovery negotiated between
+        the initiator and the target.  Higher numbers
+        represent more detailed recovery schemes."
+    REFERENCE
+        "RFC 7143, Section 13.20, ErrorRecoveryLevel"
+::= { iscsiSessionAttributesEntry 20 }
+
+iscsiSsnDiscontinuityTime  OBJECT-TYPE
+    SYNTAX        TimeStamp
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The value of SysUpTime on the most recent occasion
+        at which any one or more of this session's counters
+        suffered a discontinuity.
+        When a session is established, and this object is
+        created, it is initialized to the current value
+        of SysUpTime."
+::= { iscsiSessionAttributesEntry 21 }
+
+iscsiSsnProtocolLevel OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..31)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 63]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "The iSCSI protocol level negotiated for this session."
+    REFERENCE
+        "RFC 7144, Section 7.1.1, iSCSIProtocolLevel"
+    DEFVAL        { 1 }
+::= { iscsiSessionAttributesEntry 22 }
+
+iscsiSsnTaskReporting OBJECT-TYPE
+    SYNTAX        BITS {
+                      taskReportingRfc3720(0),
+                      taskReportingResponseFence(1),
+                      taskReportingFastAbort(2)
+                  }
+
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This key is used to negotiate the task completion reporting
+        semantics from the SCSI target.
+
+        Default value is taskReportingRfc3720."
+    REFERENCE
+        "RFC 7143, Section 13.23, TaskReporting"
+::= { iscsiSessionAttributesEntry 23 }
+
+-- Session Stats Table
+
+iscsiSessionStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiSessionStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of general iSCSI traffic counters for each of the
+        sessions present on the system."
+::= { iscsiSession 2 }
+
+iscsiSessionStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiSessionStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing general iSCSI traffic counters
+        for a particular session."
+    AUGMENTS { iscsiSessionAttributesEntry }
+
+::= { iscsiSessionStatsTable 1 }
+
+IscsiSessionStatsEntry ::= SEQUENCE {
+    iscsiSsnCmdPDUs                Counter32,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 64]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiSsnRspPDUs                Counter32,
+    iscsiSsnTxDataOctets           Counter64,
+    iscsiSsnRxDataOctets           Counter64,
+    iscsiSsnLCTxDataOctets         Counter32,
+    iscsiSsnLCRxDataOctets         Counter32,
+    iscsiSsnNopReceivedPDUs        Counter32,
+    iscsiSsnNopSentPDUs            Counter32
+}
+
+iscsiSsnCmdPDUs OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "PDUs"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Command PDUs transferred on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 1 }
+
+iscsiSsnRspPDUs OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "PDUs"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of Response PDUs transferred on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 2 }
+
+iscsiSsnTxDataOctets OBJECT-TYPE
+    SYNTAX        Counter64
+    UNITS         "octets"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of data octets that were transmitted by
+        the local iSCSI node on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 3 }
+
+iscsiSsnRxDataOctets OBJECT-TYPE
+    SYNTAX        Counter64
+    UNITS         "octets"
+    MAX-ACCESS    read-only
+    STATUS        current
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 65]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    DESCRIPTION
+        "The count of data octets that were received by
+        the local iSCSI node on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 4 }
+
+iscsiSsnLCTxDataOctets OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "octets"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A Low-Capacity shadow object of iscsiSsnTxDataOctets
+        for those systems that are accessible via SNMPv1 only.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 5 }
+
+iscsiSsnLCRxDataOctets OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "octets"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "A Low-Capacity shadow object of iscsiSsnRxDataOctets
+        for those systems which are accessible via SNMPv1 only.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 6 }
+
+iscsiSsnNopReceivedPDUs OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "PDUs"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of NOP-In or NOP-Out PDUs received on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 7 }
+
+iscsiSsnNopSentPDUs OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "PDUs"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 66]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "The count of NOP-In or NOP-Out PDUs sent on this session.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime."
+::= { iscsiSessionStatsEntry 8 }
+
+-- Session Connection Error Stats Table
+
+iscsiSessionCxnErrorStatsTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiSessionCxnErrorStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of error counters for each of the sessions
+        present on this system."
+::= { iscsiSession 3 }
+
+iscsiSessionCxnErrorStatsEntry OBJECT-TYPE
+    SYNTAX        IscsiSessionCxnErrorStatsEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing error counters for
+        a particular session."
+    AUGMENTS { iscsiSessionAttributesEntry }
+::= { iscsiSessionCxnErrorStatsTable 1 }
+
+IscsiSessionCxnErrorStatsEntry ::= SEQUENCE {
+    iscsiSsnCxnDigestErrors        Counter32,
+    iscsiSsnCxnTimeoutErrors       Counter32
+}
+
+iscsiSsnCxnDigestErrors OBJECT-TYPE
+    SYNTAX        Counter32
+    UNITS         "PDUs"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of PDUs that were received on the session and
+        contained header or data digest errors.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime.
+        This counter is most likely provided when the error-recovery
+        level is 1 or 2"
+    REFERENCE
+        "RFC 7143, Section 7.8, Digest Errors"
+::= { iscsiSessionCxnErrorStatsEntry 1 }
+
+iscsiSsnCxnTimeoutErrors OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 67]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        Counter32
+    UNITS         "connections"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The count of connections within this session
+        that have been terminated due to timeout.
+        If this counter has suffered a discontinuity, the time of the
+        last discontinuity is indicated in iscsiSsnDiscontinuityTime.
+        This counter is most likely provided when the error-recovery
+        level is 2"
+    REFERENCE
+        "RFC 7143, Section 7.5, Connection Timeout Management"
+::= { iscsiSessionCxnErrorStatsEntry 2 }
+
+--**********************************************************************
+
+iscsiConnection OBJECT IDENTIFIER ::= { iscsiObjects 11 }
+
+-- Connection Attributes Table
+
+iscsiConnectionAttributesTable OBJECT-TYPE
+    SYNTAX        SEQUENCE OF IscsiConnectionAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "A list of connections belonging to each iSCSI instance
+        present on the system."
+::= { iscsiConnection 1 }
+
+iscsiConnectionAttributesEntry OBJECT-TYPE
+    SYNTAX        IscsiConnectionAttributesEntry
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An entry (row) containing management information applicable
+        to a particular connection."
+    INDEX  { iscsiInstIndex, iscsiSsnNodeIndex, iscsiSsnIndex,
+             iscsiCxnIndex }
+::= { iscsiConnectionAttributesTable 1 }
+
+IscsiConnectionAttributesEntry ::= SEQUENCE {
+    iscsiCxnIndex                  Unsigned32,
+    iscsiCxnCid                    Unsigned32,
+    iscsiCxnState                  INTEGER,
+    iscsiCxnAddrType               InetAddressType,
+    iscsiCxnLocalAddr              InetAddress,
+    iscsiCxnProtocol               IscsiTransportProtocol,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 68]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    iscsiCxnLocalPort              InetPortNumber,
+    iscsiCxnRemoteAddr             InetAddress,
+    iscsiCxnRemotePort             InetPortNumber,
+    iscsiCxnMaxRecvDataSegLength   Unsigned32,
+    iscsiCxnMaxXmitDataSegLength   Unsigned32,
+    iscsiCxnHeaderIntegrity        IscsiDigestMethod,
+    iscsiCxnDataIntegrity          IscsiDigestMethod,
+    iscsiCxnRecvMarker             TruthValue,
+    iscsiCxnSendMarker             TruthValue,
+    iscsiCxnVersionActive          Unsigned32
+}
+
+iscsiCxnIndex OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..4294967295)
+    MAX-ACCESS    not-accessible
+    STATUS        current
+    DESCRIPTION
+        "An arbitrary integer used to uniquely identify a
+        particular connection of a particular session within
+        an iSCSI instance present on the local system.  An
+        agent should attempt to not reuse index values unless
+        a reboot has occurred.  iSCSI connections are destroyed
+        during a reboot; rows in this table are not persistent
+        across reboots."
+::= { iscsiConnectionAttributesEntry 1 }
+
+iscsiCxnCid OBJECT-TYPE
+    SYNTAX        Unsigned32 (1..65535)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The iSCSI Connection ID for this connection."
+::= { iscsiConnectionAttributesEntry 2 }
+
+iscsiCxnState OBJECT-TYPE
+    SYNTAX        INTEGER {
+                      login(1),
+                      full(2),
+                      logout(3)
+                  }
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The current state of this connection, from an iSCSI negotiation
+        point of view.  Here are the states:
+
+        login  - The transport protocol connection has been established,
+                 but a valid iSCSI login response with the final bit set
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 69]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+                 has not been sent or received.
+        full   - A valid iSCSI login response with the final bit set
+                 has been sent or received.
+        logout - A valid iSCSI logout command has been sent or
+                 received, but the transport protocol connection has
+                 not yet been closed."
+::= { iscsiConnectionAttributesEntry 3 }
+
+iscsiCxnAddrType OBJECT-TYPE
+    SYNTAX        InetAddressType
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The type of Internet Network Addresses contained in the
+        corresponding instances of iscsiCxnLocalAddr and
+        iscsiCxnRemoteAddr.
+        The value 'dns' is not allowed."
+::= { iscsiConnectionAttributesEntry 4 }
+
+iscsiCxnLocalAddr OBJECT-TYPE
+    SYNTAX        InetAddress
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The local Internet Network Address, of the type specified
+        by iscsiCxnAddrType, used by this connection."
+::= { iscsiConnectionAttributesEntry 5 }
+
+iscsiCxnProtocol OBJECT-TYPE
+    SYNTAX        IscsiTransportProtocol
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The transport protocol over which this connection is
+        running."
+::= { iscsiConnectionAttributesEntry 6 }
+
+iscsiCxnLocalPort OBJECT-TYPE
+    SYNTAX        InetPortNumber
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The local transport protocol port used by this connection.
+        This object cannot have the value zero, since it represents
+        an established connection."
+::= { iscsiConnectionAttributesEntry 7 }
+
+iscsiCxnRemoteAddr OBJECT-TYPE
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 70]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    SYNTAX        InetAddress
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The remote Internet Network Address, of the type specified
+        by iscsiCxnAddrType, used by this connection."
+::= { iscsiConnectionAttributesEntry 8 }
+
+iscsiCxnRemotePort OBJECT-TYPE
+    SYNTAX        InetPortNumber
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The remote transport protocol port used by this connection.
+        This object cannot have the value zero, since it represents
+        an established connection."
+::= { iscsiConnectionAttributesEntry 9 }
+
+iscsiCxnMaxRecvDataSegLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum data payload size supported for command
+        or data PDUs able to be received on this connection."
+    REFERENCE
+        "RFC 7143, Section 13.12, MaxRecvDataSegmentLength"
+::= { iscsiConnectionAttributesEntry 10 }
+
+iscsiCxnMaxXmitDataSegLength OBJECT-TYPE
+    SYNTAX        Unsigned32 (512..16777215)
+    UNITS         "bytes"
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "The maximum data payload size supported for command
+        or data PDUs to be sent on this connection."
+    REFERENCE
+        "RFC 7143, Section 13.12, MaxRecvDataSegmentLength"
+::= { iscsiConnectionAttributesEntry 11 }
+
+iscsiCxnHeaderIntegrity OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object identifies the iSCSI header
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 71]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        digest scheme in use within this connection."
+::= { iscsiConnectionAttributesEntry 12 }
+
+iscsiCxnDataIntegrity OBJECT-TYPE
+    SYNTAX        IscsiDigestMethod
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "This object identifies the iSCSI data
+        digest scheme in use within this connection."
+::= { iscsiConnectionAttributesEntry 13 }
+
+iscsiCxnRecvMarker OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "This object indicates whether or not this connection
+        is receiving markers in its incoming data stream."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+::= { iscsiConnectionAttributesEntry 14 }
+
+iscsiCxnSendMarker OBJECT-TYPE
+    SYNTAX        TruthValue
+    MAX-ACCESS    read-only
+    STATUS        deprecated
+    DESCRIPTION
+        "This object indicates whether or not this connection
+        is inserting markers in its outgoing data stream."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+::= { iscsiConnectionAttributesEntry 15 }
+
+iscsiCxnVersionActive OBJECT-TYPE
+    SYNTAX        Unsigned32 (0..255)
+    MAX-ACCESS    read-only
+    STATUS        current
+    DESCRIPTION
+        "Active version number of the iSCSI specification negotiated
+        on this connection."
+    REFERENCE
+        "RFC 7143, Section 11.12, Login Request"
+::= { iscsiConnectionAttributesEntry 16 }
+
+--**********************************************************************
+-- Notifications
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 72]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiTgtLoginFailure NOTIFICATION-TYPE
+    OBJECTS {
+        iscsiTgtLoginFailures,
+        iscsiTgtLastFailureType,
+        iscsiTgtLastIntrFailureName,
+        iscsiTgtLastIntrFailureAddrType,
+        iscsiTgtLastIntrFailureAddr,
+        iscsiTgtLastIntrFailurePort
+    }
+    STATUS current
+    DESCRIPTION
+        "Sent when a login is failed by a target.
+
+        To avoid sending an excessive number of notifications due
+        to multiple errors counted, an SNMP agent implementing this
+        notification SHOULD NOT send more than 3 notifications of
+        this type in any 10-second time period."
+::= { iscsiNotifications 1 }
+
+iscsiIntrLoginFailure NOTIFICATION-TYPE
+    OBJECTS {
+        iscsiIntrLoginFailures,
+        iscsiIntrLastFailureType,
+        iscsiIntrLastTgtFailureName,
+        iscsiIntrLastTgtFailureAddrType,
+        iscsiIntrLastTgtFailureAddr,
+        iscsiIntrLastTgtFailurePort
+    }
+    STATUS current
+    DESCRIPTION
+        "Sent when a login is failed by an initiator.
+
+        To avoid sending an excessive number of notifications due
+        to multiple errors counted, an SNMP agent implementing this
+        notification SHOULD NOT send more than 3 notifications of
+        this type in any 10-second time period."
+::= { iscsiNotifications 2 }
+
+iscsiInstSessionFailure NOTIFICATION-TYPE
+    OBJECTS {
+        iscsiInstSsnFailures,
+        iscsiInstLastSsnFailureType,
+        iscsiInstLastSsnRmtNodeName
+    }
+    STATUS current
+    DESCRIPTION
+        "Sent when an active session is failed by either the initiator
+        or the target.
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 73]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        To avoid sending an excessive number of notifications due
+        to multiple errors counted, an SNMP agent implementing this
+        notification SHOULD NOT send more than 3 notifications of
+        this type in any 10-second time period."
+::= { iscsiNotifications 3 }
+
+--**********************************************************************
+
+-- Conformance Statements
+
+iscsiCompliances OBJECT IDENTIFIER ::= { iscsiConformance 1 }
+iscsiGroups      OBJECT IDENTIFIER ::= { iscsiConformance 2 }
+
+iscsiInstanceAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiInstDescr,
+        iscsiInstVersionMin,
+        iscsiInstVersionMax,
+        iscsiInstVendorID,
+        iscsiInstVendorVersion,
+        iscsiInstPortalNumber,
+        iscsiInstNodeNumber,
+        iscsiInstSessionNumber,
+        iscsiInstSsnFailures,
+        iscsiInstLastSsnFailureType,
+        iscsiInstLastSsnRmtNodeName,
+        iscsiInstDiscontinuityTime,
+        iscsiInstXNodeArchitecture
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about iSCSI
+        instances."
+::= { iscsiGroups 1 }
+
+iscsiInstanceSsnErrorStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiInstSsnDigestErrors,
+        iscsiInstSsnCxnTimeoutErrors,
+        iscsiInstSsnFormatErrors
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about
+        errors that have caused a session failure for an
+        iSCSI instance."
+::= { iscsiGroups 2 }
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 74]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+iscsiPortalAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiPortalRowStatus,
+        iscsiPortalStorageType,
+        iscsiPortalRoles,
+        iscsiPortalAddrType,
+        iscsiPortalAddr,
+        iscsiPortalProtocol,
+        iscsiPortalMaxRecvDataSegLength,
+        iscsiPortalPrimaryHdrDigest,
+        iscsiPortalPrimaryDataDigest,
+        iscsiPortalSecondaryHdrDigest,
+        iscsiPortalSecondaryDataDigest,
+        iscsiPortalRecvMarker
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A collection of objects providing information about
+        the transport protocol endpoints of the local targets.
+        This object group is deprecated because the marker key
+        is obsolete."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+::= { iscsiGroups 3 }
+
+iscsiTgtPortalAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiTgtPortalPort,
+        iscsiTgtPortalTag
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about
+        the transport protocol endpoints of the local targets."
+::= { iscsiGroups 4 }
+
+iscsiIntrPortalAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiIntrPortalTag
+    }
+    STATUS current
+    DESCRIPTION
+        "An object providing information about
+        the portal tags used by the local initiators."
+::= { iscsiGroups 5 }
+
+iscsiNodeAttributesGroup OBJECT-GROUP
+    OBJECTS {
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 75]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        iscsiNodeName,
+        iscsiNodeAlias,
+        iscsiNodeRoles,
+        iscsiNodeTransportType,
+        iscsiNodeInitialR2T,
+        iscsiNodeImmediateData,
+        iscsiNodeMaxOutstandingR2T,
+        iscsiNodeFirstBurstLength,
+        iscsiNodeMaxBurstLength,
+        iscsiNodeMaxConnections,
+        iscsiNodeDataSequenceInOrder,
+        iscsiNodeDataPDUInOrder,
+        iscsiNodeDefaultTime2Wait,
+        iscsiNodeDefaultTime2Retain,
+        iscsiNodeErrorRecoveryLevel,
+        iscsiNodeDiscontinuityTime,
+        iscsiNodeStorageType
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        local targets."
+::= { iscsiGroups 6 }
+
+iscsiTargetAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiTgtLoginFailures,
+        iscsiTgtLastFailureTime,
+        iscsiTgtLastFailureType,
+        iscsiTgtLastIntrFailureName,
+        iscsiTgtLastIntrFailureAddrType,
+        iscsiTgtLastIntrFailureAddr
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        local targets."
+::= { iscsiGroups 7 }
+
+iscsiTargetLoginStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiTgtLoginAccepts,
+        iscsiTgtLoginOtherFails,
+        iscsiTgtLoginRedirects,
+        iscsiTgtLoginAuthorizeFails,
+        iscsiTgtLoginAuthenticateFails,
+        iscsiTgtLoginNegotiateFails
+    }
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 76]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        login attempts by remote initiators to local targets."
+::= { iscsiGroups 8 }
+
+iscsiTargetLogoutStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiTgtLogoutNormals,
+        iscsiTgtLogoutOthers
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        logout events between remote initiators and local targets."
+::= { iscsiGroups 9 }
+
+iscsiTargetAuthGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiTgtAuthRowStatus,
+        iscsiTgtAuthStorageType,
+        iscsiTgtAuthIdentity
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        remote initiators that are authorized to connect to local
+        targets."
+::= { iscsiGroups 10 }
+
+iscsiInitiatorAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiIntrLoginFailures,
+        iscsiIntrLastFailureTime,
+        iscsiIntrLastFailureType,
+        iscsiIntrLastTgtFailureName,
+        iscsiIntrLastTgtFailureAddrType,
+        iscsiIntrLastTgtFailureAddr
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about
+        all local initiators."
+::= { iscsiGroups 11 }
+
+iscsiInitiatorLoginStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiIntrLoginAcceptRsps,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 77]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        iscsiIntrLoginOtherFailRsps,
+        iscsiIntrLoginRedirectRsps,
+        iscsiIntrLoginAuthFailRsps,
+        iscsiIntrLoginAuthenticateFails,
+        iscsiIntrLoginNegotiateFails,
+        iscsiIntrLoginAuthorizeFails
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        login attempts by local initiators to remote targets."
+::= { iscsiGroups 12 }
+
+iscsiInitiatorLogoutStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiIntrLogoutNormals,
+        iscsiIntrLogoutOthers
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        logout events between local initiators and remote targets."
+::= { iscsiGroups 13 }
+
+iscsiInitiatorAuthGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiIntrAuthRowStatus,
+        iscsiIntrAuthStorageType,
+        iscsiIntrAuthIdentity
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        remote targets that are initiators of the local system
+        that they are authorized to access."
+::= { iscsiGroups 14 }
+
+iscsiSessionAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiSsnDirection,
+        iscsiSsnInitiatorName,
+        iscsiSsnTargetName,
+        iscsiSsnTSIH,
+        iscsiSsnISID,
+        iscsiSsnInitiatorAlias,
+        iscsiSsnTargetAlias,
+        iscsiSsnInitialR2T,
+        iscsiSsnImmediateData,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 78]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        iscsiSsnType,
+        iscsiSsnMaxOutstandingR2T,
+        iscsiSsnFirstBurstLength,
+        iscsiSsnMaxBurstLength,
+        iscsiSsnConnectionNumber,
+        iscsiSsnAuthIdentity,
+        iscsiSsnDataSequenceInOrder,
+        iscsiSsnDataPDUInOrder,
+        iscsiSsnErrorRecoveryLevel,
+        iscsiSsnDiscontinuityTime,
+        iscsiSsnProtocolLevel,
+        iscsiSsnTaskReporting
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information applicable to
+        all sessions."
+::= { iscsiGroups 15 }
+
+iscsiSessionPDUStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiSsnCmdPDUs,
+        iscsiSsnRspPDUs
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about PDU
+        traffic for each session."
+::= { iscsiGroups 16 }
+
+iscsiSessionOctetStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiSsnTxDataOctets,
+        iscsiSsnRxDataOctets
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about octet
+        traffic for each session using a Counter64 data type."
+::= { iscsiGroups 17 }
+
+iscsiSessionLCOctetStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiSsnLCTxDataOctets,
+        iscsiSsnLCRxDataOctets
+    }
+    STATUS current
+    DESCRIPTION
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 79]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        "A collection of objects providing information about octet
+        traffic for each session using a Counter32 data type."
+::= { iscsiGroups 18 }
+
+iscsiSessionCxnErrorStatsGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiSsnCxnDigestErrors,
+        iscsiSsnCxnTimeoutErrors
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about connection
+        errors for all sessions."
+::= { iscsiGroups 19 }
+
+iscsiConnectionAttributesGroup OBJECT-GROUP
+    OBJECTS {
+        iscsiCxnCid,
+        iscsiCxnState,
+        iscsiCxnProtocol,
+        iscsiCxnAddrType,
+        iscsiCxnLocalAddr,
+        iscsiCxnLocalPort,
+        iscsiCxnRemoteAddr,
+        iscsiCxnRemotePort,
+        iscsiCxnMaxRecvDataSegLength,
+        iscsiCxnMaxXmitDataSegLength,
+        iscsiCxnHeaderIntegrity,
+        iscsiCxnDataIntegrity,
+        iscsiCxnRecvMarker,
+        iscsiCxnSendMarker,
+        iscsiCxnVersionActive
+    }
+    STATUS deprecated
+    DESCRIPTION
+        "A collection of objects providing information about all
+        connections used by all sessions.
+        This object group is deprecated because the marker key
+        is obsolete."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+::= { iscsiGroups 20 }
+
+iscsiTgtLgnNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        iscsiTgtLoginFailure
+    }
+    STATUS current
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 80]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    DESCRIPTION
+        "A collection of notifications that indicate a login
+        failure from a remote initiator to a local target."
+::= { iscsiGroups 21 }
+
+iscsiIntrLgnNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        iscsiIntrLoginFailure
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of notifications that indicate a login
+        failure from a local initiator to a remote target."
+::= { iscsiGroups 22 }
+
+iscsiSsnFlrNotificationsGroup NOTIFICATION-GROUP
+    NOTIFICATIONS {
+        iscsiInstSessionFailure
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of notifications that indicate session
+        failures occurring after login."
+::= { iscsiGroups 23 }
+
+iscsiPortalAttributesGroupV2 OBJECT-GROUP
+    OBJECTS {
+        iscsiPortalRowStatus,
+        iscsiPortalStorageType,
+        iscsiPortalRoles,
+        iscsiPortalAddrType,
+        iscsiPortalAddr,
+        iscsiPortalProtocol,
+        iscsiPortalMaxRecvDataSegLength,
+        iscsiPortalPrimaryHdrDigest,
+        iscsiPortalPrimaryDataDigest,
+        iscsiPortalSecondaryHdrDigest,
+        iscsiPortalSecondaryDataDigest
+    }
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about
+        the transport protocol endpoints of the local targets."
+::= { iscsiGroups 24 }
+
+iscsiConnectionAttributesGroupV2 OBJECT-GROUP
+    OBJECTS {
+        iscsiCxnCid,
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 81]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        iscsiCxnState,
+        iscsiCxnProtocol,
+        iscsiCxnAddrType,
+        iscsiCxnLocalAddr,
+        iscsiCxnLocalPort,
+        iscsiCxnRemoteAddr,
+        iscsiCxnRemotePort,
+        iscsiCxnMaxRecvDataSegLength,
+        iscsiCxnMaxXmitDataSegLength,
+        iscsiCxnHeaderIntegrity,
+        iscsiCxnDataIntegrity,
+        iscsiCxnVersionActive
+    }
+
+    STATUS current
+    DESCRIPTION
+        "A collection of objects providing information about all
+        connections used by all sessions."
+::= { iscsiGroups 25 }
+
+iscsiNewObjectsV2 OBJECT-GROUP
+    OBJECTS {
+        iscsiInstXNodeArchitecture,
+        iscsiSsnTaskReporting,
+        iscsiSsnProtocolLevel,
+        iscsiSsnNopReceivedPDUs,
+        iscsiSsnNopSentPDUs,
+        iscsiIntrLastTgtFailurePort,
+        iscsiTgtLastIntrFailurePort,
+        iscsiPortalDescr,
+        iscsiInstSsnTgtUnmappedErrors,
+        iscsiTgtLogoutCxnClosed,
+        iscsiTgtLogoutCxnRemoved
+    }
+
+    STATUS current
+    DESCRIPTION
+        "A collection of objects added in the second version of the
+        iSCSI MIB."
+::= { iscsiGroups 26 }
+
+--**********************************************************************
+
+iscsiComplianceV1 MODULE-COMPLIANCE
+    STATUS deprecated
+    DESCRIPTION
+        "Initial version of compliance statement.
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 82]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        If an implementation can be both a target and an
+        initiator, all groups are mandatory.
+        This module compliance is deprecated because the
+        marker keys are obsolete."
+    REFERENCE
+        "RFC 7143, Section 13.25, Obsoleted Keys."
+    MODULE       -- this module
+    MANDATORY-GROUPS {
+        iscsiInstanceAttributesGroup,
+        iscsiInstanceSsnErrorStatsGroup,
+        iscsiPortalAttributesGroup,
+        iscsiNodeAttributesGroup,
+        iscsiSessionAttributesGroup,
+        iscsiSessionPDUStatsGroup,
+        iscsiSessionCxnErrorStatsGroup,
+        iscsiConnectionAttributesGroup,
+        iscsiSsnFlrNotificationsGroup
+    }
+
+    -- Conditionally mandatory groups depending on the ability
+    -- to support Counter64 data types and/or to provide counter
+    -- information to SNMPv1 applications.
+
+    GROUP iscsiSessionOctetStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that can support Counter64 data types."
+
+    GROUP iscsiSessionLCOctetStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that provide information to SNMPv1-only applications;
+        this includes agents that cannot support Counter64
+        data types."
+
+    -- Conditionally mandatory groups to be included with
+    -- the mandatory groups when the implementation has
+    -- iSCSI target facilities.
+
+    GROUP iscsiTgtPortalAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    OBJECT iscsiPortalMaxRecvDataSegLength
+    MIN-ACCESS read-only
+    DESCRIPTION
+        "Write access is not required."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 83]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    OBJECT iscsiNodeStorageType
+    MIN-ACCESS read-only
+    DESCRIPTION
+        "Write access is not required; an implementation may
+         choose to allow this object to be set to 'volatile'
+         or 'nonVolatile'."
+    GROUP iscsiTargetAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetLoginStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetLogoutStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTgtLgnNotificationsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetAuthGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    -- Conditionally mandatory groups to be included with
+    -- the mandatory groups when the implementation has
+    -- iSCSI initiator facilities.
+
+    GROUP iscsiIntrPortalAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorLoginStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 84]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorLogoutStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiIntrLgnNotificationsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorAuthGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    OBJECT       iscsiNodeErrorRecoveryLevel
+    SYNTAX       Unsigned32 (0..2)
+    DESCRIPTION
+        "Only values 0-2 are defined at present."
+
+::= { iscsiCompliances 1 }
+
+iscsiComplianceV2 MODULE-COMPLIANCE
+    STATUS current
+    DESCRIPTION
+        "Version 2 of compliance statement based on
+        this revised version of the MIB module.
+
+        If an implementation can be both a target and an
+        initiator, all groups are mandatory."
+    MODULE       -- this module
+    MANDATORY-GROUPS {
+        iscsiInstanceAttributesGroup,
+        iscsiInstanceSsnErrorStatsGroup,
+        iscsiPortalAttributesGroupV2,
+        iscsiNodeAttributesGroup,
+        iscsiSessionAttributesGroup,
+        iscsiSessionPDUStatsGroup,
+        iscsiSessionCxnErrorStatsGroup,
+        iscsiConnectionAttributesGroupV2,
+        iscsiSsnFlrNotificationsGroup
+    }
+
+    -- Conditionally mandatory groups depending on the ability
+    -- to support Counter64 data types and/or to provide counter
+    -- information to SNMPv1 applications.
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 85]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    GROUP iscsiSessionOctetStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that can support Counter64 data types."
+
+    GROUP iscsiSessionLCOctetStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that provide information to SNMPv1-only applications;
+        this includes agents that cannot support Counter64
+        data types."
+
+    -- Conditionally mandatory groups to be included with
+    -- the mandatory groups when the implementation has
+    -- iSCSI target facilities.
+
+    GROUP iscsiTgtPortalAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    OBJECT iscsiPortalMaxRecvDataSegLength
+    MIN-ACCESS read-only
+    DESCRIPTION
+        "Write access is not required."
+
+    OBJECT iscsiNodeStorageType
+    MIN-ACCESS read-only
+    DESCRIPTION
+        "Write access is not required; an implementation may
+         choose to allow this object to be set to 'volatile'
+         or 'nonVolatile'."
+
+    GROUP iscsiTargetAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetLoginStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetLogoutStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 86]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    GROUP iscsiTgtLgnNotificationsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    GROUP iscsiTargetAuthGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI target facilities."
+
+    -- Conditionally mandatory groups to be included with
+    -- the mandatory groups when the implementation has
+    -- iSCSI initiator facilities.
+
+    GROUP iscsiIntrPortalAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorAttributesGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorLoginStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorLogoutStatsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiIntrLgnNotificationsGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    GROUP iscsiInitiatorAuthGroup
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that have iSCSI initiator facilities."
+
+    OBJECT       iscsiNodeErrorRecoveryLevel
+    SYNTAX       Unsigned32 (0..2)
+    DESCRIPTION
+        "Only values 0-2 are defined at present."
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 87]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+    GROUP iscsiNewObjectsV2
+    DESCRIPTION
+        "This group is mandatory for all iSCSI implementations
+        that support a value of the iSCSIProtocolLevel key of
+        2 or greater."
+
+::= { iscsiCompliances 2 }
+
+END
+
+8.  Security Considerations
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      iscsiPortalAttributesTable, iscsiTgtPortalAttributesTable, and
+      iscsiIntrPortalAttributesTable can be used to add or remove IP
+      addresses to be used by iSCSI.
+
+      iscsiTgtAuthAttributesTable entries can be added or removed, to
+      allow or disallow access to a target by an initiator.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+      iscsiNodeAttributesTable, iscsiTargetAttributesTable, and
+      iscsiTgtAuthorization can be used to glean information needed to
+      make connections to the iSCSI targets this module represents.
+      However, it is the responsibility of the initiators and targets
+      involved to authenticate each other to ensure that an
+      inappropriately advertised or discovered initiator or target does
+      not compromise their security.  These issues are discussed in
+      [RFC7143].
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 88]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   even then, there is no control as to who on the secure network is
+   allowed to access and GET/SET (read/change/create/delete) the objects
+   in this MIB module.
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  IANA Considerations
+
+   The MIB module in this document uses the following IANA-assigned
+   OBJECT IDENTIFIER value recorded in the "SMI Network Management MGMT
+   Codes Internet-standard MIB" registry:
+
+   Descriptor        OBJECT IDENTIFIER value
+   ----------        -----------------------
+
+   iscsiMibModule       { mib-2 142 }
+
+   IANA has updated the reference for the mib-2 142 identifier to refer
+   to this document.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Structure of Management Information
+              Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 89]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   [RFC2579]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Textual Conventions for SMIv2", STD
+              58, RFC 2579, April 1999.
+
+   [RFC2580]  McCloghrie, K., Ed., Perkins, D., Ed., and J.
+              Schoenwaelder, Ed., "Conformance Statements for SMIv2",
+              STD 58, RFC 2580, April 1999.
+
+   [RFC3411]  Harrington, D., Presuhn, R., and B. Wijnen, "An
+              Architecture for Describing Simple Network Management
+              Protocol (SNMP) Management Frameworks", STD 62, RFC 3411,
+              December 2002.
+
+   [RFC3414]  Blumenthal, U. and B. Wijnen, "User-based Security Model
+              (USM) for version 3 of the Simple Network Management
+              Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3720]  Satran, J., Meth, K., Sapuntzakis, C., Chadalapaka, M.,
+              and E. Zeidner, "Internet Small Computer Systems Interface
+              (iSCSI)", RFC 3720, April 2004.
+
+   [RFC3826]  Blumenthal, U., Maino, F., and K. McCloghrie, "The
+              Advanced Encryption Standard (AES) Cipher Algorithm in the
+              SNMP User-based Security Model", RFC 3826, June 2004.
+
+   [RFC4001]  Daniele, M., Haberman, B., Routhier, S., and J.
+              Schoenwaelder, "Textual Conventions for Internet Network
+              Addresses", RFC 4001, February 2005.
+
+   [RFC4545]  Bakke, M. and J. Muchow, "Definitions of Managed Objects
+              for IP Storage User Identity Authorization", RFC 4545, May
+              2006.
+
+   [RFC5591]  Harrington, D. and W. Hardaker, "Transport Security Model
+              for the Simple Network Management Protocol (SNMP)", RFC
+              5591, June 2009.
+
+   [RFC5592]  Harrington, D., Salowey, J., and W. Hardaker, "Secure
+              Shell Transport Model for the Simple Network Management
+              Protocol (SNMP)", RFC 5592, June 2009.
+
+   [RFC6353]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 6353, July 2011.
+
+   [RFC7143]  Chadalapaka, M., Satran, J., Meth, K., and D. Black,
+              "Internet Small Computer System Interface (iSCSI) Protocol
+              (Consolidated)", RFC 7143, April 2014.
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 90]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+   [RFC7144]  Knight, F. and M. Chadalapaka, "Internet Small Computer
+              System Interface (iSCSI) SCSI Features Update", RFC 7144,
+              April 2014.
+
+10.2.  Informative References
+
+   [RFC3410]  Case, J., Mundy, R., Partain, D., and B. Stewart,
+              "Introduction and Applicability Statements for Internet-
+              Standard Management Framework", RFC 3410, December 2002.
+
+   [RFC4022]  Raghunarayan, R., Ed., "Management Information Base for
+              the Transmission Control Protocol (TCP)", RFC 4022, March
+              2005.
+
+   [RFC4455]  Hallak-Stamler, M., Bakke, M., Lederman, Y., Krueger, M.,
+              and K. McCloghrie, "Definition of Managed Objects for
+              Small Computer System Interface (SCSI) Entities", RFC
+              4455, April 2006.
+
+   [RFC4544]  Bakke, M., Krueger, M., McSweeney, T., and J. Muchow,
+              "Definitions of Managed Objects for Internet Small
+              Computer System Interface (iSCSI)", RFC 4544, May 2006.
+
+11.  Acknowledgments
+
+   The contents of this document were largely written as RFC 4544 by
+   Mark Bakke (Cisco), Marjorie Krueger (Hewlett-Packard), Tom McSweeney
+   (IBM), and James Muchow (QLogic).  A special thank you to Marjorie,
+   Tom, and James for their hard work and especially to James for his
+   attention to detail on this work.
+
+   In addition to the authors, several people contributed to the
+   development of this MIB module.  Thanks especially to those who took
+   the time to participate in our weekly conference calls to build our
+   requirements, object models, table structures, and attributes: John
+   Hufferd, Tom McSweeney (IBM), Kevin Gibbons (Nishan Systems), Chad
+   Gregory (Intel), Jack Harwood (EMC), Hari Mudaliar (Adaptec), Ie Wei
+   Njoo (Agilent), Lawrence Lamers (SAN Valley), Satish Mali (Stonefly
+   Networks), and William Terrell (Troika).
+
+   Special thanks to Tom McSweeney, Ie Wei Njoo, and Kevin Gibbons, who
+   wrote the descriptions for many of the tables and attributes in this
+   MIB module, to Ayman Ghanem for finding and suggesting changes for
+   many problems in this module, and to Keith McCloghrie for serving as
+   advisor to the team.
+
+   Thanks to Mike MacFaden (VMWare), David Black (EMC), and Tom Talpey
+   (Microsoft) for their valuable inputs.
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 91]
+
+RFC 7147                        iSCSI MIB                     April 2014
+
+
+Authors' Addresses
+
+   Mark Bakke
+   Dell
+   7625 Smetana Lane
+   Eden Prairie, MN  55344
+   USA
+
+   EMail: mark_bakke@dell.com
+
+
+   Prakash Venkatesen
+   HCL Technologies Ltd.
+   50-53, Greams Road,
+   Chennai - 600006
+   India
+
+   EMail: prakashvn@hcl.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Bakke & Venkatesen           Standards Track                   [Page 92]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7147.txt](<www.ietf.org/rfc/rfc7147.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
