### PR TITLE
Archive rfc717.txt

### DIFF
--- a/www.ietf.org/rfc/rfc717.txt
+++ b/www.ietf.org/rfc/rfc717.txt
@@ -1,0 +1,109 @@
+NWG/RFC# 717			             JBP  30-JUN-76 16:58  35873
+Assigned Network Numbers
+
+
+
+Network Working Group				    	      Jon Postel
+Request for Comments 717					 SRI-ARC
+NIC 35873						     1 July 1976
+
+			Assigned Network Numbers
+
+This note specifies the numbers assigned to identify networks for use in
+the inter-network protocol experiments.  Additional Numbers are assigned
+by Jon Postel [POSTEL@ISIC or (415) 326-6200 x3718].
+
+Assigned Network Numbers
+
+  Name		Decimal     Octal
+
+  ----------    -------     -----
+
+  BBNRCCnet	   3	       3
+  SanFranPRnet	   7	       7
+  ARPANET	  10	      12
+  BostonPRnet	  11	      13
+
+Internetwork Header Format
+
+  For convenience the current Internetwork protocol header and TCP
+  headers are reproduced here:
+
+  Octet Bit     Use			 (Width)
+
+    --- Beginning of protocol-independent information ---
+
+    0		Destination net		 (8)
+    1-3		Destination host	 (24)
+    4		Source net		 (8)
+    5-7		Source host		 (24)
+    8-9		Data length in octets	 (16)
+    10		Header length in octets	 (8)
+    11	 0-3	Format			 (4)
+      This field selects the appropriate gateway processing and is used
+      to dispatch the packet to the appropriate protocol module in the  
+      destination.  The following values are defined for this field:
+	0 -- Escape; protocol is specified by a subsequent field
+	1 -- TCP
+	2 -- Secure TCP
+	3-16 -- Not allocated
+	17 -- Cross internet debugging
+
+   --- End of protocol-independent information
+
+
+
+
+
+                                  1
+
+NWG/RFC# 717			             JBP  30-JUN-76 16:58  35873
+Assigned Network Numbers
+
+
+   --- Beginning of TCP specific information ---
+
+   11   4-7	Protocol version	 (4)
+   12-15	Sequence number		 (32)
+   16-17	Window			 (16)
+   18-20	Control (as before)	 (24)
+   21-23	Destination port	 (24)
+   24		Packet label for debugging(8)
+   25-27	Source port		 (24)
+   28-31	Acknowledgement number	 (32)
+   32-33	Checksum		 (16)
+   34-		Data			 
+
+   --- End of TCP specific information ---
+
+   --- Beginning of short TCP specific information ---
+
+   11   4-7	Protocol Version	 (4)
+   12-25	Sequence number		 (32)
+   16		Destination KID		 (8)
+   17		Source KID		 (8)
+   18-19	Control (no special function field)(16)
+   20-		Data
+
+   --- End of short TCP specific information ---
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                               2


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc717.txt](<www.ietf.org/rfc/rfc717.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
