### PR TITLE
Archive rfc7184.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7184.txt
+++ b/www.ietf.org/rfc/rfc7184.txt
@@ -1,0 +1,4819 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        U. Herberg
+Request for Comments: 7184               Fujitsu Laboratories of America
+Category: Standards Track                                        R. Cole
+ISSN: 2070-1721                                           US Army CERDEC
+                                                              T. Clausen
+                                                LIX, Ecole Polytechnique
+                                                              April 2014
+
+
+                   Definition of Managed Objects for
+          the Optimized Link State Routing Protocol Version 2
+
+Abstract
+
+   This document defines the Management Information Base (MIB) module
+   for configuring and managing the Optimized Link State Routing
+   Protocol version 2 (OLSRv2).  The OLSRv2-MIB module is structured
+   into configuration information, state information, performance
+   information, and notifications.  This additional state and
+   performance information is useful for troubleshooting problems and
+   performance issues of the routing protocol.  Two levels of compliance
+   allow this MIB module to be deployed on constrained routers.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7184.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+
+
+
+Herberg, et al.              Standards Track                    [Page 1]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction ....................................................2
+   2. The Internet-Standard Management Framework ......................3
+   3. Conventions .....................................................3
+   4. Overview ........................................................3
+      4.1. Terms ......................................................4
+   5. Structure of the MIB Module .....................................4
+      5.1. The Configuration Group ....................................5
+      5.2. The State Group ............................................5
+      5.3. The Performance Group ......................................5
+      5.4. The Notifications Group ....................................5
+      5.5. Tables and Indexing ........................................6
+   6. Relationship to Other MIB Modules ...............................9
+      6.1. Relationship to the SNMPv2-MIB .............................9
+      6.2. Relationship to the NHDP-MIB ...............................9
+      6.3. MIB Modules Required for IMPORTS ...........................9
+   7. Definitions ....................................................10
+   8. Security Considerations ........................................77
+   9. Applicability Statement ........................................80
+   10. IANA Considerations ...........................................81
+   11. Acknowledgements ..............................................81
+   12. References ....................................................82
+      12.1. Normative References .....................................82
+      12.2. Informative References ...................................83
+   Appendix A. IANAolsrv2LinkMetricType-MIB ..........................84
+
+1.  Introduction
+
+   This document defines the Management Information Base (MIB) module
+   for configuring and managing the Optimized Link State Routing
+   Protocol version 2 (OLSRv2).  The OLSRv2-MIB module is structured
+   into configuration information, state information, performance
+   information, and notifications.  In addition to configuration, this
+   additional state and performance information is useful for
+   troubleshooting problems and performance issues of the routing
+   protocol.  Different levels of compliance allow implementers to use
+   smaller subsets of all defined objects, allowing for this MIB module
+   to be deployed on more constrained routers.
+
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 2]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+2.  The Internet-Standard Management Framework
+
+   For a detailed overview of the documents that describe the current
+   Internet-Standard Management Framework, please refer to Section 7 of
+   [RFC3410].
+
+   Managed objects are accessed via a virtual information store, termed
+   the Management Information Base or MIB.  MIB objects are generally
+   accessed through the Simple Network Management Protocol (SNMP).
+   Objects in the MIB module are defined using the mechanisms defined in
+   the Structure of Management Information (SMI).  This document
+   specifies a MIB module that is compliant to the SMIv2, which is
+   described in STD 58, [RFC2578], STD 58, [RFC2579] and STD 58
+   [RFC2580].
+
+3.  Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   [RFC2119].
+
+4.  Overview
+
+   The Optimized Link State Routing Protocol version 2 (OLSRv2)
+   [RFC7181] is a table-driven, proactive routing protocol, i.e., it
+   exchanges topology information with other routers in the network
+   periodically.  OLSRv2 is an optimization of the classical link state
+   routing protocol.  Its key concept is that of multipoint relays
+   (MPRs).  Each router selects a set of its neighbor routers (which
+   "cover" all of its symmetrically connected 2-hop neighbor routers) as
+   MPRs.  MPRs are then used to achieve both flooding reduction and
+   topology reduction.
+
+   This document provides management and control capabilities of an
+   OLSRv2 instance, allowing management applications to monitor the
+   state and performance of an OLSRv2 router, as well as to change
+   settings of the OLSRv2 instance (e.g., router or interface parameters
+   such as message intervals, etc.).
+
+   As OLSRv2 relies on the neighborhood information discovered by the
+   "Mobile Ad Hoc Network (MANET) Neighborhood Discovery Protocol
+   (NHDP)" [RFC6130], the OLSRv2-MIB module is aligned with the NHDP-MIB
+   module [RFC6779] and augments several of the tables and objects in
+   the NHDP-MIB.  In particular, common indexes for router interfaces
+   and discovered neighbors are used, as described in Section 5.2.
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 3]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+4.1.  Terms
+
+   The following definitions apply throughout this document:
+
+   o  Configuration Objects - switches, tables, and objects that are
+      initialized to default settings or set through the management
+      interface defined by this MIB module.
+
+   o  State Objects - automatically generated values that define the
+      current operating state of the OLSRv2 protocol instance in the
+      router.
+
+   o  Performance Objects - automatically generated values that help an
+      administrator or automated tool to assess the performance of the
+      OLSRv2 process on the router.
+
+   o  Notification Objects - objects that define triggers and associated
+      notification messages allowing for asynchronous tracking of
+      predefined events on the managed router.
+
+5.  Structure of the MIB Module
+
+   This section presents the structure of the OLSRv2-MIB module.  The
+   objects are arranged into the following structure:
+
+   o  olsrv2MIBObjects - defines objects forming the basis for the
+      OLSRv2-MIB module.  These objects are divided up by function into
+      the following groups:
+
+      *  Configuration Group - defining objects related to the
+         configuration of the OLSRv2 instance on the router.
+
+      *  State Group - defining objects that reflect the current state
+         of the OLSRv2 instance running on the router.
+
+      *  Performance Group - defining objects that are useful to a
+         management system when characterizing the performance of OLSRv2
+         on the router and in the MANET.
+
+   o  olsrv2MIBNotifications - objects defining OLSRv2-MIB module
+      notifications.
+
+   o  olsrv2MIBConformance - defining the minimal and maximal
+      conformance requirements for implementations of this MIB module.
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 4]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+5.1.  The Configuration Group
+
+   The OLSRv2 router is configured with a set of controls.  The
+   authoritative list of configuration controls within the OLSRv2-MIB
+   module is found within the MIB module itself.  Generally, an attempt
+   was made in developing the OLSRv2-MIB module to support all
+   configuration objects defined in [RFC7181].  For all of the
+   configuration parameters, the same constraints and default values of
+   these parameters as defined in [RFC7181] are followed.
+
+5.2.  The State Group
+
+   The State Group reports current state information of a router running
+   [RFC7181].  The OLSRv2-MIB module State Group tables were designed to
+   contain the complete set of state information defined within the
+   Information Bases in [RFC7181].
+
+   The OLSRv2-MIB module State Group tables are constructed as
+   extensions to the corresponding tables within the State Group of the
+   NHDP-MIB module [RFC6779].  Use of the AUGMENTS clause is made, when
+   possible, to accomplish these table extensions.  Further, the State
+   Group tables defined in this MIB module are aligned with the
+   corresponding tables in the NHDP-MIB module [RFC6779], as described
+   in Section 6.2.
+
+5.3.  The Performance Group
+
+   The Performance Group reports values relevant to system performance.
+   Frequent changes of sets or frequent recalculation of the Routing Set
+   or the MPRs can have a negative influence on the performance of
+   OLSRv2.  This MIB module defines several objects that can be polled,
+   e.g., in order to calculate histories or monitor frequencies of
+   changes.  This may help the network administrator to determine
+   unusual topology changes or other changes that affect stability and
+   reliability of the MANET.  One such framework is specified in REPORT-
+   MIB [REPORT-MIB].
+
+5.4.  The Notifications Group
+
+   The Notifications Group contains Control
+   (olsrv2NotificationsControl), Objects (olsrv2NotificationsObjects),
+   and States (olsrv2NotificationsStates), where the Control contains
+   definitions of objects to control the frequency of notifications
+   being generated.  The Objects define the supported notifications, and
+   the State is used to define additional information to be carried
+   within the notifications.
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 5]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   The olsrv2NotificationsObjects sub-tree contains the list of
+   notifications supported within the OLSRv2-MIB module and their
+   intended purpose or utility.
+
+   The same mechanisms for improving the network performance by reducing
+   the number of notifications apply as defined in Section 5.1 of
+   [RFC6779].  The following objects are used to define the thresholds
+   and time windows for specific notifications defined in the NHDP-MIB
+   module: olsrv2RoutingSetRecalculationCountThreshold,
+   olsrv2RoutingSetRecalculationCountWindow,
+   olsrv2MPRSetRecalculationCountThreshold, and
+   olsrv2MPRSetRecalculationCountWindow.
+
+5.5.  Tables and Indexing
+
+   The OLSRv2-MIB module's tables are indexed by the following
+   constructs:
+
+   o  nhdpIfIndex - the ifIndex of the local router on which NHDP is
+      configured.  This is defined in the NHDP-MIB.
+
+   o  nhdpDiscIfIndex - a locally managed index representing a known
+      interface on a neighboring router.  This is defined in the NHDP-
+      MIB.
+
+   o  nhdpDiscRouterIndex - a locally managed index representing an ID
+      of a known neighboring router.  This is defined in the NHDP-MIB.
+
+   o  {olsrv2LibOrigSetIpAddrType, olsrv2LibOrigSetIpAddr} - this index
+      (pair) uniquely identifies recently used originator addresses
+      found within the olsrv2LibOrigSetTable.
+
+   o  {olsrv2LibLocAttNetSetIpAddrType, olsrv2LibLocAttNetSetIpAddr,
+      olsrv2LibLocAttNetSetIpAddrPrefixLen} - this index (triplet)
+      uniquely identifies local attached networks reachable through
+      local (non-OLSRv2) interfaces on this router.  These are recorded
+      in the olsrv2LibLocAttNetSetTable.
+
+   o  {olsrv2TibAdRemoteRouterSetIpAddrType,
+      olsrv2TibAdRemoteRouterSetIpAddr} - this index (pair) uniquely
+      identifies each router in the network that transmits Topology
+      Control (TC) messages received by this router.  These records are
+      recorded in the olsrv2TibAdRemoteRouterSetIpAddr.
+
+   o  {olsrv2TibRouterTopologySetFromOrigIpAddrType,
+      olsrv2TibRouterTopologySetFromOrigIpAddr,
+      olsrv2TibRouterTopologySetToOrigIpAddrType,
+      olsrv2TibRouterTopologySetToOrigIpAddr} - this index (quadruplet)
+
+
+
+Herberg, et al.              Standards Track                    [Page 6]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      uniquely identifies discovered links within the network recorded
+      by this router.  Information associated with each link is stored
+      in the olsrv2TibRouterTopologySetTable.
+
+   o  {olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType,
+      olsrv2TibRoutableAddressTopologySetFromOrigIpAddr,
+      olsrv2TibRoutableAddressTopologySetFromDestIpAddrType,
+      olsrv2TibRoutableAddressTopologySetFromDestIpAddr} - this index
+      (quadruplet) uniquely identifies reachable addresses within the
+      network and the router's advertising of these addresses.  This
+      information is stored in the
+      olsrv2TibRoutableAddressTopologySetTable.
+
+   o  {olsrv2TibAttNetworksSetOrigIpAddrType,
+      olsrv2TibAttNetworksSetOrigIpAddr,
+      olsrv2TibAttNetworksSetNetIpAddrType,
+      olsrv2TibAttNetworksSetNetIpAddr,
+      olsrv2TibAttNetworksSetNetIpAddrPrefixLen} - this index
+      (quintuplet) uniquely identifies the networks (which may be
+      outside the MANET) and the routers through which these networks
+      can be reached.  This information is stored in the
+      olsrv2TibAttNetworksSetTable.
+
+   o  {olsrv2TibRoutingSetDestIpAddrType, olsrv2TibRoutingSetDestIpAddr,
+      olsrv2TibRoutingSetDestIpAddrPrefixLen} - this index (triplet)
+      uniquely identifies the address of a reachable destination in the
+      network.  This indexes the olsrv2TibRoutingSetTable, which
+      contains the next-hop information to reach the indexed addresses.
+
+   These tables and their indexing are:
+
+   o  olsrv2InterfaceTable - describes the OLSRv2 status on the NHDP
+      interfaces of this router.  This table augments nhdpInterfaceEntry
+      and, as such, it is indexed by the {nhdpIfIndex} from the NHDP-
+      MIB.
+
+   o  olsrv2IibLinkSetTable - records all links from other routers that
+      are, or recently were, 1-hop neighbors.  This table augments
+      nhdpIibLinkSetEntry and, as such, it is indexed by nhdpIfIndex and
+      nhdpDiscIfIndex.
+
+   o  olsrv2Iib2HopSetTable - records network addresses of symmetric
+      2-hop neighbors and the links to the associated 1-hop neighbors.
+      This table augments nhdpIib2HopSetEntry and, as such, it is
+      indexed by {nhdpIfIndex, nhdpDiscIfIndex,
+      nhdpIib2HopSetIpAddressType, nhdpIib2HopSetIpAddress}.
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 7]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   o  olsrv2LibOrigSetTable - records addresses that were recently used
+      as originator addresses by this router.  This table is indexed by
+      {olsrv2LibOrigSetIpAddrType, olsrv2LibOrigSetIpAddr}.
+
+   o  olsrv2LibLocAttNetSetTable - records its local non-OLSRv2
+      interfaces via which it can act as a gateway to other networks.
+      This table is indexed by {olsrv2LibLocAttNetSetIpAddrType,
+      olsrv2LibLocAttNetSetIpAddr,
+      olsrv2LibLocAttNetSetIpAddrPrefixLen}.
+
+   o  olsrv2NibNeighborSetTable - records all network addresses of each
+      1-hop neighbor.  This table augments nhdpNibNeighborSetEntry and,
+      as such, it is indexed by the {nhdpDiscRouterIndex}.
+
+   o  olsrv2TibAdRemoteRouterSetTable - records information describing
+      each remote router in the network that transmits TC messages.
+      This table is indexed by {olsrv2TibAdRemoteRouterSetIpAddrType,
+      olsrv2TibAdRemoteRouterSetIpAddr}.
+
+   o  olsrv2TibRouterTopologySetTable - records topology information
+      about the network.  This table is indexed by
+      {olsrv2TibRouterTopologySetFromOrigIpAddrType,
+      olsrv2TibRouterTopologySetFromOrigIpAddr,
+      olsrv2TibRouterTopologySetToOrigIpAddrType,
+      olsrv2TibRouterTopologySetToOrigIpAddr}.
+
+   o  olsrv2TibRoutableAddressTopologySetTable - records topology
+      information about the routable addresses within the MANET and via
+      which routers they may be reached.  This table is indexed by
+      {olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType,
+      olsrv2TibRoutableAddressTopologySetFromOrigIpAddr,
+      olsrv2TibRoutableAddressTopologySetFromDestIpAddrType,
+      olsrv2TibRoutableAddressTopologySetFromDestIpAddr}.
+
+   o  olsrv2TibAttNetworksSetTable - records information about networks
+      (which may be outside the MANET) attached to other routers and
+      their routable addresses.  This table is indexed by
+      {olsrv2TibAttNetworksSetOrigIpAddrType,
+      olsrv2TibAttNetworksSetOrigIpAddr,
+      olsrv2TibAttNetworksSetNetIpAddrType,
+      olsrv2TibAttNetworksSetNetIpAddr,
+      olsrv2TibAttNetworksSetNetIpAddrPrefixLen}.
+
+   o  olsrv2TibRoutingSetTable - records the first hop along a selected
+      path to each destination for which any such path is known.  This
+      table is indexed by {olsrv2TibRoutingSetDestIpAddrType,
+      olsrv2TibRoutingSetDestIpAddr,
+      olsrv2TibRoutingSetDestIpAddrPrefixLen}.
+
+
+
+Herberg, et al.              Standards Track                    [Page 8]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   o  olsrv2InterfacePerfTable - records performance counters for each
+      active OLSRv2 interface on this device.  This table augments
+      nhdpInterfacePerfEntry and, as such, it is indexed by
+      {nhdpIfIndex} from the NHDP-MIB.
+
+6.  Relationship to Other MIB Modules
+
+   This section specifies the relationship of the MIB modules contained
+   in this document to other standards, particularly to standards
+   containing other MIB modules.  MIB modules and specific definitions
+   imported from MIB modules that SHOULD be implemented in conjunction
+   with the MIB module contained within this document are identified in
+   this section.
+
+6.1.  Relationship to the SNMPv2-MIB
+
+   The System group in the SNMPv2-MIB module [RFC3418] is defined as
+   being mandatory for all systems, and the objects apply to the entity
+   as a whole.  The System group provides identification of the
+   management entity and certain other system-wide data.  The OLSRv2-MIB
+   module does not duplicate those objects.
+
+6.2.  Relationship to the NHDP-MIB
+
+   OLSRv2 depends on the neighborhood information that is discovered by
+   [RFC6130].  An instance of OLSRv2 MUST have an associated instance of
+   NHDP running on the same device for proper operations of the
+   discovery and routing system.  In order for the OLSRv2-MIB module to
+   correctly populate the objects relating to discovered neighbors, the
+   State Group tables of the NHDP-MIB module [RFC6779] are aligned with
+   the State Group tables of this MIB module.  This is accomplished
+   through the use of the AUGMENTS capability of SMIv2 (where
+   appropriate).  This will allow for cross referencing of information
+   between the two MIB modules within a given SNMP context.
+
+6.3.  MIB Modules Required for IMPORTS
+
+   The following OLSRv2-MIB module IMPORTS objects from NHDP-MIB
+   [RFC6779], SNMPv2-SMI [RFC2578], SNMPv2-TC [RFC2579], SNMPv2-CONF
+   [RFC2580], IF-MIB [RFC2863], and INET-ADDRESS-MIB [RFC4001].  The
+   OLSRv2-MIB module also IMPORTS objects from the
+   IANAolsrv2LinkMetricType-MIB, which is available at <http://
+   www.iana.org/assignments/ianaolsrv2linkmetrictype-mib>.
+
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                    [Page 9]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+7.  Definitions
+
+   This section contains the OLSRv2-MIB module defined by the
+   specification.
+
+   OLSRv2-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+
+      MODULE-IDENTITY, OBJECT-TYPE, Counter32, Counter64,
+      Integer32, Unsigned32, mib-2, TimeTicks,
+      NOTIFICATION-TYPE
+               FROM SNMPv2-SMI -- RFC 2578
+
+      TEXTUAL-CONVENTION, TimeStamp, TruthValue
+               FROM SNMPv2-TC -- RFC 2579
+
+      MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+               FROM SNMPv2-CONF -- STD 58
+
+      InetAddressType, InetAddress,
+      InetAddressPrefixLength
+               FROM INET-ADDRESS-MIB -- RFC 4001
+
+      nhdpInterfaceEntry,
+      nhdpIibLinkSetEntry, nhdpIib2HopSetEntry,
+      nhdpNibNeighborSetEntry, nhdpInterfacePerfEntry
+               FROM NHDP-MIB -- RFC 6779
+
+      IANAolsrv2LinkMetricTypeTC
+               FROM IANA-OLSRv2-LINK-METRIC-TYPE-MIB
+      ;
+
+   manetOlsrv2MIB MODULE-IDENTITY
+      LAST-UPDATED "201404090000Z"   -- 09 April 2014
+      ORGANIZATION "IETF MANET Working Group"
+      CONTACT-INFO
+         "WG E-Mail: manet@ietf.org
+
+          WG Chairs: sratliff@cisco.com
+                     jmacker@nrl.navy.mil
+
+          Editors:   Ulrich Herberg
+                     Fujitsu Laboratories of America
+                     1240 East Arques Avenue
+                     Sunnyvale, CA 94085
+                     USA
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 10]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+                     Email: ulrich@herberg.name
+                     URI: http://www.herberg.name/
+
+                     Thomas Heide Clausen
+                     Ecole Polytechnique
+                     LIX
+                     91128 Palaiseau Cedex
+                     France
+                     Email: T.Clausen@computer.org
+                     URI: http://www.thomasclausen.org/
+
+                     Robert G. Cole
+                     US Army CERDEC
+                     Space and Terrestrial Communications
+                     6010 Frankford Street
+                     Bldg 6010, Room 453H
+                     Aberdeen Proving Ground, MD 21005
+                     USA
+                     Phone: +1 443 395-8744
+                     Email: robert.g.cole@us.army.mil
+                     URI: http://www.cs.jhu.edu/~rgcole"
+
+      DESCRIPTION
+         "This OLSRv2-MIB module is applicable to routers
+          implementing the Optimized Link State Routing
+          Protocol version 2 (OLSRv2) defined in RFC 7181.
+
+          Copyright (c) 2014 IETF Trust and the persons
+          identified as authors of the code.  All rights reserved.
+
+          Redistribution and use in source and binary forms, with
+          or without modification, is permitted pursuant to, and
+          subject to the license terms contained in, the Simplified
+          BSD License set forth in Section 4.c of the IETF Trust's
+          Legal Provisions Relating to IETF Documents
+          (http://trustee.ietf.org/license-info).
+
+          This version of this MIB module is part of RFC 7184; see
+          the RFC itself for full legal notices."
+
+        -- Revision History
+        REVISION    "201404090000Z"   -- 09 April 2014
+        DESCRIPTION
+         "Initial version of this MIB module,
+          published as RFC 7184."
+
+        ::= { mib-2 219 }
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 11]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+--
+-- TEXTUAL CONVENTIONS
+--
+
+Olsrv2MetricValueCompressedFormTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "d"
+   STATUS      current
+   DESCRIPTION
+      "OLSRv2 Metrics are expressed in terms of a Link Metric
+       Compressed Form within the OLSRv2 protocol.  This textual
+       convention defines the syntax of the metric objects
+       consistent with the definitions of the OLSRv2 Link
+       Metric Compressed Form in Section 6.2 of RFC 7181.
+
+       The 12-bit compressed form of a link metric uses a modified
+       form of a representation with an 8-bit mantissa (denoted a)
+       and a 4-bit exponent (denoted b).  Note that if represented
+       as the 12-bit value 256b+a, then the ordering of those 12-bit
+       values is identical to the ordering of the represented values.
+
+       The value so represented is (257+a)2^b - 256, where ^ denotes
+       exponentiation.  This has a minimum value
+       (when a = 0 and b = 0) of MINIMUM_METRIC = 1 and a maximum
+       value (when a = 255 and b = 15) of MAXIMUM_METRIC = 2^24 - 256.
+
+       Hence, the metric values so represented range from 1 to
+       16776960.  The special value of 0 is reserved for the
+       UNKNOWN_METRIC value.
+
+       If a network manager sets the metric value 'm' through the
+       MIB module, then the OLSRv2 code can both use this value
+       and derive a compressed representation of 'm' (as used in
+       messages) as specified in Section 6.2 of RFC7181.
+       The value 'm' is persistently stored by the MIB module.
+       If the MIB module is pulling this metric's value from some other
+       source, e.g., the protocol instance, then this value is stored
+       as is."
+   SYNTAX  Unsigned32 (0..16776960)
+
+Olsrv2TimeValueCompressedForm32TC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "x"
+   STATUS      current
+   DESCRIPTION
+      "OLSRv2 time values may be expressed in terms of a compressed
+       form within the OLSRv2 protocol.  This textual convention
+       defines the syntax of the time objects defined in terms of
+       an integer number of milliseconds, consistent with the
+       definitions of the 8-bit exponent-mantissa compressed form
+
+
+
+Herberg, et al.              Standards Track                   [Page 12]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+       defined in Section 5 of RFC 5497.  Time values with this
+       representation are defined in terms of a constant C, which
+       is represented in terms of seconds.  The constant C
+       (time granularity) is used as specified in RFC 5497.
+       It MUST be the same as is used by NHDP (RFC 6130).
+
+       The 8-bit compressed form of a time value uses a modified
+       form of a representation with a 3-bit mantissa (denoted a)
+       and a 5-bit exponent (denoted b).  Note that if represented
+       as the 8-bit value 8b+a, then the ordering of those 8-bit
+       values is identical to the ordering of the represented values.
+
+       The minimum time value that can be represented in this manner
+       is C.  The maximum time value that can be represented in
+       this manner is 15 * 2^28 * C, 15*268,435,456 * C,
+       4,026,531,840 * C, or about 45 days if, for example,
+       C = 1/1024 second.
+
+       This TEXTUAL-CONVENTION limits the maximum value of the
+       time granularity constant C to be no greater than 1/1024
+       seconds due to its use of the Unsigned32 syntax limiting
+       the maximum number of milliseconds to no more than
+       3932160000.
+
+       When OLSRv2 uses this 8-bit exponent-mantissa compressed
+       form, this object value MUST be translated from the
+       integer form represented in this MIB module into the
+       exponent-mantissa form for the OLSRv2 protocol to use
+       according to the algorithm defined in Section 5 of
+       RFC 5497 for finding the next larger time value within
+       the exponent-mantissa format.
+
+       If a network manager sets the time value 't' through the
+       MIB module, then the OLSRv2 code can derive
+       'compressed_t' = T(a,b) according to the algorithm
+       in RFC 5497 and 'compressed_t' is the value represented
+       in the OLSRv2 messages.  But, the value 't' is persistently
+       stored by the MIB module.  If the MIB module is pulling
+       this time parameter from some other source that is using
+       the compressed form, i.e., the protocol instance, then
+       this value is stored as is, after converting from
+       number of time constants C into number of milliseconds."
+   SYNTAX  Unsigned32 (1..3932160000)
+
+Olsrv2StatusTC ::= TEXTUAL-CONVENTION
+   STATUS      current
+   DESCRIPTION
+      "Controls the operation of the OLSRv2
+
+
+
+Herberg, et al.              Standards Track                   [Page 13]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+       protocol on the device or a specific interface.
+       For example, for an interface, 'enabled' indicates
+       that OLSRv2 is permitted to operate,
+       and 'disabled' indicates that it is not."
+   SYNTAX  INTEGER {
+      enabled (1),
+      disabled (2)
+   }
+
+WillingnessTC ::= TEXTUAL-CONVENTION
+   DISPLAY-HINT "x"
+   STATUS    current
+   DESCRIPTION
+      "A willingness value that evaluates to the
+       device's interest in participating in
+       a particular function, process, or behavior.
+
+       The willingness ranges from a low value of
+       WILL_NEVER(0) to a high value of
+       WILL_ALWAYS(15).  For each parameter x,
+       there is an associated willingness value
+       W(x) such that WILL_NEVER < W(x) <= WILL_ALWAYS."
+   SYNTAX   Unsigned32 (0..15)
+
+
+--
+-- Top-Level Object Identifier Assignments
+--
+
+olsrv2MIBNotifications OBJECT IDENTIFIER ::= { manetOlsrv2MIB 0 }
+olsrv2MIBObjects       OBJECT IDENTIFIER ::= { manetOlsrv2MIB 1 }
+olsrv2MIBConformance   OBJECT IDENTIFIER ::= { manetOlsrv2MIB 2 }
+
+--
+-- olsrv2ConfigurationGroup
+--
+
+--    Contains the OLSRv2 objects that configure specific
+--    options that determine the overall performance and operation
+--    of the OLSRv2 routing process.
+
+olsrv2ConfigurationGroup OBJECT IDENTIFIER ::= {olsrv2MIBObjects 1}
+
+
+   olsrv2AdminStatus  OBJECT-TYPE
+      SYNTAX      Olsrv2StatusTC
+      MAX-ACCESS  read-write
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 14]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "The configured status of the OLSRv2 process
+          on this device.  'enabled(1)' means that
+          OLSRv2 is configured to run on this device.
+          'disabled(2)' mean that the OLSRv2 process
+          is configured off.
+
+          Operation of the OLSRv2 protocol
+          requires the operation of the Neighborhood
+          Discovery Protocol (RFC 6130).  Hence, this
+          object cannot have a status of 'enabled'
+          unless at least one interface on the device
+          is a MANET interface with NHDP enabled on that
+          interface.  If a network manager attempts to
+          set this object to 'enabled' when no interfaces
+          on this device have NHDP enabled, the device
+          MUST fail the set with inconsistentValue.
+          If all device interfaces running NHDP become
+          disabled or removed, then the
+          olsrv2AdminStatus MUST be 'disabled'.
+
+          If the network manager, or other means, sets
+          this object to 'disabled', then the associated
+          interface specific objects, i.e., the
+          olsrv2InterfaceAdminStatus objects MUST all
+          be 'disabled'.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      DEFVAL { disabled }
+   ::= { olsrv2ConfigurationGroup 1 }
+
+   olsrv2InterfaceTable  OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2InterfaceEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The olsrv2InterfaceTable describes the OLSRv2
+          status on the NHDP interfaces of this router.
+          As such, this table augments the nhdpInterfaceTable
+          defined in the NHDP-MIB (RFC 6779).  NHDP interfaces
+          are explicitly defined by network management, command
+          line interface (CLI) or other means for interfaces on
+          the device that are intended to run MANET protocols.
+          The olsrv2InterfaceTable contains a single object: the
+          olsrv2InterfaceAdminStatus object.  This
+          object is set by network management, or by
+
+
+
+Herberg, et al.              Standards Track                   [Page 15]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          other means, e.g., CLI.
+
+          A conceptual row in this table exists if and only
+          if a corresponding entry in the nhdpInterfaceTable
+          exists.  If the corresponding entry with nhdpIfIndex
+          value is deleted from the nhdpInterfaceTable, then
+          the entry in this table is automatically deleted and
+          OLSRv2 is disabled on this interface,
+          and all configuration and state information
+          related to this interface is to be removed
+          from memory.
+
+          The olsrv2InterfaceAdminStatus can only be
+          'enabled' if the corresponding olsrv2AdminStatus
+          object is also set to 'enabled'."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2ConfigurationGroup 2 }
+
+   olsrv2InterfaceEntry OBJECT-TYPE
+      SYNTAX      Olsrv2InterfaceEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The olsrv2InterfaceEntry describes one OLSRv2
+          local interface configuration as indexed by
+          its nhdpIfIndex, as defined in the
+          NHDP-MIB (RFC 6779).
+
+          The objects in this table are persistent, and when
+          written, the device SHOULD save the change to
+          non-volatile storage.  For further information
+          on the storage behavior for these objects, refer
+          to the description for the nhdpIfRowStatus
+          object in the NHDP-MIB (RFC6779)."
+      REFERENCE
+         "RFC 6779 - Definition of Managed Objects for
+          the Neighborhood Discovery Protocol,
+          Herberg, U., Cole, R.G., and I. Chakeres,
+          October 2012"
+      AUGMENTS { nhdpInterfaceEntry }
+   ::= { olsrv2InterfaceTable 1 }
+
+   Olsrv2InterfaceEntry ::=
+      SEQUENCE {
+         olsrv2InterfaceAdminStatus
+
+
+
+Herberg, et al.              Standards Track                   [Page 16]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+            Olsrv2StatusTC
+      }
+
+   olsrv2InterfaceAdminStatus OBJECT-TYPE
+      SYNTAX      Olsrv2StatusTC
+      MAX-ACCESS  read-create
+      STATUS      current
+      DESCRIPTION
+         "The OLSRv2 interface's administrative status.
+          The value 'enabled(1)' denotes that the interface
+          is permitted to participate in the OLSRv2 routing
+          process.  The value 'disabled(2)' denotes that
+          the interface is not permitted to participate
+          in the OLSRv2 routing process.
+
+          The configuration objects for the OLSRv2 routing
+          process, other than the administrative status objects,
+          are common to all interfaces on this device.
+          As such, the OLSRv2 configuration objects are globally
+          defined for the device and are not contained within
+          the olsrv2InterfaceTable."
+      DEFVAL { disabled }
+   ::= { olsrv2InterfaceEntry 1 }
+
+   olsrv2OrigIpAddrType  OBJECT-TYPE
+       SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+          "The type of the olsrv2OrigIpAddr, as defined
+           in the InetAddress MIB module (RFC 4001).
+
+           Only the values 'ipv4(1)' and
+           'ipv6(2)' are supported."
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2ConfigurationGroup 3 }
+
+   olsrv2OrigIpAddr  OBJECT-TYPE
+       SYNTAX      InetAddress (SIZE(4|16))
+       MAX-ACCESS  read-write
+       STATUS      current
+       DESCRIPTION
+          "The router's originator address.  An address that
+           is unique (within the MANET) to this router.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 17]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+           This object is persistent, and when written,
+           the entity SHOULD save the change to
+           non-volatile storage."
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2ConfigurationGroup 4 }
+
+   --
+   -- Local History Times
+   --
+
+   olsrv2OHoldTime  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2OHoldTime corresponds to
+         O_HOLD_TIME of OLSRv2, and represents the
+         time for which a recently used and replaced
+         originator address is used to recognize the router's
+         own messages.
+
+         Guidance for setting this object may be found
+         in Section 5 of the OLSRv2 specification (RFC 7181),
+         which indicates that:
+             o  olsrv2OHoldTime > 0
+
+         This object is persistent, and when written,
+         the entity SHOULD save the change to
+         non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 30000 }
+   ::= { olsrv2ConfigurationGroup 5 }
+
+
+   --
+   -- Message intervals
+   --
+
+   olsrv2TcInterval  OBJECT-TYPE
+      SYNTAX      Olsrv2TimeValueCompressedForm32TC
+
+
+
+Herberg, et al.              Standards Track                   [Page 18]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TcInterval corresponds to
+         TC_INTERVAL of OLSRv2 and represents the
+         maximum time between the transmission of
+         two successive TC messages by this router.
+
+         Guidance for setting this object may be found
+         in Section 5 of the OLSRv2 specification (RFC 7181),
+         which indicates that:
+
+             o olsrv2TcInterval > 0
+             o olsrv2TcInterval >= olsrv2TcMinInterval
+
+         This object is persistent, and when written,
+         the entity SHOULD save the change to
+         non-volatile storage."
+      REFERENCE
+         "Section 5 on Representing Time.
+          RFC 5497 - Representing Multi-Value Time in
+          Mobile Ad Hoc Networks (MANETs),
+          Clausen, T. and C. Dearlove, March 2009.
+
+          and
+
+          Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 5000 }
+   ::= { olsrv2ConfigurationGroup 6 }
+
+   olsrv2TcMinInterval  OBJECT-TYPE
+      SYNTAX      Olsrv2TimeValueCompressedForm32TC
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TcMinInterval corresponds to
+         TC_MIN_INTERVAL of OLSRv2 and represents
+         the minimum interval between transmission of
+         two successive TC messages by this router.
+
+         Guidance for setting this object may be found
+         in Section 5 of the OLSRv2 specification (RFC 7181),
+         which indicates that:
+
+
+
+Herberg, et al.              Standards Track                   [Page 19]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+             o olsrv2TcInterval >= olsrv2TcMinInterval
+
+         The OLSRv2 protocol may choose to represent this
+         time interval in terms of the 8-bit exponent-mantissa
+         form defined in Section 5 of RFC 5497.  When this
+         is the case, this object value MUST be translated
+         from the integer form represented in this
+         MIB module into the exponent-mantissa form for the
+         OLSRv2 protocol to use according to the algorithm
+         defined in Section 5 of RFC 5497 for finding the
+         next larger time value within the exponent-mantissa
+         format.
+
+         This object is persistent, and when written,
+         the entity SHOULD save the change to
+         non-volatile storage."
+      REFERENCE
+         "Section 5 on Representing Time.
+          RFC 5497 - Representing Multi-Value Time in
+          Mobile Ad Hoc Networks (MANETs),
+          Clausen, T. and C. Dearlove, March 2009.
+
+          and
+
+          Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 1250 }
+   ::= { olsrv2ConfigurationGroup 7 }
+
+
+   --
+   -- Advertised information validity times
+   --
+
+   olsrv2THoldTime  OBJECT-TYPE
+      SYNTAX      Olsrv2TimeValueCompressedForm32TC
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2THoldTime corresponds to
+         T_HOLD_TIME of OLSRv2 and is used as the
+         minimum value in the TLV with
+         Type = VALIDITY_TIME included in all
+         TC messages sent by this router.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 20]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         Guidance for setting this object may be found
+         in Section 5 of the OLSRv2 specification (RFC 7181),
+         which indicates that:
+             o olsrv2THoldTime >= olsrv2TcInterval
+             o If TC messages can be lost, then
+               olsrv2THoldTime SHOULD be
+               significantly greater than olsrv2TcInterval;
+               a value >= 3 x olsrv2TcInterval is RECOMMENDED.
+
+         This object is persistent, and when written,
+         the entity SHOULD save the change to
+         non-volatile storage."
+      REFERENCE
+         "Section 5 on Representing Time.
+          RFC 5497 - Representing Multi-Value Time in
+          Mobile Ad Hoc Networks (MANETs),
+          Clausen, T. and C. Dearlove, March 2009.
+
+          and
+
+          Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 15000 }
+   ::= { olsrv2ConfigurationGroup 8 }
+
+   olsrv2AHoldTime  OBJECT-TYPE
+      SYNTAX      Olsrv2TimeValueCompressedForm32TC
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2AHoldTime corresponds to
+         A_HOLD_TIME of OLSRv2 and represents
+         the period during which TC messages are sent
+         after they no longer have any advertised
+         information to report, but are sent in order
+         to accelerate outdated information removal by other
+         routers.
+
+         Guidance for setting this object may be found
+         in Section 5 of the OLSRv2 specification (RFC 7181),
+         which indicates that:
+            o If TC messages can be lost, then
+              olsrv2AHoldTime SHOULD be
+              significantly greater than olsrv2TcInterval;
+              a value >= 3 x olsrv2TcInterval is
+
+
+
+Herberg, et al.              Standards Track                   [Page 21]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+              RECOMMENDED.
+
+         This object is persistent, and when written,
+         the entity SHOULD save the change to
+         non-volatile storage."
+      REFERENCE
+         "Section 5 on Representing Time.
+          RFC 5497 - Representing Multi-Value Time in
+          Mobile Ad Hoc Networks (MANETs),
+          Clausen, T. and C. Dearlove, March 2009.
+
+          and
+
+          Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 15000 }
+   ::= { olsrv2ConfigurationGroup 9 }
+
+   --
+   -- Received message validity times
+   --
+
+   olsrv2RxHoldTime  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2RxHoldTime corresponds to
+          RX_HOLD_TIME of OLSRv2 and represents the period
+          after receipt of a message by the appropriate OLSRv2
+          interface of this router for which that information
+          is recorded, in order that the message is recognized
+          as having been previously received on this OLSRv2
+          interface.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o olsrv2RxHoldTime > 0
+             o This parameter SHOULD be greater
+               than the maximum difference in time that a
+               message may take to traverse the MANET,
+               taking into account any message forwarding
+               jitter as well as propagation, queuing,
+               and processing delays.
+
+
+
+Herberg, et al.              Standards Track                   [Page 22]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 30000 }
+   ::= { olsrv2ConfigurationGroup 10 }
+
+   olsrv2PHoldTime  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2PHoldTime corresponds to
+          P_HOLD_TIME of OLSRv2 and represents the period
+          after receipt of a message that is processed by
+          this router for which that information is recorded,
+          in order that the message is not processed again
+          if received again.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o olsrv2PHoldTime > 0
+             o This parameter SHOULD be greater
+               than the maximum difference in time that a
+               message may take to traverse the MANET,
+               taking into account any message forwarding
+               jitter as well as propagation, queuing,
+               and processing delays.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 30000 }
+   ::= { olsrv2ConfigurationGroup 11 }
+
+   olsrv2FHoldTime  OBJECT-TYPE
+      SYNTAX      Unsigned32
+
+
+
+Herberg, et al.              Standards Track                   [Page 23]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2FHoldTime corresponds to
+          F_HOLD_TIME of OLSRv2 and represents the period
+          after receipt of a message that is forwarded by this
+          router for which that information is recorded, in order
+          that the message is not forwarded again if received again.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o olsrv2FHoldTime > 0
+             o This parameter SHOULD be greater
+               than the maximum difference in time that a
+               message may take to traverse the MANET,
+               taking into account any message forwarding
+               jitter as well as propagation, queuing,
+               and processing delays.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 30000 }
+   ::= { olsrv2ConfigurationGroup 12 }
+
+   --
+   -- Jitter times
+   --
+
+   olsrv2TpMaxJitter  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TpMaxJitter corresponds to
+          TP_MAXJITTER of OLSRv2 and represents the value
+          of MAXJITTER used in RFC 5148 for periodically
+          generated TC messages sent by this router.
+
+          For constraints on these parameters, see RFC 5148.
+
+
+
+Herberg, et al.              Standards Track                   [Page 24]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 500 }
+   ::= { olsrv2ConfigurationGroup 13 }
+
+   olsrv2TtMaxJitter  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TtMaxJitter corresponds to
+          TT_MAXJITTER of OLSRv2 and represents the value
+          of MAXJITTER used in RFC 5148 for externally
+          triggered TC messages sent by this router.
+
+          For constraints on these parameters, see RFC 5148.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 500 }
+   ::= { olsrv2ConfigurationGroup 14 }
+
+   olsrv2FMaxJitter  OBJECT-TYPE
+      SYNTAX      Unsigned32
+      UNITS       "milliseconds"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2FMaxJitter corresponds to
+          F_MAXJITTER of OLSRv2 and represents the
+          default value of MAXJITTER used in RFC 5148 for
+          messages forwarded by this router.
+
+          For constraints on these parameters, see RFC 5148.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 25]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 500 }
+   ::= { olsrv2ConfigurationGroup 15 }
+
+   --
+   -- Hop limits
+   --
+
+   olsrv2TcHopLimit  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..255)
+      UNITS       "hops"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TcHopLimit corresponds to
+          TC_HOP_LIMIT of OLSRv2.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o The maximum value of
+               olsrv2TcHopLimit >= the network diameter
+               in hops, a value of 255 is RECOMMENDED.
+             o olsrv2TcHopLimit >= 2.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+       REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+       DEFVAL { 255 }
+   ::= { olsrv2ConfigurationGroup 16 }
+
+   --
+   -- Willingness
+   --
+
+   olsrv2WillRouting  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 26]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      WillingnessTC
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2WillRouting corresponds to
+          WILL_ROUTING of OLSRv2.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o WILL_NEVER (0) <= olsrv2WillRouting <=
+                                  WILL_ALWAYS (15)
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 7 }
+   ::= { olsrv2ConfigurationGroup 17 }
+
+   olsrv2WillFlooding     OBJECT-TYPE
+      SYNTAX      WillingnessTC
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2WillFlooding corresponds to
+          WILL_FLOODING of OLSRv2.
+
+          Guidance for setting this object may be found
+          in Section 5 of the OLSRv2 specification (RFC 7181),
+          which indicates that:
+             o WILL_NEVER (0) <= olsrv2WillFlooding <=
+                                  WILL_ALWAYS (15)
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { 7 }
+   ::= { olsrv2ConfigurationGroup 18 }
+
+
+
+Herberg, et al.              Standards Track                   [Page 27]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   olsrv2LinkMetricType  OBJECT-TYPE
+      SYNTAX      IANAolsrv2LinkMetricTypeTC
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2LinkMetricType corresponds to
+          LINK_METRIC_TYPE of OLSRv2.
+
+          If olsrv2LinkMetricType changes, then all
+          link metric information recorded by this router
+          is invalid.  The router MUST take the
+          actions described in Section 5.5.
+          'Parameter Change Constraints' and
+          Section 17 'Information Base Changes'
+          in RFC 7181.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "Section 5 on Protocol Parameters.
+          RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      DEFVAL { unknown }
+   ::= { olsrv2ConfigurationGroup 19 }
+
+--
+-- olsrv2StateGroup
+--
+
+--
+-- Contains information describing the current state of
+-- the OLSRv2 process.
+--
+
+olsrv2StateGroup  OBJECT IDENTIFIER ::= { olsrv2MIBObjects 2 }
+
+   --
+   -- Interface Information Base (IIB)
+   --
+
+   --
+   -- Link Set from RFC 6130, extended by L_in_metric,
+   -- L_out_metric, and L_mpr_selector entries for each tuple
+   --
+
+   olsrv2IibLinkSetTable OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 28]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX       SEQUENCE OF Olsrv2IibLinkSetEntry
+      MAX-ACCESS   not-accessible
+      STATUS       current
+      DESCRIPTION
+         "A Link Set of an interface records all links
+          from other routers that are, or recently
+          were, 1-hop neighbors."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 1 }
+
+   olsrv2IibLinkSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2IibLinkSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A Link Set consists of Link Tuples, each
+          representing a single link indexed by the
+          local and remote interface pair.  Each Link Set
+          from NHDP is extended by OLSRv2 by the following
+          fields:
+
+          (L_in_metric (olsrv2IibLinkSetInMetricValue),
+           L_out_metric (olsrv2IibLinkSetOutMetricValue),
+           L_mpr_selector (olsrv2IibLinkSetMprSelector))"
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      AUGMENTS { nhdpIibLinkSetEntry }
+   ::= { olsrv2IibLinkSetTable 1 }
+
+   Olsrv2IibLinkSetEntry ::=
+      SEQUENCE {
+         olsrv2IibLinkSetInMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2IibLinkSetOutMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2IibLinkSetMprSelector
+            TruthValue
+      }
+
+   olsrv2IibLinkSetInMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 29]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "olsrv2IibLinkSetInMetricValue is the metric of the link
+          from the OLSRv2 interface with addresses
+          L_neighbor_iface_addr_list to this OLSRv2 interface.
+          The L_neighbor_iface_addr_list is identified by
+          the nhdpDiscIfIndex, which is an index to the
+          nhdpIibLinkSetTable, which this table augments."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2IibLinkSetEntry 1 }
+
+   olsrv2IibLinkSetOutMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "olsrv2IibLinkSetOutMetricValue is the metric of the
+          link to the OLSRv2 interface with addresses
+          L_neighbor_iface_addr_list from this OLSRv2 interface.
+          The L_neighbor_iface_addr_list is identified by
+          the nhdpDiscIfIndex, which is an index to the
+          nhdpIibLinkSetTable, which this table augments."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2IibLinkSetEntry 2 }
+
+   olsrv2IibLinkSetMprSelector  OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2IibLinkSetMprSelector is a boolean flag,
+          recording whether this neighbor has selected this router
+          as a flooding MPR, i.e., is a flooding MPR selector
+          of this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2IibLinkSetEntry 3 }
+
+   --
+   -- 2-Hop Set; from RFC 6130, extended by OLSRv2 by the
+   -- following fields: N2_in_metric, N2_out_metric
+
+
+
+Herberg, et al.              Standards Track                   [Page 30]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   --
+
+   olsrv2Iib2HopSetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2Iib2HopSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A 2-Hop Set of an interface records network
+          addresses of symmetric 2-hop neighbors, and
+          the symmetric links to symmetric 1-hop neighbors
+          through which these symmetric 2-hop neighbors
+          can be reached.  It consists of 2-Hop Tuples."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 2 }
+
+   olsrv2Iib2HopSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2Iib2HopSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "olsrv2Iib2HopSetTable consists of 2-Hop Tuples,
+          each representing a single network address of
+          a symmetric 2-hop neighbor and a single MANET
+          interface of a symmetric 1-hop neighbor.
+          Each 2-Hop Set from NHDP is extended by
+          OLSRv2 by the following fields:
+
+          (N2_in_metric (olsrv2Iib2HopSetInMetricValue),
+           N2_out_metric (olsrv2Iib2HopSetOutMetricValue))"
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      AUGMENTS { nhdpIib2HopSetEntry }
+   ::= { olsrv2Iib2HopSetTable 1 }
+
+   Olsrv2Iib2HopSetEntry ::=
+      SEQUENCE {
+         olsrv2Iib2HopSetInMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2Iib2HopSetOutMetricValue
+            Olsrv2MetricValueCompressedFormTC
+      }
+
+   olsrv2Iib2HopSetInMetricValue  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 31]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2Iib2HopSetInMetricValue is the neighbor
+          metric from the router with address
+          N2_2hop_iface_addr to the router
+          with OLSRv2 interface addresses
+          N2_neighbor_iface_addr_list.
+
+          The N2_2hop_iface_addr is identified by the
+          (nhdpIib2HopSetIpAddressType,
+          nhdpIib2HopSetIpAddress) pair from the
+          nhdpIibLinkSetTable, which this table augments.
+
+          The N2_neighbor_iface_addr_list is defined by
+          the nhdpDiscIfIndex, which is an index of the
+          nhdpIibLinkSetTable, which this table augments."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014.
+
+          and
+
+          RFC 6779 - Definition of Managed Objects for the
+          Neighborhood Discovery Process, Herberg, U.,
+          Cole, R., and I. Chakeres, October 2012."
+   ::= { olsrv2Iib2HopSetEntry 1 }
+
+   olsrv2Iib2HopSetOutMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2Iib2HopSetOutMetricValue is the neighbor metric
+          to the router with address N2_2hop_iface_addr
+          from the router with OLSRv2 interface addresses
+          N2_neighbor_iface_addr_list.
+
+          The N2_2hop_iface_addr is identified by the
+          (nhdpIib2HopSetIpAddressType,
+          nhdpIib2HopSetIpAddress) pair from the
+          nhdpIibLinkSetTable, which this table augments.
+
+          The N2_neighbor_iface_addr_list is defined by
+          the nhdpDiscIfIndex, which is an index of the
+          nhdpIibLinkSetTable, which this table augments."
+
+
+
+Herberg, et al.              Standards Track                   [Page 32]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014.
+
+          and
+
+          RFC 6779 - Definition of Managed Objects for the
+          Neighborhood Discovery Process, Herberg, U.,
+          Cole, R., and I. Chakeres, October 2012."
+   ::= { olsrv2Iib2HopSetEntry 2 }
+
+   --
+   -- Local Information Base  - as defined in RFC 6130,
+   -- extended by the addition of an Originator Set,
+   -- defined in Section 6.1 and a Local Attached
+   -- Network Set, defined in Section 6.2.
+   --
+
+   --
+   -- Originator Set
+   --
+
+   olsrv2LibOrigSetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2LibOrigSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Originator Set records addresses
+          that were recently used as originator addresses
+          by this router."
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 3 }
+
+   olsrv2LibOrigSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2LibOrigSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Originator Set consists of
+          Originator Tuples:
+
+          (O_orig_addr (olsrv2LibOrigSetIpAddrType
+           and olsrv2LibOrigSetIpAddr),
+           O_time (olsrv2LibOrigSetExpireTime))."
+
+
+
+Herberg, et al.              Standards Track                   [Page 33]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2LibOrigSetIpAddrType,
+              olsrv2LibOrigSetIpAddr }
+   ::= { olsrv2LibOrigSetTable 1 }
+
+   Olsrv2LibOrigSetEntry ::=
+      SEQUENCE {
+         olsrv2LibOrigSetIpAddrType
+            InetAddressType,
+         olsrv2LibOrigSetIpAddr
+            InetAddress,
+         olsrv2LibOrigSetExpireTime
+            TimeStamp
+      }
+
+   olsrv2LibOrigSetIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2LibOrigSetIpAddr,
+          as defined in the InetAddress MIB (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibOrigSetEntry 1 }
+
+   olsrv2LibOrigSetIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "An originator address recently employed
+          by this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibOrigSetEntry 2 }
+
+   olsrv2LibOrigSetExpireTime  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 34]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      TimeStamp
+      UNITS      "centiseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2LibOrigSetExpireTime specifies the value
+          of sysUptime when this entry SHOULD expire and be
+          removed from the olsrv2LibOrigSetTable.  This time
+          is determined at the time the entry is added,
+          derived from the following expression:
+
+             O_time := current time + O_HOLD_TIME
+
+          where O_time is olsrv2LibOrigSetExpireTime,
+          current_time is current sysUptime, and
+          O_HOLD_TIME is a parameter of the OLSRv2
+          protocol.  In the event that the
+          O_HOLD_TIME is changed, the
+          olsrv2LibOrigSetExpireTime needs to be
+          recomputed for each of the entries in this table."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibOrigSetEntry 3 }
+
+   --
+   -- Local Attached Network Set
+   --
+
+   olsrv2LibLocAttNetSetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2LibLocAttNetSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Local Attached Network Set records
+          its local non-OLSRv2 interfaces via which it
+          can act as a gateway to other networks."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 4 }
+
+   olsrv2LibLocAttNetSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2LibLocAttNetSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 35]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "The entries include the Local Attached
+          Network Tuples:
+
+          (AL_net_addr (olsrv2LibLocAttNetSetIpAddr),
+           AL_dist (olsrv2LibLocAttNetSetDistance),
+           AL_metric (olsrv2LibLocAttNetSetMetricValue)
+          )
+
+          where:
+
+             AL_net_addr is the network address
+             of an attached network that can
+             be reached via this router.  The
+             AL_net_addr is defined in this MIB
+             module by the tuple
+             (olsrv2LibLocAttNetSetIpAddrType,
+              olsrv2LibLocAttNetSetIpAddr,
+              olsrv2LibLocAttNetSetIpAddrPrefixLen).
+
+             AL_dist is the number of hops to
+             the network with address AL_net_addr
+             from this router.  The AL_dist is
+             defined in this MIB module by the
+             olsrv2LibLocAttNetSetDistance object.
+
+             AL_metric is the metric of the link to
+             the attached network with address
+             AL_net_addr from this router.  The
+             AL_metric is defined in this MIB module
+             by the olsrv2LibLocAttNetSetMetricValue
+             object.
+
+          OLSRv2 (RFC 7181) defines the rules for managing
+          entries within this table, e.g., populating
+          and purging entries.  Specific instructions for the
+          olsrv2LibLocAttNetSetEntry(s) are found in
+          Sections 7.2 and 17 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2LibLocAttNetSetIpAddrType,
+              olsrv2LibLocAttNetSetIpAddr,
+              olsrv2LibLocAttNetSetIpAddrPrefixLen }
+   ::= { olsrv2LibLocAttNetSetTable 1 }
+
+   Olsrv2LibLocAttNetSetEntry ::=
+
+
+
+Herberg, et al.              Standards Track                   [Page 36]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SEQUENCE {
+         olsrv2LibLocAttNetSetIpAddrType
+            InetAddressType,
+         olsrv2LibLocAttNetSetIpAddr
+            InetAddress,
+         olsrv2LibLocAttNetSetIpAddrPrefixLen
+            InetAddressPrefixLength,
+         olsrv2LibLocAttNetSetDistance
+            Unsigned32,
+         olsrv2LibLocAttNetSetMetricValue
+            Olsrv2MetricValueCompressedFormTC
+      }
+
+   olsrv2LibLocAttNetSetIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2LibLocAttNetSetIpAddr, as defined
+          in the InetAddress MIB (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibLocAttNetSetEntry 1 }
+
+   olsrv2LibLocAttNetSetIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the network address of an attached
+          network that can be reached via this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibLocAttNetSetEntry 2 }
+
+   olsrv2LibLocAttNetSetIpAddrPrefixLen  OBJECT-TYPE
+      SYNTAX      InetAddressPrefixLength
+      UNITS       "bits"
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+
+
+
+Herberg, et al.              Standards Track                   [Page 37]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         "Indicates the number of leading one bits that form the
+          mask to be logically ANDed with the destination address
+          before being compared to the value in the
+          olsrv2LibLocAttNetSetIpAddr field."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibLocAttNetSetEntry 3 }
+
+   olsrv2LibLocAttNetSetDistance  OBJECT-TYPE
+      SYNTAX      Unsigned32 (1..255)
+      UNITS       "hops"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object specifies the number of hops
+          to the network with address
+          olsrv2LibLocAttNetSetIpAddr from this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibLocAttNetSetEntry 4 }
+
+   olsrv2LibLocAttNetSetMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object specifies the metric of the
+          link to the attached network with
+          address AL_net_addr from this router.  The
+          AL_net_addr is defined by the tuple
+          (olsrv2LibLocAttNetSetIpAddrType,
+           olsrv2LibLocAttNetSetIpAddr,
+           olsrv2LibLocAttNetSetIpAddrPrefixLen)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2LibLocAttNetSetEntry 5 }
+
+   --
+   -- Neighbor Information Base
+   --
+
+   --
+
+
+
+Herberg, et al.              Standards Track                   [Page 38]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   -- Neighbor Set - as defined in RFC 6130,
+   -- extended by OLSRv2 by the addition of the following
+   -- elements to each Neighbor Tuple:
+   --     N_orig_addr (olsrv2NibNeighborSetNOrigIpAddrType,
+   --                  olsrv2NibNeighborSetNOrigIpAddr)
+   --     N_in_metric (olsrv2NibNeighborSetNInMetricValue)
+   --     N_out_metric (olsrv2NibNeighborSetNOutMetricValue)
+   --     N_will_flooding (olsrv2NibNeighborSetNWillFlooding)
+   --     N_will_routing (olsrv2NibNeighborSetNWillRouting)
+   --     N_flooding_mpr (olsrv2NibNeighborSetNFloodingMpr)
+   --     N_routing_mpr (olsrv2NibNeighborSetNRoutingMpr)
+   --     N_mpr_selector (olsrv2NibNeighborSetNMprSelector)
+   --     N_advertised (olsrv2NibNeighborSetNAdvertised)
+   --
+
+   olsrv2NibNeighborSetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2NibNeighborSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Neighbor Set records all network
+          addresses of each 1-hop neighbor.  It consists
+          of Neighbor Tuples, each representing a single
+          1-hop neighbor."
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+    ::= { olsrv2StateGroup 5 }
+
+    olsrv2NibNeighborSetEntry  OBJECT-TYPE
+       SYNTAX      Olsrv2NibNeighborSetEntry
+       MAX-ACCESS  not-accessible
+       STATUS      current
+       DESCRIPTION
+          "Each Neighbor Tuple in the Neighbor Set, defined
+           in RFC 6130, has these additional elements:
+              N_orig_addr (olsrv2NibNeighborSetNOrigIpAddrType,
+                           olsrv2NibNeighborSetNOrigIpAddr)
+              N_in_metric (olsrv2NibNeighborSetNInMetricValue)
+              N_out_metric (olsrv2NibNeighborSetNOutMetricValue)
+              N_will_flooding (olsrv2NibNeighborSetNWillFlooding)
+              N_will_routing (olsrv2NibNeighborSetNWillRouting)
+              N_flooding_mpr (olsrv2NibNeighborSetNFloodingMpr)
+              N_routing_mpr (olsrv2NibNeighborSetNRoutingMpr)
+              N_mpr_selector (olsrv2NibNeighborSetNMprSelector)
+              N_advertised (olsrv2NibNeighborSetNAdvertised)
+           defined here as extensions."
+
+
+
+Herberg, et al.              Standards Track                   [Page 39]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+       AUGMENTS { nhdpNibNeighborSetEntry }
+   ::= { olsrv2NibNeighborSetTable 1 }
+
+   Olsrv2NibNeighborSetEntry ::=
+      SEQUENCE {
+         olsrv2NibNeighborSetNOrigIpAddrType
+            InetAddressType,
+         olsrv2NibNeighborSetNOrigIpAddr
+            InetAddress,
+         olsrv2NibNeighborSetNInMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2NibNeighborSetNOutMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2NibNeighborSetNWillFlooding
+            WillingnessTC,
+         olsrv2NibNeighborSetNWillRouting
+            WillingnessTC,
+         olsrv2NibNeighborSetNFloodingMpr
+            TruthValue,
+         olsrv2NibNeighborSetNRoutingMpr
+            TruthValue,
+         olsrv2NibNeighborSetNMprSelector
+            TruthValue,
+         olsrv2NibNeighborSetNAdvertised
+            TruthValue
+      }
+
+   olsrv2NibNeighborSetNOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2NibNeighborSetNOrigIpAddr, as defined
+          in the InetAddress MIB module (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 1 }
+
+   olsrv2NibNeighborSetNOrigIpAddr  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 40]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the originator IP address of the neighbor
+          represented by this table entry."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 2 }
+
+   olsrv2NibNeighborSetNInMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the neighbor metric of any
+          link from this neighbor to an OLSRv2 interface
+          of this router, i.e., the minimum of all corresponding
+          L_in_metric (olsrv2IibLinkSetInMetricValue)
+          with L_status = SYMMETRIC and
+          L_in_metric (olsrv2IibLinkSetInMetricValue) != UNKNOWN_METRIC,
+          UNKNOWN_METRIC if there are no such Link Tuples.
+          UNKNOWN_METRIC has a value of 0."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 3 }
+
+   olsrv2NibNeighborSetNOutMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the neighbor metric of any
+          link from an OLSRv2 interface of this router
+          to this neighbor, i.e., the minimum of all
+          corresponding L_out_metric
+          (olsrv2IibLinkSetOutMetricValue) with L_status =
+          SYMMETRIC and L_out_metric
+          (olsrv2IibLinkSetOutMetricValue) != UNKNOWN_METRIC,
+          UNKNOWN_METRIC if there are no such Link Tuples.
+          UNKNOWN_METRIC has a value of 0."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+
+
+
+Herberg, et al.              Standards Track                   [Page 41]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 4 }
+
+   olsrv2NibNeighborSetNWillFlooding  OBJECT-TYPE
+      SYNTAX      WillingnessTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the neighbor's willingness to be
+          selected as a flooding MPR, in the range from
+          WILL_NEVER to WILL_ALWAYS, both inclusive, taking
+          the value WILL_NEVER if no OLSRv2 specific
+          information is received from this neighbor."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 5 }
+
+   olsrv2NibNeighborSetNWillRouting  OBJECT-TYPE
+      SYNTAX      WillingnessTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the neighbor's willingness to be
+          selected as a routing MPR, in the range from
+          WILL_NEVER to WILL_ALWAYS, both inclusive, taking
+          the value WILL_NEVER if no OLSRv2 specific
+          information is received from this neighbor."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 6 }
+
+   olsrv2NibNeighborSetNFloodingMpr  OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is a boolean flag, recording whether
+          this neighbor is selected as a flooding MPR
+          by this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 7 }
+
+
+
+Herberg, et al.              Standards Track                   [Page 42]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   olsrv2NibNeighborSetNRoutingMpr  OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is a boolean flag, recording whether
+          this neighbor is selected as a routing MPR
+          by this router."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 8 }
+
+   olsrv2NibNeighborSetNMprSelector  OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is a boolean flag,
+          recording whether this neighbor has selected this router
+          as a routing MPR, i.e., is a routing MPR
+          selector of this router.
+
+          When set to 'true', then this router is selected as
+          a routing MPR by the neighbor router.
+          When set to 'false',
+          then this router is not selected by the neighbor
+          as a routing MPR."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NibNeighborSetEntry 9 }
+
+   olsrv2NibNeighborSetNAdvertised  OBJECT-TYPE
+      SYNTAX      TruthValue
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object, N_mpr_selector
+          (olsrv2NibNeighborSetNMprSelector), is a boolean flag,
+          recording whether this router has elected to
+          advertise a link to this neighbor in its TC messages."
+       REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+
+
+
+Herberg, et al.              Standards Track                   [Page 43]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   ::= { olsrv2NibNeighborSetEntry 10 }
+
+   olsrv2NibNeighborSetTableAnsn OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "Advertised Neighbor Sequence Number (ANSN), is
+          a variable, whose value is included in TC messages to
+          indicate the freshness of the information transmitted."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 6 }
+
+   --
+   -- Topology Information Base - this Information
+   -- Base is specific to OLSRv2 and is defined in
+   -- Section 10 of RFC 7181.
+   --
+
+   --
+   -- Advertising Remote Router Set
+   --
+
+   olsrv2TibAdRemoteRouterSetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2TibAdRemoteRouterSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Advertising Remote Router Set records
+          information describing each remote router in the
+          network that transmits TC messages."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 7 }
+
+   olsrv2TibAdRemoteRouterSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2TibAdRemoteRouterSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Advertised Neighbor Set Table entry
+          consists of Advertising Remote Router Tuples:
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 44]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          (AR_orig_addr (olsrv2TibAdRemoteRouterSetIpAddrType,
+                         olsrv2TibAdRemoteRouterSetIpAddr),
+           AR_seq_number (olsrv2TibAdRemoteRouterSetMaxSeqNo),
+           AR_time (olsrv2TibAdRemoteRouterSetExpireTime).
+
+          Addresses associated with this router are
+          found in the NHDP-MIB module's nhdpDiscIfSetTable.
+
+          OLSRv2 (RFC 7181) defines the rules for managing
+          entries within this table, e.g., populating
+          and purging entries.  Specific instructions for the
+          olsrv2TibAdRemoteRouterSetEntry(s) are found in
+          Section 10.1 and Section 17 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2TibAdRemoteRouterSetIpAddrType,
+              olsrv2TibAdRemoteRouterSetIpAddr }
+   ::= { olsrv2TibAdRemoteRouterSetTable 1 }
+
+   Olsrv2TibAdRemoteRouterSetEntry ::=
+      SEQUENCE {
+         olsrv2TibAdRemoteRouterSetIpAddrType
+            InetAddressType,
+         olsrv2TibAdRemoteRouterSetIpAddr
+            InetAddress,
+         olsrv2TibAdRemoteRouterSetMaxSeqNo
+            Unsigned32,
+         olsrv2TibAdRemoteRouterSetExpireTime
+            TimeStamp
+      }
+
+   olsrv2TibAdRemoteRouterSetIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibAdRemoteRouterSetIpAddr,
+          as defined in the InetAddress MIB module (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAdRemoteRouterSetEntry 1 }
+
+
+
+Herberg, et al.              Standards Track                   [Page 45]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   olsrv2TibAdRemoteRouterSetIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the originator address of a received
+          TC message."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAdRemoteRouterSetEntry 2 }
+
+   olsrv2TibAdRemoteRouterSetMaxSeqNo  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the greatest Advertised Neighbor Sequence
+          Number (ANSN) in any TC message
+          received that originated from the router
+          with originator address
+          olsrv2TibAdRemoteRouterSetIpAddr.
+
+          Sequence numbers are used in the OLSRv2 protocol
+          for the purpose of discarding 'old' information,
+          i.e., messages received out of order.  However,
+          with a limited number of bits for representing
+          sequence numbers, wraparound (that the sequence
+          number is incremented from the maximum possible
+          value to zero) will occur.  To prevent this from
+          interfering with the operation of this protocol,
+          OLSRv2 implementations observe the following when
+          determining the ordering of sequence numbers.
+
+          In OLSRv2, MAXVALUE designates one more than the
+          largest possible value for a sequence number.
+          For a 16-bit sequence number, MAXVALUE is 65536.
+
+          The sequence number S1 is said to be 'greater than'
+          the sequence number S2 if:
+
+             o  S1 > S2 AND S1 - S2 < MAXVALUE/2 OR
+
+             o  S2 > S1 AND S2 - S1 > MAXVALUE/2
+
+          When sequence numbers S1 and S2 differ by MAXVALUE/2,
+          their ordering cannot be determined.  In this case,
+
+
+
+Herberg, et al.              Standards Track                   [Page 46]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          which should not occur, either ordering may be
+          assumed.
+
+          Thus, when comparing two messages, it is possible
+          - even in the presence of wraparound - to determine
+          which message contains the most recent information."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAdRemoteRouterSetEntry 3 }
+
+   olsrv2TibAdRemoteRouterSetExpireTime  OBJECT-TYPE
+      SYNTAX      TimeStamp
+      UNITS       "centiseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TibAdRemoteRouterSetExpireTime specifies the value
+          of sysUptime when this entry SHOULD expire and be
+          removed from the olsrv2TibAdRemoteRouterSetTable."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAdRemoteRouterSetEntry 4 }
+
+   --
+   -- Router Topology Set
+   --
+
+   olsrv2TibRouterTopologySetTable OBJECT-TYPE
+      SYNTAX       SEQUENCE OF Olsrv2TibRouterTopologySetEntry
+      MAX-ACCESS   not-accessible
+      STATUS       current
+      DESCRIPTION
+         "A router's Router Topology Set records topology
+          information about the network."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 8 }
+
+   olsrv2TibRouterTopologySetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2TibRouterTopologySetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 47]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "It consists of Router Topology Tuples:
+
+          (TR_from_orig_addr
+             (olsrv2TibRouterTopologySetFromOrigIpAddrType,
+              olsrv2TibRouterTopologySetFromOrigIpAddr),
+           TR_to_orig_addr
+             (olsrv2TibRouterTopologySetToOrigIpAddrType,
+              olsrv2TibRouterTopologySetToOrigIpAddr),
+           TR_seq_number (olsrv2TibRouterTopologySetSeqNo),
+           TR_metric (olsrv2TibRouterTopologySetMetricValue),
+           TR_time (olsrv2TibRouterTopologySetExpireTime)).
+
+          OLSRv2 (RFC 7181) defines the rules for managing
+          entries within this table, e.g., populating
+          and purging entries.  Specific instructions for the
+          olsrv2TibRouterTopologySetEntry(s) are found in
+          Section 10.2 and Section 17 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2TibRouterTopologySetFromOrigIpAddrType,
+              olsrv2TibRouterTopologySetFromOrigIpAddr,
+              olsrv2TibRouterTopologySetToOrigIpAddrType,
+              olsrv2TibRouterTopologySetToOrigIpAddr }
+   ::= { olsrv2TibRouterTopologySetTable 1 }
+
+   Olsrv2TibRouterTopologySetEntry ::=
+      SEQUENCE {
+         olsrv2TibRouterTopologySetFromOrigIpAddrType
+            InetAddressType,
+         olsrv2TibRouterTopologySetFromOrigIpAddr
+            InetAddress,
+         olsrv2TibRouterTopologySetToOrigIpAddrType
+            InetAddressType,
+         olsrv2TibRouterTopologySetToOrigIpAddr
+            InetAddress,
+         olsrv2TibRouterTopologySetSeqNo
+            Unsigned32,
+         olsrv2TibRouterTopologySetMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2TibRouterTopologySetExpireTime
+            TimeStamp
+      }
+
+   olsrv2TibRouterTopologySetFromOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+
+
+
+Herberg, et al.              Standards Track                   [Page 48]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRouterTopologySetFromOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 1 }
+
+   olsrv2TibRouterTopologySetFromOrigIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the originator address of a router that can
+          reach the router with originator address TR_to_orig_addr
+          in one hop."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 2 }
+
+   olsrv2TibRouterTopologySetToOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRouterTopologySetToOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 3 }
+
+   olsrv2TibRouterTopologySetToOrigIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 49]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "This is the originator address of a router that can be
+          reached by the router with originator address
+          TR_to_orig_addr in one hop."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 4 }
+
+   olsrv2TibRouterTopologySetSeqNo  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the greatest Advertised Neighbor Sequence
+          Number (ANSN) in any TC message
+          received that originated from the router
+          with originator address TR_from_orig_addr,
+          i.e., that contributed to the information
+          contained in this Tuple and that is defined by the
+          objects:
+             (olsrv2TibRouterTopologySetFromOrigIpAddrType,
+              olsrv2TibRouterTopologySetFromOrigIpAddr).
+
+          Sequence numbers are used in the OLSRv2 protocol
+          for the purpose of discarding 'old' information,
+          i.e., messages received out of order.  However,
+          with a limited number of bits for representing
+          sequence numbers, wraparound (that the sequence
+          number is incremented from the maximum possible
+          value to zero) will occur.  To prevent this from
+          interfering with the operation of this protocol,
+          OLSRv2 implementations observe the following when
+          determining the ordering of sequence numbers.
+
+          In OLSRv2, MAXVALUE designates one more than the
+          largest possible value for a sequence number.
+          For a 16-bit sequence number, MAXVALUE is 65536.
+
+          The sequence number S1 is said to be 'greater than'
+          the sequence number S2 if:
+
+             o  S1 > S2 AND S1 - S2 < MAXVALUE/2 OR
+
+             o  S2 > S1 AND S2 - S1 > MAXVALUE/2
+
+          When sequence numbers S1 and S2 differ by MAXVALUE/2,
+
+
+
+Herberg, et al.              Standards Track                   [Page 50]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          their ordering cannot be determined.  In this case,
+          which should not occur, either ordering may be
+          assumed.
+
+          Thus, when comparing two messages, it is possible
+          - even in the presence of wraparound - to determine
+          which message contains the most recent information."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 5 }
+
+   olsrv2TibRouterTopologySetMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the neighbor metric from the router
+          with originator address TR_from_orig_addr
+          (olsrv2TibRouterTopologySetFromOrigIpAddrType,
+          olsrv2TibRouterTopologySetFromOrigIpAddr) to
+          the router with originator address TR_to_orig_addr
+          (olsrv2TibRouterTopologySetToOrigIpAddrType,
+          olsrv2TibRouterTopologySetToOrigIpAddr)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 6 }
+
+   olsrv2TibRouterTopologySetExpireTime  OBJECT-TYPE
+      SYNTAX      TimeStamp
+      UNITS       "centiseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TibRouterTopologySetExpireTime specifies the value
+          of sysUptime when this entry SHOULD expire and be
+          removed from the olsrv2TibRouterTopologySetTable."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRouterTopologySetEntry 7 }
+
+   --
+   -- Routable Address Topology Set
+
+
+
+Herberg, et al.              Standards Track                   [Page 51]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   --
+
+   olsrv2TibRoutableAddressTopologySetTable OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2TibRoutableAddressTopologySetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A router's Routable Address Topology Set records topology
+          information about the routable addresses within the MANET,
+          including via which routers they may be reached."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 9 }
+
+   olsrv2TibRoutableAddressTopologySetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2TibRoutableAddressTopologySetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "It consists of Router Topology Tuples:
+
+          (TA_from_orig_addr
+               (olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType
+                olsrv2TibRoutableAddressTopologySetFromOrigIpAddr),
+           TA_dest_addr
+               (olsrv2TibRoutableAddressTopologySetFromDestIpAddrType
+                olsrv2TibRoutableAddressTopologySetFromDestIpAddr),
+           TA_seq_number (olsrv2TibRoutableAddressTopologySetSeqNo)
+           TA_metric (olsrv2TibRoutableAddressTopologySetMetricValue)
+           TA_time (olsrv2TibRoutableAddressTopologySetExpireTime)
+          )
+
+          OLSRv2 (RFC 7181) defines the rules for managing
+          entries within this table, e.g., populating
+          and purging entries.  Specific instructions for the
+          olsrv2TibRoutableAddressTopologySetEntry(s) are found
+          in Section 10.3 and Section 17 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType,
+              olsrv2TibRoutableAddressTopologySetFromOrigIpAddr,
+              olsrv2TibRoutableAddressTopologySetDestIpAddrType,
+              olsrv2TibRoutableAddressTopologySetDestIpAddr }
+   ::= { olsrv2TibRoutableAddressTopologySetTable 1 }
+
+
+
+Herberg, et al.              Standards Track                   [Page 52]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+    Olsrv2TibRoutableAddressTopologySetEntry ::=
+       SEQUENCE {
+          olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType
+            InetAddressType,
+          olsrv2TibRoutableAddressTopologySetFromOrigIpAddr
+            InetAddress,
+          olsrv2TibRoutableAddressTopologySetDestIpAddrType
+            InetAddressType,
+          olsrv2TibRoutableAddressTopologySetDestIpAddr
+            InetAddress,
+          olsrv2TibRoutableAddressTopologySetSeqNo
+            Unsigned32,
+          olsrv2TibRoutableAddressTopologySetMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+          olsrv2TibRoutableAddressTopologySetExpireTime
+            TimeStamp
+       }
+
+   olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the
+          olsrv2TibRoutableAddressTopologySetFromOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 1 }
+
+   olsrv2TibRoutableAddressTopologySetFromOrigIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the originator address of a router that can
+          reach the router with routable address TA_dest_addr
+          in one hop."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 2 }
+
+
+
+Herberg, et al.              Standards Track                   [Page 53]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   olsrv2TibRoutableAddressTopologySetDestIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRouterTopologySetToOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 3 }
+
+   olsrv2TibRoutableAddressTopologySetDestIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is a routable address of a router that can be
+          reached by the router with originator address
+          TA_from_orig_addr in one hop.  The TA_from_orig_addr
+          is defined by the tuple
+          (olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType
+           olsrv2TibRoutableAddressTopologySetFromOrigIpAddr)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 4 }
+
+   olsrv2TibRoutableAddressTopologySetSeqNo  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the greatest Advertised Neighbor Sequence
+          Number (ANSN) in any TC message
+          received that originated from the router
+          with originator address TA_from_orig_addr,
+          i.e., that contributed to the information
+          contained in this Tuple.  The TA_from_orig_addr
+          is defined by the tuple
+          (olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType
+           olsrv2TibRoutableAddressTopologySetFromOrigIpAddr)."
+      REFERENCE
+
+
+
+Herberg, et al.              Standards Track                   [Page 54]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 5 }
+
+   olsrv2TibRoutableAddressTopologySetMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the neighbor metric from the router
+          with originator address TA_from_orig_addr (defined
+          by the tuple
+          (olsrv2TibRoutableAddressTopologySetFromOrigIpAddrType
+           olsrv2TibRoutableAddressTopologySetFromOrigIpAddr))
+          to the router with OLSRv2 interface address TA_dest_addr
+          (defined by the tuple
+          (olsrv2TibRoutableAddressTopologySetFromDestIpAddrType
+           olsrv2TibRoutableAddressTopologySetFromDestIpAddr))."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 6 }
+
+   olsrv2TibRoutableAddressTopologySetExpireTime  OBJECT-TYPE
+      SYNTAX      TimeStamp
+      UNITS       "centiseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TibRoutableAddressTopologySetExpireTime
+          specifies the value of sysUptime when this entry
+          SHOULD expire and be removed from the
+          olsrv2TibRoutableAddressTopologySetTable."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutableAddressTopologySetEntry 7 }
+
+   --
+   -- Attached Network Set
+   --
+
+   olsrv2TibAttNetworksSetTable OBJECT-TYPE
+      SYNTAX       SEQUENCE OF Olsrv2TibAttNetworksSetEntry
+      MAX-ACCESS   not-accessible
+
+
+
+Herberg, et al.              Standards Track                   [Page 55]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      STATUS       current
+      DESCRIPTION
+         "A router's Attached Network Set records information
+          about networks (which may be outside the MANET)
+          attached to other routers and their routable addresses."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 10 }
+
+   olsrv2TibAttNetworksSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2TibAttNetworksSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "It consists of Attached Network Tuples:
+
+          (AN_orig_addr
+             (olsrv2TibAttNetworksSetOrigIpAddrType,
+              olsrv2TibAttNetworksSetOrigIpAddr),
+           AN_net_addr
+             (olsrv2TibAttNetworksSetNetIpAddrType,
+              olsrv2TibAttNetworksSetNetIpAddr,
+              olsrv2TibAttNetworksSetNetIpAddrPrefixLen),
+           AN_seq_number (olsrv2TibAttNetworksSetSeqNo),
+           AN_dist (olsrv2TibAttNetworksSetDist),
+           AN_metric (olsrv2TibAttNetworksSetMetricValue),
+           AN_time (olsrv2TibAttNetworksSetExpireTime)
+          )
+
+          OLSRv2 (RFC 7181) defines the rules for managing
+          entries within this table, e.g., populating
+          and purging entries.  Specific instructions for the
+          olsrv2TibRoutableAddressTopologySetEntry(s) are found
+          in Section 10.4 and Section 17 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+      INDEX { olsrv2TibAttNetworksSetOrigIpAddrType,
+              olsrv2TibAttNetworksSetOrigIpAddr,
+              olsrv2TibAttNetworksSetNetIpAddrType,
+              olsrv2TibAttNetworksSetNetIpAddr,
+              olsrv2TibAttNetworksSetNetIpAddrPrefixLen }
+   ::= { olsrv2TibAttNetworksSetTable 1 }
+
+   Olsrv2TibAttNetworksSetEntry ::=
+
+
+
+Herberg, et al.              Standards Track                   [Page 56]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SEQUENCE {
+         olsrv2TibAttNetworksSetOrigIpAddrType
+            InetAddressType,
+         olsrv2TibAttNetworksSetOrigIpAddr
+            InetAddress,
+         olsrv2TibAttNetworksSetNetIpAddrType
+            InetAddressType,
+         olsrv2TibAttNetworksSetNetIpAddr
+            InetAddress,
+         olsrv2TibAttNetworksSetNetIpAddrPrefixLen
+            InetAddressPrefixLength,
+         olsrv2TibAttNetworksSetSeqNo
+            Unsigned32,
+         olsrv2TibAttNetworksSetDist
+            Unsigned32,
+         olsrv2TibAttNetworksSetMetricValue
+            Olsrv2MetricValueCompressedFormTC,
+         olsrv2TibAttNetworksSetExpireTime
+            TimeStamp
+      }
+
+   olsrv2TibAttNetworksSetOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibAttNetworksSetOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 1 }
+
+   olsrv2TibAttNetworksSetOrigIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the originator address, of type
+          olsrv2TibAttNetworksSetOrigIpAddrType, of a
+          router that can act as gateway to the
+          network with address AN_net_addr.  The
+          AN_net_addr is defined by the tuple
+             (olsrv2TibAttNetworksSetNetIpAddrType,
+
+
+
+Herberg, et al.              Standards Track                   [Page 57]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+              olsrv2TibAttNetworksSetNetIpAddr,
+              olsrv2TibAttNetworksSetNetIpAddrPrefixLen)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 2 }
+
+   olsrv2TibAttNetworksSetNetIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibAttNetworksSetNetIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 3 }
+
+   olsrv2TibAttNetworksSetNetIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "This is the network address, of type
+          olsrv2TibAttNetworksSetNetIpAddrType, of an
+          attached network, that may be reached via
+          the router with originator address AN_orig_addr.
+          The AN_orig_addr is defined by the tuple
+             (olsrv2TibAttNetworksSetOrigIpAddrType,
+              olsrv2TibAttNetworksSetOrigIpAddr)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 4 }
+
+   olsrv2TibAttNetworksSetNetIpAddrPrefixLen  OBJECT-TYPE
+      SYNTAX      InetAddressPrefixLength
+      UNITS       "bits"
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+
+
+
+Herberg, et al.              Standards Track                   [Page 58]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         "Indicates the number of leading one bits that form the
+          mask to be logically ANDed with the destination address
+          before being compared to the value in the
+          olsrv2TibAttNetworksSetNetIpAddr field."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 5 }
+
+   olsrv2TibAttNetworksSetSeqNo  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..65535)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This is the greatest Advertised Neighbor Sequence
+          Number (ANSN) in any TC message received
+          that originated from the router
+          with originator address AN_orig_addr
+          (i.e., that contributed to the information
+          contained in this Tuple).  The AN_orig_addr
+          is defined by the tuple
+             (olsrv2TibAttNetworksSetOrigIpAddrType,
+              olsrv2TibAttNetworksSetOrigIpAddr).
+
+          Sequence numbers are used in the OLSRv2 protocol
+          for the purpose of discarding 'old' information,
+          i.e., messages received out of order.  However,
+          with a limited number of bits for representing
+          sequence numbers, wraparound (that the sequence
+          number is incremented from the maximum possible
+          value to zero) will occur.  To prevent this from
+          interfering with the operation of this protocol,
+          the following MUST be observed when determining
+          the ordering of sequence numbers.
+
+          The term MAXVALUE designates in the following one
+          more than the largest possible value for a sequence
+          number.  For a 16-bit sequence number (as are those
+          defined in this specification), MAXVALUE is 65536.
+
+          The sequence number S1 is said to be 'greater than'
+          the sequence number S2 if:
+
+             o  S1 > S2 AND S1 - S2 < MAXVALUE/2 OR
+
+             o  S2 > S1 AND S2 - S1 > MAXVALUE/2
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 59]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          When sequence numbers S1 and S2 differ by MAXVALUE/2,
+          their ordering cannot be determined.  In this case,
+          which should not occur, either ordering may be
+          assumed.
+
+          Thus, when comparing two messages, it is possible
+          - even in the presence of wraparound - to determine
+          which message contains the most recent information."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 6 }
+
+   olsrv2TibAttNetworksSetDist  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..255)
+      UNITS       "hops"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The number of hops to the network
+          with address AN_net_addr from the router with
+          originator address AN_orig_addr.
+          The AN_orig_addr is defined by the tuple
+             (olsrv2TibAttNetworksSetOrigIpAddrType,
+              olsrv2TibAttNetworksSetOrigIpAddr)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 7 }
+
+   olsrv2TibAttNetworksSetMetricValue  OBJECT-TYPE
+      SYNTAX      Olsrv2MetricValueCompressedFormTC
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The metric of the link from the router with
+          originator address AN_orig_addr to the attached
+          network with address AN_net_addr.
+          The AN_net_addr is defined by the tuple
+            (olsrv2TibAttNetworksSetNetIpAddrType,
+             olsrv2TibAttNetworksSetNetIpAddr,
+             olsrv2TibAttNetworksSetNetIpAddrPrefixLen)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+
+
+
+Herberg, et al.              Standards Track                   [Page 60]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   ::= { olsrv2TibAttNetworksSetEntry 9 }
+
+   olsrv2TibAttNetworksSetExpireTime  OBJECT-TYPE
+      SYNTAX      TimeStamp
+      UNITS       "centiseconds"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "olsrv2TibAttNetworksSetExpireTime
+          specifies the value of sysUptime when this
+          entry SHOULD expire and be removed from the
+          olsrv2TibAttNetworksSetTable."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibAttNetworksSetEntry 10 }
+
+   --
+   -- Routing Set
+   --
+
+   olsrv2TibRoutingSetTable OBJECT-TYPE
+      SYNTAX       SEQUENCE OF Olsrv2TibRoutingSetEntry
+      MAX-ACCESS   not-accessible
+      STATUS       current
+      DESCRIPTION
+         "A router's Routing Set records the first hop along a
+          selected path to each destination for which any such
+          path is known."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2StateGroup 11 }
+
+   olsrv2TibRoutingSetEntry  OBJECT-TYPE
+      SYNTAX      Olsrv2TibRoutingSetEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+          "It consists of Routing Tuples:
+
+           (R_dest_addr, R_next_iface_addr,
+            R_local_iface_addr, R_dist, R_metric)"
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+
+
+
+Herberg, et al.              Standards Track                   [Page 61]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          and U. Herberg, April 2014."
+      INDEX { olsrv2TibRoutingSetDestIpAddrType,
+              olsrv2TibRoutingSetDestIpAddr,
+              olsrv2TibRoutingSetDestIpAddrPrefixLen }
+   ::= { olsrv2TibRoutingSetTable 1 }
+
+   Olsrv2TibRoutingSetEntry ::=
+      SEQUENCE {
+         olsrv2TibRoutingSetDestIpAddrType
+            InetAddressType,
+         olsrv2TibRoutingSetDestIpAddr
+            InetAddress,
+         olsrv2TibRoutingSetDestIpAddrPrefixLen
+            InetAddressPrefixLength,
+         olsrv2TibRoutingSetNextIfIpAddrType
+            InetAddressType,
+         olsrv2TibRoutingSetNextIfIpAddr
+            InetAddress,
+         olsrv2TibRoutingSetLocalIfIpAddrType
+            InetAddressType,
+         olsrv2TibRoutingSetLocalIfIpAddr
+            InetAddress,
+         olsrv2TibRoutingSetDist
+            Unsigned32,
+         olsrv2TibRoutingSetMetricValue
+            Unsigned32
+      }
+
+   olsrv2TibRoutingSetDestIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRoutingSetDestIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and 'ipv6(2)' are
+          supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 1 }
+
+   olsrv2TibRoutingSetDestIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  not-accessible
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 62]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "This is the address of the destination,
+          either the address of an interface of
+          a destination router or the network
+          address of an attached network."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 2 }
+
+   olsrv2TibRoutingSetDestIpAddrPrefixLen  OBJECT-TYPE
+      SYNTAX      InetAddressPrefixLength
+      UNITS       "bits"
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "Indicates the number of leading one bits that form the
+          mask to be logically ANDed with the destination address
+          before being compared to the value in the
+          olsrv2TibRoutingSetDestIpAddr field.
+
+          Note: This definition needs to be consistent
+          with the current forwarding table MIB module description.
+          Specifically, it SHOULD allow for longest prefix
+          matching of network addresses."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 3 }
+
+   olsrv2TibRoutingSetNextIfIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRoutingSetNextIfIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 4 }
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 63]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   olsrv2TibRoutingSetNextIfIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the OLSRv2 interface address of the
+          next hop on the selected path to the
+          destination."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 5 }
+
+   olsrv2TibRoutingSetLocalIfIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2TibRoutingSetLocalIfIpAddr
+          and olsrv2TibRoutingSetNextIfIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 6 }
+
+   olsrv2TibRoutingSetLocalIfIpAddr  OBJECT-TYPE
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the address of the local OLSRv2
+          interface over which a packet must be
+          sent to reach the destination by the
+          selected path."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 7 }
+
+   olsrv2TibRoutingSetDist  OBJECT-TYPE
+      SYNTAX      Unsigned32 (0..255)
+
+
+
+Herberg, et al.              Standards Track                   [Page 64]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      UNITS       "hops"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the number of hops on the selected
+          path to the destination."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 8 }
+
+   olsrv2TibRoutingSetMetricValue  OBJECT-TYPE
+      SYNTAX      Unsigned32(0..4294901760)
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This object is the metric of the route
+          to the destination with address R_dest_addr.
+          The maximum value of this object can be
+          256 times MAXIMUM_METRIC,
+          as represented in Olsrv2MetricValueCompressedFormTC, i.e.,
+          4294901760."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2TibRoutingSetEntry 9 }
+
+--
+-- OLSRv2 Performance Group
+--
+
+--
+--    Contains objects that help to characterize the
+--    performance of the OLSRv2 routing process.
+--
+
+olsrv2PerformanceObjGrp  OBJECT IDENTIFIER ::= {olsrv2MIBObjects 3}
+
+    --
+    -- Objects per local interface
+    --
+
+   olsrv2InterfacePerfTable  OBJECT-TYPE
+      SYNTAX      SEQUENCE OF Olsrv2InterfacePerfEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+
+
+
+Herberg, et al.              Standards Track                   [Page 65]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      DESCRIPTION
+         "This table summarizes performance objects that are
+          measured per each active local OLSRv2 interface.
+          If the olsrv2InterfaceAdminStatus of the interface
+          changes to 'disabled', then the row associated with this
+          interface SHOULD be removed from this table."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2PerformanceObjGrp 1 }
+
+   olsrv2InterfacePerfEntry OBJECT-TYPE
+      SYNTAX      Olsrv2InterfacePerfEntry
+      MAX-ACCESS  not-accessible
+      STATUS      current
+      DESCRIPTION
+         "A single entry contains performance counters for
+          each active local OLSRv2 interface."
+      AUGMENTS { nhdpInterfacePerfEntry }
+   ::= { olsrv2InterfacePerfTable 1 }
+
+   Olsrv2InterfacePerfEntry ::=
+      SEQUENCE {
+         olsrv2IfTcMessageXmits
+            Counter32,
+         olsrv2IfTcMessageRecvd
+            Counter32,
+         olsrv2IfTcMessageXmitAccumulatedSize
+            Counter64,
+         olsrv2IfTcMessageRecvdAccumulatedSize
+            Counter64,
+         olsrv2IfTcMessageTriggeredXmits
+            Counter32,
+         olsrv2IfTcMessagePeriodicXmits
+            Counter32,
+         olsrv2IfTcMessageForwardedXmits
+            Counter32,
+         olsrv2IfTcMessageXmitAccumulatedMPRSelectorCount
+            Counter32
+      }
+
+   olsrv2IfTcMessageXmits  OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "messages"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+
+
+
+Herberg, et al.              Standards Track                   [Page 66]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         "A counter is incremented each time a TC
+          message has been transmitted on that interface."
+   ::= { olsrv2InterfacePerfEntry 1 }
+
+   olsrv2IfTcMessageRecvd  OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "messages"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented each time a
+          TC message has been received on that interface.
+          This excludes all messages that are ignored due to
+          OLSRv2 protocol procedures, such as messages
+          considered invalid for processing by this router,
+          as defined in Section 16.3.1 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2InterfacePerfEntry 2 }
+
+   olsrv2IfTcMessageXmitAccumulatedSize  OBJECT-TYPE
+      SYNTAX      Counter64
+      UNITS       "octets"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented by the number of octets in
+          a TC message each time a TC message has been sent."
+   ::= { olsrv2InterfacePerfEntry 3 }
+
+   olsrv2IfTcMessageRecvdAccumulatedSize  OBJECT-TYPE
+      SYNTAX      Counter64
+      UNITS       "octets"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented by the number of octets in
+          a TC message each time a TC message has been received.
+          This excludes all messages that are ignored due to
+          OLSRv2 protocol procedures, such as messages
+          considered invalid for processing by this router,
+          as defined in Section 16.3.1 of OLSRv2 (RFC 7181)."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+
+
+
+Herberg, et al.              Standards Track                   [Page 67]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   ::= { olsrv2InterfacePerfEntry 4 }
+
+   olsrv2IfTcMessageTriggeredXmits  OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "messages"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented each time a triggered
+          TC message has been sent."
+   ::= { olsrv2InterfacePerfEntry 5 }
+
+   olsrv2IfTcMessagePeriodicXmits  OBJECT-TYPE
+      SYNTAX      Counter32
+       UNITS      "messages"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented each time a periodic
+          TC message has been sent."
+   ::= { olsrv2InterfacePerfEntry 6 }
+
+   olsrv2IfTcMessageForwardedXmits  OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "messages"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented each time a
+          TC message has been forwarded."
+   ::= { olsrv2InterfacePerfEntry 7 }
+
+   olsrv2IfTcMessageXmitAccumulatedMPRSelectorCount OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "advertised MPR selectors"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "A counter is incremented by the number of advertised
+          MPR selectors in a TC each time a TC
+          message has been sent."
+   ::= { olsrv2InterfacePerfEntry 8 }
+
+   --
+   -- Objects concerning the Routing Set
+   --
+
+   olsrv2RoutingSetRecalculationCount  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 68]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      Counter32
+      UNITS       "recalculations"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This counter increments each time the Routing Set has
+          been recalculated."
+   ::= { olsrv2PerformanceObjGrp 2 }
+
+   --
+   -- Objects concerning the MPR set
+   --
+
+   olsrv2MPRSetRecalculationCount  OBJECT-TYPE
+      SYNTAX      Counter32
+      UNITS       "recalculations"
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "This counter increments each time the MPRs
+          of this router have been recalculated for
+          any of its interfaces."
+   ::= { olsrv2PerformanceObjGrp 3 }
+
+--
+-- Notifications
+--
+
+olsrv2NotificationsObjects OBJECT IDENTIFIER ::=
+                                     { olsrv2MIBNotifications 0 }
+olsrv2NotificationsControl OBJECT IDENTIFIER ::=
+                                     { olsrv2MIBNotifications 1 }
+olsrv2NotificationsStates  OBJECT IDENTIFIER ::=
+                                     { olsrv2MIBNotifications 2 }
+
+
+   -- olsrv2NotificationsObjects
+
+   olsrv2RouterStatusChange NOTIFICATION-TYPE
+       OBJECTS { olsrv2OrigIpAddrType, -- The address type of
+                                       --    the originator of
+                                       --    the notification.
+                 olsrv2OrigIpAddr,     -- The originator of
+                                       --    the notification.
+                 olsrv2AdminStatus     -- The new state.
+       }
+       STATUS      current
+       DESCRIPTION
+
+
+
+Herberg, et al.              Standards Track                   [Page 69]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          "olsrv2RouterStatusChange is a notification generated
+           when the OLSRv2 router changes it status.
+           The router status is maintained in the
+           olsrv2AdminStatus object."
+   ::= { olsrv2NotificationsObjects 1 }
+
+   olsrv2OrigIpAddrChange NOTIFICATION-TYPE
+      OBJECTS { olsrv2OrigIpAddrType, -- The address type of
+                                      --    the originator of
+                                      --    the notification.
+                olsrv2OrigIpAddr,     -- The originator of
+                                      --    the notification.
+                olsrv2PreviousOrigIpAddrType, -- The address
+                                      -- type of the previous
+                                      -- address of
+                                      -- the originator of
+                                      -- the notification.
+                olsrv2PreviousOrigIpAddr  -- The previous
+                                      -- address of the
+                                      -- originator of
+                                      -- the notification.
+      }
+      STATUS      current
+      DESCRIPTION
+         "olsrv2OrigIpAddrChange is a notification generated when
+          the OLSRv2 router changes it originator IP address.
+          The notification includes the new and the previous
+          originator IP address of the OLSRv2 router."
+   ::= { olsrv2NotificationsObjects 2 }
+
+   olsrv2RoutingSetRecalculationCountChange NOTIFICATION-TYPE
+      OBJECTS { olsrv2OrigIpAddrType, -- The address type of
+                                      --   the originator of
+                                      --   the notification.
+                olsrv2OrigIpAddr,     -- The originator of
+                                      --   the notification.
+                olsrv2RoutingSetRecalculationCount  -- Number
+                                          -- of the
+                                          -- Routing Set
+                                          -- recalculations.
+      }
+      STATUS       current
+      DESCRIPTION
+         "The olsrv2RoutingSetRecalculationCountChange
+          notification is generated when a significant number of
+          Routing Set recalculations have occurred in a short time.
+          This notification SHOULD be generated no more than once
+          per olsrv2RoutingSetRecalculationCountWindow.
+
+
+
+Herberg, et al.              Standards Track                   [Page 70]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          The network administrator SHOULD select
+          appropriate values for 'significant number of
+          Routing Set recalculations' and 'short time' through
+          the settings of the
+          olsrv2RoutingSetRecalculationCountThreshold
+          and olsrv2RoutingSetRecalculationCountWindow objects."
+   ::= { olsrv2NotificationsObjects 3 }
+
+   olsrv2MPRSetRecalculationCountChange NOTIFICATION-TYPE
+      OBJECTS { olsrv2OrigIpAddrType, -- The address type of
+                                      --   the originator of
+                                      --   the notification.
+                olsrv2OrigIpAddr,     -- The originator of
+                                      --   the notification.
+                olsrv2MPRSetRecalculationCount  -- Number of
+                                      --   MPR set
+                                      --   recalculations.
+      }
+      STATUS       current
+      DESCRIPTION
+         "The olsrv2MPRSetRecalculationCountChange
+          notification is generated when a significant
+          number of MPR set recalculations occur in
+          a short period of time.  This notification
+          SHOULD be generated no more than once
+          per olsrv2MPRSetRecalculationCountWindow.
+          The network administrator SHOULD select
+          appropriate values for 'significant number of
+          MPR set recalculations' and 'short period of
+          time' through the settings of the
+          olsrv2MPRSetRecalculationCountThreshold and
+          olsrv2MPRSetRecalculationCountWindow objects."
+   ::= { olsrv2NotificationsObjects 4 }
+
+   -- olsrv2NotificationsControl
+
+   olsrv2RoutingSetRecalculationCountThreshold OBJECT-TYPE
+      SYNTAX      Integer32 (0..255)
+      UNITS       "recalculations"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "A threshold value for the
+          olsrv2RoutingSetRecalculationCount object.
+          If the number of occurrences exceeds this
+          threshold within the previous
+          olsrv2RoutingSetRecalculationCountWindow,
+          then the olsrv2RoutingSetRecalculationCountChange
+
+
+
+Herberg, et al.              Standards Track                   [Page 71]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          notification is to be generated.
+
+          It is RECOMMENDED that the value of this
+          threshold be set to at least 20 and higher
+          in dense topologies with frequent expected
+          topology changes."
+      DEFVAL { 20 }
+   ::= { olsrv2NotificationsControl 1 }
+
+   olsrv2RoutingSetRecalculationCountWindow OBJECT-TYPE
+      SYNTAX      TimeTicks
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "This object is used to determine whether to generate
+          an olsrv2RoutingSetRecalculationCountChange notification.
+          This object represents an interval from the present moment,
+          extending into the past, expressed in hundredths of
+          a second.  If the change in the value of the
+          olsrv2RoutingSetRecalculationCount object during
+          this interval has exceeded the value of
+          olsrv2RoutingSetRecalculationCountThreshold, then
+          an olsrv2RoutingSetRecalculationCountChange notification
+          is generated.
+
+          It is RECOMMENDED that the value for this
+          window be set to at least 5 times the
+          nhdpHelloInterval (whose default value is
+          2 seconds."
+      DEFVAL { 1000 }
+   ::= { olsrv2NotificationsControl 2 }
+
+   olsrv2MPRSetRecalculationCountThreshold OBJECT-TYPE
+      SYNTAX      Integer32 (0..255)
+      UNITS       "recalculations"
+      MAX-ACCESS  read-write
+      STATUS      current
+      DESCRIPTION
+         "A threshold value for the
+          olsrv2MPRSetRecalculationCount object.
+          If the number of occurrences exceeds this
+          threshold within the previous
+          olsrv2MPRSetRecalculationCountWindow,
+          then the
+          olsrv2MPRSetRecalculationCountChange
+          notification is to be generated.
+
+          It is RECOMMENDED that the value of this
+
+
+
+Herberg, et al.              Standards Track                   [Page 72]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          threshold be set to at least 20 and higher
+          in dense topologies with frequent expected
+          topology changes."
+      DEFVAL { 20 }
+   ::= { olsrv2NotificationsControl 3 }
+
+   olsrv2MPRSetRecalculationCountWindow OBJECT-TYPE
+      SYNTAX       TimeTicks
+      MAX-ACCESS   read-write
+      STATUS       current
+      DESCRIPTION
+         "This object is used to determine whether to generate
+          an olsrv2MPRSetRecalculationCountChange notification.
+          This object represents an interval from the present moment,
+          extending into the past, expressed in hundredths of
+          a second.  If the change in the value of the
+          olsrv2MPRSetRecalculationCount object during
+          that interval has exceeded the value of
+          olsrv2MPRSetRecalculationCountThreshold, then the
+          an olsrv2MPRSetRecalculationCountChange notification
+          is generated.
+
+          It is RECOMMENDED that the value for this
+          window be set to at least 5 times the
+          nhdpHelloInterval."
+      DEFVAL { 1000 }
+   ::= { olsrv2NotificationsControl 4 }
+
+   olsrv2PreviousOrigIpAddrType  OBJECT-TYPE
+      SYNTAX      InetAddressType  { ipv4(1) , ipv6(2) }
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The type of the olsrv2PreviousOrigIpAddr,
+          as defined in the InetAddress MIB module (RFC 4001).
+
+          Only the values 'ipv4(1)' and
+          'ipv6(2)' are supported.
+
+          This object MUST have the same persistence
+          characteristics as olsrv2PreviousOrigIpAddr."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NotificationsStates 1 }
+
+   olsrv2PreviousOrigIpAddr  OBJECT-TYPE
+
+
+
+Herberg, et al.              Standards Track                   [Page 73]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+      SYNTAX      InetAddress (SIZE(4|16))
+      MAX-ACCESS  read-only
+      STATUS      current
+      DESCRIPTION
+         "The previous origination IP address
+          of this OLSRv2 router.
+
+          This object SHOULD be updated each time
+          the olsrv2OrigIpAddr is modified.
+
+          This object is persistent, and when written,
+          the entity SHOULD save the change to
+          non-volatile storage."
+      REFERENCE
+         "RFC 7181 - The Optimized Link State Routing Protocol
+          Version 2, Clausen, T., Dearlove, C., Jacquet, P.,
+          and U. Herberg, April 2014."
+   ::= { olsrv2NotificationsStates 2 }
+
+   --
+   -- Compliance Statements
+   --
+
+   olsrv2Compliances  OBJECT IDENTIFIER ::= { olsrv2MIBConformance 1 }
+   olsrv2MIBGroups    OBJECT IDENTIFIER ::= { olsrv2MIBConformance 2 }
+
+   olsrv2BasicCompliance  MODULE-COMPLIANCE
+      STATUS current
+      DESCRIPTION
+         "The basic implementation requirements for
+          managed network entities that implement
+          the OLSRv2 routing process."
+      MODULE  -- this module
+      MANDATORY-GROUPS { olsrv2ConfigObjectsGroup }
+   ::= { olsrv2Compliances 1 }
+
+   olsrv2FullCompliance MODULE-COMPLIANCE
+      STATUS current
+      DESCRIPTION
+         "The full implementation requirements for
+          managed network entities that implement
+          the OLSRv2 routing process."
+      MODULE  -- this module
+      MANDATORY-GROUPS { olsrv2ConfigObjectsGroup,
+                         olsrv2StateObjectsGroup,
+                         olsrv2PerfObjectsGroup,
+                         olsrv2NotificationsObjectsGroup,
+                         olsrv2NotificationsGroup }
+
+
+
+Herberg, et al.              Standards Track                   [Page 74]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   ::= { olsrv2Compliances 2 }
+
+   --
+   -- Units of Conformance
+   --
+
+   olsrv2ConfigObjectsGroup OBJECT-GROUP
+      OBJECTS {
+         olsrv2AdminStatus,
+         olsrv2InterfaceAdminStatus,
+         olsrv2OrigIpAddrType,
+         olsrv2OrigIpAddr,
+         olsrv2OHoldTime,
+         olsrv2TcInterval,
+         olsrv2TcMinInterval,
+         olsrv2THoldTime,
+         olsrv2AHoldTime,
+         olsrv2RxHoldTime,
+         olsrv2PHoldTime,
+         olsrv2FHoldTime,
+         olsrv2TpMaxJitter,
+         olsrv2TtMaxJitter,
+         olsrv2FMaxJitter,
+         olsrv2TcHopLimit,
+         olsrv2WillFlooding,
+         olsrv2WillRouting,
+         olsrv2LinkMetricType
+      }
+      STATUS      current
+      DESCRIPTION
+         "Objects to permit configuration of OLSRv2.
+          All of these SHOULD be backed by non-volatile
+          storage."
+   ::= { olsrv2MIBGroups 1 }
+
+   olsrv2StateObjectsGroup  OBJECT-GROUP
+      OBJECTS {
+         olsrv2LibOrigSetExpireTime,
+         olsrv2LibLocAttNetSetDistance,
+         olsrv2LibLocAttNetSetMetricValue,
+         olsrv2IibLinkSetInMetricValue,
+         olsrv2IibLinkSetOutMetricValue,
+         olsrv2IibLinkSetMprSelector,
+         olsrv2Iib2HopSetInMetricValue,
+         olsrv2Iib2HopSetOutMetricValue,
+         olsrv2NibNeighborSetNOrigIpAddrType,
+         olsrv2NibNeighborSetNOrigIpAddr,
+         olsrv2NibNeighborSetNInMetricValue,
+
+
+
+Herberg, et al.              Standards Track                   [Page 75]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+         olsrv2NibNeighborSetNOutMetricValue,
+         olsrv2NibNeighborSetNWillFlooding,
+         olsrv2NibNeighborSetNWillRouting,
+         olsrv2NibNeighborSetNFloodingMpr,
+         olsrv2NibNeighborSetNRoutingMpr,
+         olsrv2NibNeighborSetNMprSelector,
+         olsrv2NibNeighborSetNAdvertised,
+         olsrv2NibNeighborSetTableAnsn,
+         olsrv2TibAdRemoteRouterSetMaxSeqNo,
+         olsrv2TibAdRemoteRouterSetExpireTime,
+         olsrv2TibRouterTopologySetSeqNo,
+         olsrv2TibRouterTopologySetMetricValue,
+         olsrv2TibRouterTopologySetExpireTime,
+         olsrv2TibRoutableAddressTopologySetExpireTime,
+         olsrv2TibRoutableAddressTopologySetSeqNo,
+         olsrv2TibRoutableAddressTopologySetMetricValue,
+         olsrv2TibAttNetworksSetSeqNo,
+         olsrv2TibAttNetworksSetDist,
+         olsrv2TibAttNetworksSetMetricValue,
+         olsrv2TibAttNetworksSetExpireTime,
+         olsrv2TibRoutingSetNextIfIpAddrType,
+         olsrv2TibRoutingSetNextIfIpAddr,
+         olsrv2TibRoutingSetLocalIfIpAddrType,
+         olsrv2TibRoutingSetLocalIfIpAddr,
+         olsrv2TibRoutingSetDist,
+         olsrv2TibRoutingSetMetricValue
+      }
+      STATUS      current
+      DESCRIPTION
+         "Objects to permit monitoring of OLSRv2 state."
+   ::= { olsrv2MIBGroups 2 }
+
+   olsrv2PerfObjectsGroup  OBJECT-GROUP
+      OBJECTS {
+         olsrv2IfTcMessageXmits,
+         olsrv2IfTcMessageRecvd,
+         olsrv2IfTcMessageXmitAccumulatedSize,
+         olsrv2IfTcMessageRecvdAccumulatedSize,
+         olsrv2IfTcMessageTriggeredXmits,
+         olsrv2IfTcMessagePeriodicXmits,
+         olsrv2IfTcMessageForwardedXmits,
+         olsrv2IfTcMessageXmitAccumulatedMPRSelectorCount,
+         olsrv2RoutingSetRecalculationCount,
+         olsrv2MPRSetRecalculationCount
+      }
+      STATUS      current
+      DESCRIPTION
+         "Objects to support monitoring of OLSRv2 performance."
+
+
+
+Herberg, et al.              Standards Track                   [Page 76]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   ::= { olsrv2MIBGroups 3 }
+
+   olsrv2NotificationsObjectsGroup OBJECT-GROUP
+      OBJECTS {
+         olsrv2RoutingSetRecalculationCountThreshold,
+         olsrv2RoutingSetRecalculationCountWindow,
+         olsrv2MPRSetRecalculationCountThreshold,
+         olsrv2MPRSetRecalculationCountWindow,
+         olsrv2PreviousOrigIpAddrType,
+         olsrv2PreviousOrigIpAddr
+      }
+      STATUS      current
+      DESCRIPTION
+         "Objects to support the notification types in the
+          olsrv2NotificationsGroup.  Some of these appear in
+          notification payloads, others serve to control
+          notification generation."
+   ::= { olsrv2MIBGroups 4 }
+
+
+   olsrv2NotificationsGroup NOTIFICATION-GROUP
+      NOTIFICATIONS {
+         olsrv2RouterStatusChange,
+         olsrv2OrigIpAddrChange,
+         olsrv2RoutingSetRecalculationCountChange,
+         olsrv2MPRSetRecalculationCountChange
+      }
+      STATUS current
+      DESCRIPTION
+          "Notification types to support management of OLSRv2."
+   ::= { olsrv2MIBGroups 5 }
+
+END
+
+
+8.  Security Considerations
+
+   This MIB module defines objects for the configuration, monitoring,
+   and notification of the Optimized Link State Routing Protocol version
+   2 (OLSRv2) [RFC7181].  OLSRv2 allows routers to acquire topological
+   information of the routing domain by exchanging TC messages in order
+   to calculate shortest paths to each destination router in the routing
+   domain.
+
+   There are a number of management objects defined in this MIB module
+   with a MAX-ACCESS clause of read-write and/or read-create.  Such
+   objects may be considered sensitive or vulnerable in some network
+   environments.  The support for SET operations in a non-secure
+
+
+
+Herberg, et al.              Standards Track                   [Page 77]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   environment without proper protection can have a negative effect on
+   network operations.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  olsrv2TcInterval, olsrv2TcMinInterval - these writable objects
+      control the rate at which TC messages are sent.  If set at too
+      high a rate, this could represent a form of a DoS attack by
+      overloading interface resources.  If set too low, OLSRv2 may not
+      converge fast enough to provide accurate routes to all
+      destinations in the routing domain.
+
+   o  olsrv2TcHopLimit - defines the hop limit for TC messages.  If set
+      too low, messages will not be forwarded beyond the defined scope;
+      thus, routers further away from the message originator will not be
+      able to construct appropriate topology graphs.
+
+   o  olsrv2OHoldTime, olsrv2THoldTime, olsrv2AHoldTime,
+      olsrv2RxHoldTime, olsrv2PHoldTime, olsrv2FHoldTime - define hold
+      times for tuples of different Information Bases of OLSRv2.  If set
+      too low, information will expire quickly, and may this harm a
+      correct operation of the routing protocol.
+
+   o  olsrv2WillFlooding and olsrv2WillRouting - define the willingness
+      of this router to become MPR.  If this is set to WILL_NEVER (0),
+      the managed router will not forward any TC messages, nor accept a
+      selection to become MPR by neighboring routers.  If set to
+      WILL_ALWAYS (15), the router will be preferred by neighbors during
+      MPR selection and may thus attract more traffic.
+
+   o  olsrv2TpMaxJitter, olsrv2TtMaxJitter, olsrv2FMaxJitter - define
+      jitter values for TC message transmission and forwarding.  If set
+      too low, control traffic may get lost when collisions occur.
+
+   o  olsrv2LinkMetricType - defines the type of the link metric that a
+      router uses (e.g., ETX or hop count).  Whenever this value
+      changes, all link metric information recorded by the router is
+      invalid, causing a reset of information acquired from other
+      routers in the MANET.  Moreover, if olsrv2LinkMetricType on a
+      router is set to a value that is not known to other routers in the
+      MANET, these routers will not be able to establish routes to that
+      router or transiting that router.  Existing routes to the router
+      with an olsrv2LinkMetricType unknown to other routers in the MANET
+      will be removed.
+
+   Some of the readable objects in this MIB module (i.e., objects with a
+   MAX-ACCESS other than not-accessible) may be considered sensitive or
+   vulnerable in some network environments.  It is thus important to
+   control even GET and/or NOTIFY access to these objects and possibly
+
+
+
+Herberg, et al.              Standards Track                   [Page 78]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   to even encrypt the values of these objects when sending them over
+   the network via SNMP.  These are the tables and objects and their
+   sensitivity/vulnerability:
+
+   o  olsrv2TibRouterTopologySetTable - The contains information on the
+      topology of the MANET, specifically the IP address of the routers
+      in the MANET (as identified by
+      olsrv2TibRouterTopologySetFromOrigIpAddr and
+      olsrv2TibRouterTopologySetToOrigIpAddr objects).  This information
+      provides an adversary broad information on the members of the
+      MANET, located within this single table.  This information can be
+      used to expedite attacks on the other members of the MANET without
+      having to go through a laborious discovery process on their own.
+
+   Some of the Tables in this MIB module AUGMENT Tables defined in NHDP-
+   MIB [RFC6779].  Hence, care must be taken in configuring access
+   control here in order make sure that the permitted permissions
+   granted for the AUGMENTing Tables here are consistent with the access
+   controls permitted within the NHDP-MIB.  The below list identifies
+   the AUGMENTing Tables and their NHDP-MIB counterparts.  It is
+   RECOMMENDED that access control policies for these Table pairs are
+   consistently set.
+
+   o  The olsrv2InterfaceTable AUGMENTs the nhdpInterfaceTable.
+
+   o  The olsrv2IibLinkSetTable AUGMENTs the nhdpIibLinkSetTable.
+
+   o  The olsrv2Iib2HopSetTable AUGMENTs the nhdpIib2HopSetTable.
+
+   o  The olsrv2NibNeighborSetTable AUGMENTs the
+      nhdpNibNeighborSetTable.
+
+   o  The olsrv2InterfacePerfTable AUGMENTs the nhdpInterfacePerfTable.
+
+   MANET technology is often deployed to support communications of
+   emergency services or military tactical applications.  In these
+   applications, it is imperative to maintain the proper operation of
+   the communications network and to protect sensitive information
+   related to its operation.  Therefore, when implementing these
+   capabilities, the full use of SNMPv3 cryptographic mechanisms for
+   authentication and privacy is RECOMMENDED.
+
+   SNMP versions prior to SNMPv3 did not include adequate security.
+   Even if the network itself is secure (for example by using IPsec),
+   there is no control as to who on the secure network is allowed to
+   access and GET/SET (read/change/create/delete) the objects in this
+   MIB module.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 79]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   Implementations SHOULD provide the security features described by the
+   SNMPv3 framework (see [RFC3410]), and implementations claiming
+   compliance to the SNMPv3 standard MUST include full support for
+   authentication and privacy via the User-based Security Model (USM)
+   [RFC3414] with the AES cipher algorithm [RFC3826].  Implementations
+   MAY also provide support for the Transport Security Model (TSM)
+   [RFC5591] in combination with a secure transport such as SSH
+   [RFC5592] or TLS/DTLS [RFC6353].
+
+   Further, deployment of SNMP versions prior to SNMPv3 is NOT
+   RECOMMENDED.  Instead, it is RECOMMENDED to deploy SNMPv3 and to
+   enable cryptographic security.  It is then a customer/operator
+   responsibility to ensure that the SNMP entity giving access to an
+   instance of this MIB module is properly configured to give access to
+   the objects only to those principals (users) that have legitimate
+   rights to indeed GET or SET (change/create/delete) them.
+
+9.  Applicability Statement
+
+   This document describes objects for configuring parameters of the
+   Optimized Link State Routing Protocol version 2 (OLSRv2) [RFC7181]
+   process on a router.  This MIB module, denoted OLSRv2-MIB, also
+   reports state, performance information, and notifications.  The
+   OLSRv2 protocol relies upon information gathered via the Neighborhood
+   Discovery Protocol [RFC6130] in order to perform its operations.
+   NHDP is managed via the NHDP-MIB [RFC6779].
+
+   MANET deployments can greatly differ in aspects of dynamics of the
+   topology, capacity, and loss rates of underlying channels, traffic
+   flow directions, memory and CPU capacity of routers, etc.  SNMP, and
+   therefore this MIB module, are only applicable for a subset of MANET
+   deployments, in particular deployments:
+
+   o  In which routers have enough memory and CPU resources to run SNMP
+      and expose the MIB module.
+
+   o  Where a Network Management System (NMS) is defined to which
+      notifications are generated and from which routers can be managed.
+
+   o  Where this NMS is reachable from routers in the MANET most of the
+      time (as notifications to the NMS and management information from
+      the NMS to the router will be lost when connectivity is
+      temporarily lost).  This requires that the topology of the MANET
+      is only moderately dynamic.
+
+   o  Where the underlying wireless channel supports enough bandwidth to
+      run SNMP, and where loss rates of the channel are not exhaustive.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 80]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   Certain MANET deployments such as community networks with non-mobile
+   routers, dynamic topology because of changing link quality, and a
+   predefined gateway (that could also serve as NMS), are examples of
+   networks applicable for this MIB module.  Other, more constrained
+   deployments of MANETs may not be able to run SNMP and require
+   different management protocols.
+
+   Some level of configuration, i.e., read-write objects, is desirable
+   for OLSRv2 deployments.  Topology-related configuration, such as the
+   ability to enable OLSRv2 on new interfaces or initially configure
+   OLSRv2 on a router's interfaces through the
+   olsrv2InterfaceAdminStatus object, is critical to initial system
+   startup.  The OLSRv2 protocol allows for some level of performance
+   tuning through various protocol parameters, and this MIB module
+   allows for configuration of those protocol parameters through read-
+   write objects such as the olsrv2TcHopLimit or the olsrv2FMaxJitter.
+   Other read-write objects allow for the control of Notification
+   behavior through this MIB module, e.g., the
+   olsrv2RoutingSetRecalculationCountThreshold object.  A fuller
+   discussion of MANET network management applicability is to be
+   provided elsewhere: [MGMT-SNAP] provides a snapshot of OLSRv2-routed
+   MANET management as currently deployed, while [MANET-MGMT] is
+   intended to provide specific guidelines on MANET network management
+   considering the various MIB modules that have been written.
+
+10.  IANA Considerations
+
+   IANA now maintains the IANAolsrv2LinkMetricType-MIB and keeps it
+   synchronized with the "LINK_METRIC Address Block TLV Type Extensions"
+   registry at <http://www.iana.org/assignments/manet-parameters>.
+
+   The MIB modules in this document use the following IANA-assigned
+   OBJECT IDENTIFIER values recorded in the SMI Numbers registry:
+
+         Descriptor                       OBJECT IDENTIFIER value
+         ----------                       -----------------------
+         OLSRv2-MIB                           { mib-2 219 }
+         IANA-OLSRv2-LINK-METRIC-TYPE-MIB     { mib-2 221 }
+
+11.  Acknowledgements
+
+   The authors would like to thank Randy Presuhn, Benoit Claise, Adrian
+   Farrel, as well as the entire MANET WG for reviews of this document.
+
+   This MIB document uses the template authored by D. Harrington, which
+   is based on contributions from the MIB Doctors, especially Juergen
+   Schoenwaelder, Dave Perkins, C.M. Heard, and Randy Presuhn.
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 81]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+12.  References
+
+12.1.  Normative References
+
+   [RFC2119]    Bradner, S., "Key words for use in RFCs to Indicate
+                Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2578]    McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                Schoenwaelder, Ed., "Structure of Management Information
+                Version 2 (SMIv2)", STD 58, RFC 2578, April 1999.
+
+   [RFC2579]    McCloghrie, K., Ed., Perkins, D., Ed., and J.
+                Schoenwaelder, Ed., "Textual Conventions for SMIv2", STD
+                58, RFC 2579, April 1999.
+
+   [RFC2580]    McCloghrie, K., Perkins, D., and J. Schoenwaelder,
+                "Conformance Statements for SMIv2", STD 58, RFC 2580,
+                April 1999.
+
+   [RFC2863]    McCloghrie, K. and F. Kastenholz, "The Interfaces Group
+                MIB", RFC 2863, June 2000.
+
+   [RFC3414]    Blumenthal, U. and B. Wijnen, "User-based Security Model
+                (USM) for version 3 of the Simple Network Management
+                Protocol (SNMPv3)", STD 62, RFC 3414, December 2002.
+
+   [RFC3418]    Presuhn, R., "Management Information Base (MIB) for the
+                Simple Network Management Protocol (SNMP)", STD 62, RFC
+                3418, December 2002.
+
+   [RFC3826]    Blumenthal, U., Maino, F., and K. McCloghrie, "The
+                Advanced Encryption Standard (AES) Cipher Algorithm in
+                the SNMP User-based Security Model", RFC 3826, June
+                2004.
+
+   [RFC4001]    Daniele, M., Haberman, B., Routhier, S., and J.
+                Schoenwaelder, "Textual Conventions for Internet Network
+                Addresses", RFC 4001, February 2005.
+
+   [RFC5591]    Harrington, D. and W. Hardaker, "Transport Security
+                Model for the Simple Network Management Protocol
+                (SNMP)", RFC 5591, June 2009.
+
+   [RFC5592]    Harrington, D., Salowey, J., and W. Hardaker, "Secure
+                Shell Transport Model for the Simple Network Management
+                Protocol (SNMP)", RFC 5592, June 2009.
+
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 82]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+   [RFC6130]    Clausen, T., Dearlove, C., and J. Dean, "Mobile Ad Hoc
+                Network (MANET) Neighborhood Discovery Protocol (NHDP)",
+                RFC 6130, April 2011.
+
+   [RFC6353]    Hardaker, W., "Transport Layer Security (TLS) Transport
+                Model for the Simple Network Management Protocol
+                (SNMP)", RFC 6353, July 2011.
+
+   [RFC6779]    Herberg, U., Cole, R., and I. Chakeres, "Definition of
+                Managed Objects for the Neighborhood Discovery
+                Protocol", RFC 6779, October 2012.
+
+   [RFC7181]    Clausen, T., Dearlove, C., Jacquet, P., and U. Herberg,
+                "The Optimized Link State Routing Protocol Version 2",
+                RFC 7181, April 2014.
+
+12.2.  Informative References
+
+   [MANET-MGMT] Nguyen, J., Cole, R., Herberg, U., Yi, J., and J. Dean,
+                "Network Management of Mobile Ad hoc Networks (MANET):
+                Architecture, Use Cases, and Applicability", Work in
+                Progress, February 2013.
+
+   [MGMT-SNAP]  Clausen, T. and U. Herberg, "Snapshot of OLSRv2-Routed
+                MANET Management", Work in Progress, February 2014.
+
+   [REPORT-MIB] Cole, R., Macker, J., and A. Bierman, "Definition of
+                Managed Objects for Performance Reporting", Work in
+                Progress, November 2012.
+
+   [RFC3410]    Case, J., Mundy, R., Partain, D., and B. Stewart,
+                "Introduction and Applicability Statements for Internet-
+                Standard Management Framework", RFC 3410, December 2002.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 83]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+Appendix A.  IANAolsrv2LinkMetricType-MIB
+
+   This document has set up the IANAolsrv2LinkMetricType-MIB module.
+   IANA now maintains the IANAolsrv2LinkMetricType-MIB and keeps it
+   synchronized with the "LINK_METRIC Address Block TLV Type Extensions"
+   registry at <http://www.iana.org/assignments/manet-parameters>.  The
+   IANA site is the definitive source for this MIB should there be any
+   discrepancies (e.g., future updates to the MIB).
+
+   IANA-OLSRv2-LINK-METRIC-TYPE-MIB DEFINITIONS ::= BEGIN
+
+   IMPORTS
+       MODULE-IDENTITY, mib-2
+                 FROM SNMPv2-SMI
+       TEXTUAL-CONVENTION
+                 FROM SNMPv2-TC;
+
+   ianaolsrv2LinkMetricType MODULE-IDENTITY
+       LAST-UPDATED "201404090000Z"  -- 09 April 2014
+       ORGANIZATION "IANA"
+       CONTACT-INFO "Internet Assigned Numbers Authority
+
+                     Postal: ICANN
+                             12025 Waterfront Drive, Suite 300
+                             Los Angeles, CA 90094-2536
+
+                     Tel:    +1 310 301 5800
+                     E-Mail: iana@iana.org"
+       DESCRIPTION  "This MIB module defines the
+                     IANAolsrv2LinkMetricType Textual
+                     Convention, and thus the enumerated values of
+                     the olsrv2LinkMetricType object defined in
+                     the OLSRv2-MIB."
+       REVISION      "201404090000Z"  -- 09 April 2014
+       DESCRIPTION   "Initial version of this MIB as published in
+                      RFC 7184."
+
+       ::= { mib-2 221 }
+
+   IANAolsrv2LinkMetricTypeTC ::= TEXTUAL-CONVENTION
+      STATUS      current
+      DESCRIPTION
+         "This data type is used as the syntax of the
+          olsrv2LinkMetricType object in the definition
+          of the OLSRv2-MIB module.
+
+          The olsrv2LinkMetricType corresponds to
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 84]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+          LINK_METRIC_TYPE of OLSRv2 (RFC 7181).
+          OLSRv2 uses bidirectional additive link metrics
+          to determine shortest distance routes (i.e.,
+          routes with smallest total of link metric values).
+
+          OLSRv2 has established a registry for the LINK_METRIC_TYPEs
+          (denoted 'LINK_METRIC Address Block TLV Type Extensions'):
+                 http://www.iana.org/assignments/manet-parameters/
+
+          This is done in Section 24.5 in OLSRv2 (RFC 7181).
+          The LINK_METRIC_TYPE (which has as corresponding
+          object in the MIB module olsrv2LinkMetricType)
+          corresponds to the type extension of
+          the LINK_METRIC TLV that is set up in the
+          'LINK_METRIC Address Block TLV Type Extensions' registry.
+          Whenever new link metric types are added to that registry,
+          IANA MUST update this textual convention accordingly.
+
+          The definition of this textual convention with the
+          addition of newly assigned values is published
+          periodically by the IANA, in either the Assigned
+          Numbers RFC, or some derivative of it specific to
+          Internet Network Management number assignments.  (The
+          latest arrangements can be obtained by contacting the
+          IANA.)
+
+          Requests for new values should be made to IANA via
+          email (iana@iana.org)."
+      SYNTAX  INTEGER {
+                 unknown(0)     -- Link metric meaning assigned
+                                --       by administrative action
+                                -- 1-223 Unassigned
+                                -- 224-255 Reserved for
+                                --       Experimental Use
+      }
+
+      END
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 85]
+
+RFC 7184                     The OLSRv2-MIB                   April 2014
+
+
+Authors' Addresses
+
+   Ulrich Herberg
+   Fujitsu Laboratories of America
+   1240 East Arques Avenue
+   Sunnyvale, CA  94085
+   USA
+
+   EMail: ulrich@herberg.name
+   URI:   http://www.herberg.name/
+
+
+   Robert G. Cole
+   US Army CERDEC
+   6010 Frankford Road, Bldg 6010
+   Aberdeen Proving Ground, Maryland  21005
+   USA
+
+   Phone: +1 443 395 8744
+   EMail: robert.g.cole@us.army.mil
+   URI:   http://www.cs.jhu.edu/~rgcole/
+
+
+   Thomas Heide Clausen
+   LIX, Ecole Polytechnique
+   Palaiseau Cedex  91128
+   France
+
+   Phone: +33 6 6058 9349
+   EMail: T.Clausen@computer.org
+   URI:   http://www.ThomasClausen.org/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Herberg, et al.              Standards Track                   [Page 86]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7184.txt](<www.ietf.org/rfc/rfc7184.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
