### PR TITLE
Archive rfc7187.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7187.txt
+++ b/www.ietf.org/rfc/rfc7187.txt
@@ -1,0 +1,283 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                       C. Dearlove
+Request for Comments: 7187                               BAE Systems ATC
+Updates: 7181                                                 T. Clausen
+Category: Standards Track                       LIX, Ecole Polytechnique
+ISSN: 2070-1721                                               April 2014
+
+
+               Routing Multipoint Relay Optimization for
+      the Optimized Link State Routing Protocol Version 2 (OLSRv2)
+
+Abstract
+
+   This specification updates the Optimized Link State Routing Protocol
+   version 2 (OLSRv2) with an optimization to improve the selection of
+   routing multipoint relays.  The optimization retains full
+   interoperability between implementations of OLSRv2 with and without
+   this optimization.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7187.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+Dearlove & Clausen           Standards Track                    [Page 1]
+
+RFC 7187             OLSRv2 Routing MPR Optimization          April 2014
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   3.  Applicability Statement . . . . . . . . . . . . . . . . . . .   2
+   4.  Routing MPR Selection . . . . . . . . . . . . . . . . . . . .   3
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   4
+   6.  Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .   4
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   4
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .   4
+     7.2.  Informative References  . . . . . . . . . . . . . . . . .   4
+
+1.  Introduction
+
+   The Optimized Link State Routing Protocol version 2 [RFC7181] is a
+   proactive link state routing protocol designed for use in mobile ad
+   hoc networks (MANETs) [RFC2501].  This document improves one area of
+   the OLSRv2 specification.
+
+   One improvement included in OLSRv2, compared to its predecessor
+   described in [RFC3626], is the use of link metrics, rather than
+   minimum-hop routing.  A rationale for how link metrics were included
+   in OLSRv2 is documented in [RFC7185].  However, one aspect of the use
+   of link metrics described in [RFC7185], the removal of some
+   unnecessarily selected routing multipoint relays (MPRs), was not
+   included in [RFC7181].  This specification updates OLSRv2 to include
+   this optimization.
+
+   Note that this optimization does not impact interoperability:
+   implementations that do and do not implement this optimization will
+   interoperate seamlessly.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   [RFC2119].
+
+   Additionally, this document uses the terminology of [RFC7181].
+
+3.  Applicability Statement
+
+   This specification updates [RFC7181].  As such, it is applicable to
+   all implementations of this protocol.  The optimization presented in
+   this specification is simply permissive; it allows an additional
+   optimization, and there is no requirement for any implementation to
+
+
+
+
+Dearlove & Clausen           Standards Track                    [Page 2]
+
+RFC 7187             OLSRv2 Routing MPR Optimization          April 2014
+
+
+   include it.  However, inclusion of this optimization is advised; it
+   can, in some cases, create smaller and fewer messages, without ever
+   having the opposite effect.
+
+   [RFC7181] defines the properties for the selection of routing MPRs
+   from among a router's symmetric 1-hop neighbors.  The properties are
+
+   o  the selected MPRs must consist of a set of symmetric 1-hop
+      neighbors that cover all the symmetric 2-hop neighbors, and
+
+   o  the selected MPRs must do so retaining a minimum distance route
+      (1-hop, if present, or 2-hop) to each symmetric 2-hop neighbor.
+
+   The discussion in the latter part of Section 6.2 of [RFC7185]
+   indicates that this requirement is overly prescriptive for routing
+   MPR selection.  The update to [RFC7181] described in this
+   specification permits a router to use the described optimization,
+   while still being considered compliant with OLSRv2.
+
+   Note that whether or not a router is considered compliant, a router
+   that implements the optimization described in this specification will
+   interoperate successfully with routers that are not implementing this
+   optimization.
+
+4.  Routing MPR Selection
+
+   A set of routing MPRs created as specified in [RFC7181] MAY be
+   optimized in the following manner.  Note that this uses the notation
+   of Section 18.2 of [RFC7181]:
+
+   1.  If there is a sequence x_0, ..., x_n of elements of N1 such that:
+
+       *  x_0 is a routing MPR,
+
+       *  x_1, ... , x_n have corresponding elements y_1, ..., y_n of
+          N2, and
+
+       *  d1(x_0) + d2(x_0,y_1) + ... + d2(x_m-1,y_m) < d1(x_m) for m =
+          1, ... , n,
+
+       then x_1 to x_n may be removed from the set of routing MPRs, if
+       selected.
+
+   Note that "corresponding elements" in N1 and N2 means that these
+   elements represent the same router.  All of this information is
+   available from information gathered by NHDP [RFC6130].
+
+
+
+
+
+Dearlove & Clausen           Standards Track                    [Page 3]
+
+RFC 7187             OLSRv2 Routing MPR Optimization          April 2014
+
+
+5.  Security Considerations
+
+   The update to OLSRv2 [RFC7181] does not introduce any new protocol
+   signals, nor does it change the processing of any received protocol
+   signals.
+
+   This update to OLSRv2 [RFC7181] permits an implementation that is
+   compliant with OLSRv2 to (potentially) eliminate some unneeded
+   routers from the routing MPR sets generated as described in
+   [RFC7181], which also eliminates the need to include the
+   corresponding information in generated Topology Control (TC)
+   messages.  Because this information is not used when included, this
+   update to OLSRv2 [RFC7181] does not present any additional security
+   considerations, beyond those described in [RFC7181].
+
+6.  Acknowledgments
+
+   The authors would like to gratefully acknowledge Philippe Jacquet
+   (Alcatel-Lucent) for intense technical discussions and comments.
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC6130]  Clausen, T., Dean, J., and C. Dearlove, "Mobile Ad Hoc
+              Network (MANET) Neighborhood Discovery Protocol (NHDP)",
+              RFC 6130, April 2011.
+
+   [RFC7181]  Clausen, T., Dearlove, C., Jacquet, P., and U. Herberg,
+              "The Optimized Link State Routing Protocol Version 2", RFC
+              7181, April 2014.
+
+7.2.  Informative References
+
+   [RFC2501]  Macker, J. and S. Corson, "Mobile Ad hoc Networking
+              (MANET): Routing Protocol Performance Issues and
+              Evaluation Considerations", RFC 2501, January 1999.
+
+   [RFC3626]  Clausen, T. and P. Jacquet, "The Optimized Link State
+              Routing Protocol", RFC 3626, October 2003.
+
+   [RFC7185]  Clausen, T., Dearlove, C., and P. Jacquet, "Rationale for
+              the Use of Link Metrics in the Optimized Link State
+              Routing Protocol Version 2 (OLSRv2)", RFC 7185, April
+              2014.
+
+
+
+Dearlove & Clausen           Standards Track                    [Page 4]
+
+RFC 7187             OLSRv2 Routing MPR Optimization          April 2014
+
+
+Authors' Addresses
+
+   Christopher Dearlove
+   BAE Systems Advanced Technology Centre
+   West Hanningfield Road
+   Great Baddow, Chelmsford
+   United Kingdom
+
+   Phone: +44 1245 242194
+   EMail: chris.dearlove@baesystems.com
+   URI:   http://www.baesystems.com/
+
+
+   Thomas Heide Clausen
+   LIX, Ecole Polytechnique
+
+   Phone: +33 6 6058 9349
+   EMail: T.Clausen@computer.org
+   URI:   http://www.ThomasClausen.org/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Dearlove & Clausen           Standards Track                    [Page 5]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7187.txt](<www.ietf.org/rfc/rfc7187.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
