### PR TITLE
Archive rfc7154.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7154.txt
+++ b/www.ietf.org/rfc/rfc7154.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                 S. Moonesamy, Ed.
+Request for Comments: 7154                                    March 2014
+BCP: 54
+Obsoletes: 3184
+Category: Best Current Practice
+ISSN: 2070-1721
+
+                      IETF Guidelines for Conduct
+
+
+Abstract
+
+   This document provides a set of guidelines for personal interaction
+   in the Internet Engineering Task Force.  The guidelines recognize the
+   diversity of IETF participants, emphasize the value of mutual
+   respect, and stress the broad applicability of our work.
+
+   This document is an updated version of the guidelines for conduct
+   originally published in RFC 3184.
+
+Status of This Memo
+
+   This memo documents an Internet Best Current Practice.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   BCPs is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7154.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 1]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+1.  Introduction
+
+   The work of the IETF relies on cooperation among a diverse range of
+   people with different ideas and communication styles.  The IETF
+   strives, through these guidelines for conduct, to create and maintain
+   an environment in which every person is treated with dignity,
+   decency, and respect.  People who participate in the IETF are
+   expected to behave in a professional manner as we work together to
+   develop interoperable technologies for the Internet.  We aim to abide
+   by these guidelines as we build consensus in person and through email
+   discussions.  If conflicts arise, they are resolved according to the
+   procedures outlined in RFC 2026 [RFC2026].
+
+   This document obsoletes RFC 3184 [RFC3184], as it is an updated
+   version of the guidelines for conduct.
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 2]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+2.  Guidelines for Conduct
+
+   1. IETF participants extend respect and courtesy to their colleagues
+      at all times.
+
+      IETF participants come from diverse origins and backgrounds; there
+      can be different expectations or assumptions.  Regardless of these
+      individual differences, participants treat their colleagues with
+      respect as persons especially when it is difficult to agree with
+      them: treat other participants as you would like to be treated.
+
+      English is the de facto language of the IETF.  However, it is not
+      the native language of many IETF participants.  All participants,
+      particularly those with English as a first language, attempt to
+      accommodate the needs of other participants by communicating
+      clearly, including speaking slowly and limiting the use of slang.
+      When faced with English that is difficult to understand, IETF
+      participants make a sincere effort to understand each other and
+      engage in conversation to clarify what was meant.
+
+   2. IETF participants have impersonal discussions.
+
+      We dispute ideas by using reasoned argument rather than through
+      intimidation or personal attack.  Try to provide data and facts
+      for your standpoints so the rest of the participants who are
+      sitting on the sidelines watching the discussion can form an
+      opinion.  The discussion is easier when the response to a simple
+      question is a polite answer [SQPA].
+
+   3. IETF participants devise solutions for the global Internet that
+      meet the needs of diverse technical and operational environments.
+
+      The mission of the IETF is to produce high-quality, relevant
+      technical and engineering documents that influence the way people
+      design, use, and manage the Internet in such a way as to make the
+      Internet work better.  The IETF puts its emphasis on technical
+      competence, rough consensus, and individual participation, and it
+      needs to be open to competent input from any source.  We
+      understand that "scaling is the ultimate problem" and that many
+      ideas that are quite workable on a small scale fail this crucial
+      test.
+
+      IETF participants use their best engineering judgment to find the
+      best solution for the whole Internet, not just the best solution
+      for any particular network, technology, vendor, or user.  While we
+      all have ideas that may stand improvement from time to time, no
+      one shall ever knowingly contribute advice or text that would make
+      a standard technically inferior.
+
+
+
+Moonesamy                 Best Current Practice                 [Page 3]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+   4. Individuals are prepared to contribute to the ongoing work of the
+      group.
+
+      We follow the intellectual property guidelines outlined in BCP 79
+      [RFC3979].  IETF participants read the relevant Internet-Drafts,
+      RFCs, and email archives in order to familiarize themselves with
+      the technology under discussion.  Working Group sessions run on a
+      very limited time schedule, and sometimes participants have to
+      limit their questions.  The work of the group will continue on the
+      mailing list, and questions can be asked and answered on the
+      mailing list.  It can be a challenge to participate in a Working
+      Group without knowing the history of longstanding Working Group
+      debates.  Information about a Working Group including its charter
+      and milestones is available on the IETF datatracker site [TRACK]
+      or from the Working Group Chair.
+
+3.  Security Considerations
+
+   The IETF guidelines for conduct do not directly affect the security
+   of the Internet.  However, it is to be noted that there is an
+   expectation that no one shall ever knowingly contribute advice or
+   text that may adversely affect the security of the Internet without
+   describing all known or foreseen risks and threats to potential
+   implementers and users that they are aware of.
+
+4.  Acknowledgements
+
+   Most of the text in this document is based on RFC 3184, which was
+   written by Susan Harris.  The editor would like to acknowledge that
+   this document would not exist without her contribution.  Mike O'Dell
+   wrote the first draft of the Guidelines for Conduct, and many of his
+   thoughts, statements, and observations are included in this version.
+   Many useful editorial comments were supplied by Dave Crocker.
+   Members of the POISSON Working Group provided many significant
+   additions to the text.
+
+   The editor would like to thank Jari Arkko, Brian Carpenter, Dave
+   Cridland, Dave Crocker, Spencer Dawkins, Alan DeKok, Lars Eggert,
+   David Farmer, Adrian Farrel, Stephen Farrell, Russ Housley, Eliot
+   Lear, Barry Leiba, Ines Robles, Eduardo A. Suarez, Brian Trammell,
+   and Sean Turner for contributing towards the improvement of the
+   document.
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 4]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+5.  References
+
+5.1.  Informative References
+
+   [RFC2026]  Bradner, S., "The Internet Standards Process -- Revision
+              3", BCP 9, RFC 2026, October 1996.
+
+   [RFC2418]  Bradner, S., "IETF Working Group Guidelines and
+              Procedures", BCP 25, RFC 2418, September 1998.
+
+   [RFC3184]  Harris, S., "IETF Guidelines for Conduct", BCP 54, RFC
+              3184, October 2001.
+
+   [RFC3683]  Rose, M., "A Practice for Revoking Posting Rights to IETF
+              Mailing Lists", BCP 83, RFC 3683, March 2004.
+
+   [RFC3934]  Wasserman, M., "Updates to RFC 2418 Regarding the
+              Management of IETF Mailing Lists", BCP 25, RFC 3934,
+              October 2004.
+
+   [RFC3979]  Bradner, S., Ed., "Intellectual Property Rights in IETF
+              Technology", BCP 79, RFC 3979, March 2005.
+
+   [SQPA]     Perlman, R., "Miss Manners meets the IETF", March 2002,
+              <http://www.ietf.org/proceedings/53/slides/plenary-3/
+              index.html>
+
+   [TRACK]    "The IETF Datatracker Tool", Web Application:
+              <https://datatracker.ietf.org/wg>, Version 5.0.2.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 5]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+Appendix A.  Reporting Transgressions of the Guidelines
+
+   An individual can report transgressions of the guidelines for conduct
+   to the IETF Chair or the IESG.
+
+Appendix B. Consequences of Transgressing the Guidelines
+
+   This document does not discuss measures that can be taken against a
+   participant transgressing the guidelines for conduct.
+
+   RFC 2418 [RFC2418] describes a measure where a Working Group Chair
+   has the authority to refuse to grant the floor to any individual who
+   is unprepared or otherwise covering inappropriate material, or who,
+   in the opinion of the Chair, is disrupting the Working Group process.
+
+   RFC 3683 [RFC3683] describes "posting rights" action to remove the
+   posting rights of an individual.  RFC 3934 [RFC3934] describes a
+   measure through which a Working Group Chair can suspend posting
+   privileges of a disruptive individual for a short period of time.
+
+Appendix C. Changes from RFC 3184
+
+   o  Added text about the IETF striving to create an environment in
+      which every person is treated with dignity, decency, and respect.
+
+   o  Added text about contributing advice or text that may affect the
+      security of the Internet.
+
+   o  The recommendation that newcomers should not interfere with the
+      ongoing process in Section 2 was removed as it can be read as
+      discouraging newcomers from participating in discussions.
+
+   o  The text about the goal of the IETF was replaced with text about
+      the mission statement and what the IETF puts its emphasis on.
+
+   o  The text about "think globally" was removed as the meaning was not
+      clear.
+
+   o  The text about English as a first language was clarified.
+
+   o  The guideline about impersonal discussions was reworded as a
+      positive statement.
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 6]
+
+RFC 7154               IETF Guidelines for Conduct            March 2014
+
+
+Author's Address
+
+   S. Moonesamy (editor)
+   76, Ylang Ylang Avenue
+   Quatres Bornes
+   Mauritius
+
+   EMail: sm+ietf@elandsys.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Moonesamy                 Best Current Practice                 [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7154.txt](<www.ietf.org/rfc/rfc7154.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
