### PR TITLE
Archive rfc7259.txt

### DIFF
--- a/www.ietf.org/rfc/rfc7259.txt
+++ b/www.ietf.org/rfc/rfc7259.txt
@@ -1,0 +1,395 @@
+
+
+
+
+
+
+Independent Submission                                    P. Saint-Andre
+Request for Comments: 7259                                          &yet
+Category: Informational                                         May 2014
+ISSN: 2070-1721
+
+
+                       The Jabber-ID Header Field
+
+Abstract
+
+   This document defines a header field that enables the author of an
+   email or netnews message to include a Jabber ID in the message header
+   block for the purpose of associating the author with a particular
+   Extensible Messaging and Presence Protocol (XMPP) address.
+
+Status of This Memo
+
+   This document is not an Internet Standards Track specification; it is
+   published for informational purposes.
+
+   This is a contribution to the RFC Series, independently of any other
+   RFC stream.  The RFC Editor has chosen to publish this document at
+   its discretion and makes no statement about its value for
+   implementation or deployment.  Documents approved for publication by
+   the RFC Editor are not a candidate for any level of Internet
+   Standard; see Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7259.
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 1]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Syntax  . . . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Usage . . . . . . . . . . . . . . . . . . . . . . . . . . . .   3
+     3.1.  Inclusion . . . . . . . . . . . . . . . . . . . . . . . .   3
+     3.2.  Generation  . . . . . . . . . . . . . . . . . . . . . . .   3
+     3.3.  Processing  . . . . . . . . . . . . . . . . . . . . . . .   4
+     3.4.  Disposition . . . . . . . . . . . . . . . . . . . . . . .   4
+   4.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   4
+   5.  Security and Privacy Considerations . . . . . . . . . . . . .   5
+   6.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   5
+     6.1.  Normative References  . . . . . . . . . . . . . . . . . .   5
+     6.2.  Informative References  . . . . . . . . . . . . . . . . .   6
+   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .   7
+
+1.  Introduction
+
+   The Extensible Messaging and Presence Protocol (XMPP), documented in
+   [RFC6120], is a streaming XML technology that enables any two
+   entities on a network to exchange well-defined but extensible XML
+   elements (called "XML stanzas") in close to real time.  Given XMPP's
+   heritage in the Jabber open-source community, one of the primary uses
+   for XMPP is instant messaging and presence as documented in
+   [RFC6121], and XMPP addresses are still referred to as Jabber IDs.
+
+   Because almost all human users of Jabber/XMPP instant messaging and
+   presence systems also use email systems [RFC5322] and because many
+   also use netnews systems [RFC5536], it can be helpful for them to
+   associate their Jabber IDs with the messages they author.  The
+   Jabber-ID header field provides a standard location for that
+   information.
+
+   Members of the XMPP instant messaging and presence community have
+   been experimenting with the Jabber-ID header field for many years.
+   This document defines the syntax and usage of the Jabber-ID header
+   field, including the information necessary to register the field in
+   the Provisional Message Header Field Names registry maintained by the
+   IANA.
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 2]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+2.  Syntax
+
+   The syntax of the Jabber-ID header field is defined below using
+   Augmented Backus-Naur Form [RFC5234], where the "pathxmpp" rule is
+   defined in the XMPP URI specification [RFC5122] and the remaining
+   rules are defined in the Internet Message Format specification
+   [RFC5322]:
+
+      Jabber-ID = SP *WSP pathxmpp *WSP CRLF
+
+   Although a native XMPP address can contain virtually any Unicode
+   character [UNICODE], the header of an email or netnews message is
+   allowed to contain only printable ASCII characters (see Section 2 of
+   [RFC5322]).  Therefore, any characters outside the ASCII range
+   [RFC20] in an XMPP address need to be converted to ASCII before
+   inclusion in a Jabber-ID header field, in accordance with the rules
+   defined in the XMPP URI specification [RFC5122].  In addition,
+   characters allowed in XMPP localparts and XMPP resourceparts but
+   disallowed by the relevant URI rules need to be percent-encoded in
+   accordance with the rules defined in the URI specification [RFC3986].
+
+3.  Usage
+
+3.1.  Inclusion
+
+   The Jabber-ID header field is associated with the author of the
+   message; see [RFC5322].  If the "From:" header field of an email
+   message contains more than one mailbox, it is best not to add the
+   Jabber-ID header field to the message.  To reduce the possibility of
+   confusion, it is best to include only one instance of the Jabber-ID
+   header field in a given message.
+
+3.2.  Generation
+
+   For a user whose XMPP address is "juliet@example.com", the
+   corresponding Jabber-ID header field would be:
+
+      Jabber-ID: juliet@example.com
+
+   As noted, non-ASCII characters in XMPP addresses need to be converted
+   into ASCII before inclusion in a Jabber-ID header field.  Consider
+   the following XMPP address:
+
+      ji&#x159;i@&#x10D;echy.example
+
+   In the foregoing example, the string "&#x159;" stands for the Unicode
+   character LATIN SMALL LETTER R WITH CARON and the string "&#x10D;"
+   stands for the Unicode character LATIN SMALL LETTER C WITH CARON,
+
+
+
+Saint-Andre                   Informational                     [Page 3]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+   following the "XML Notation" used in [RFC3987] to represent
+   characters that cannot be rendered in ASCII-only documents.  For
+   those who do not read Czech, this example could be anglicized as
+   "george@czech-lands.example".
+
+   Following the rules in [RFC5122] and the Jabber-ID header field
+   syntax, the resulting header field might be as shown below (note that
+   this representation includes folding white space, which is allowed in
+   accordance with the ABNF):
+
+      Jabber-ID:
+             ji%C5%99i@%C4%8Dechy.example
+
+3.3.  Processing
+
+   Upon receiving an email message or netnews message containing a
+   Jabber-ID header field, a user agent that supports the field ought to
+   process the field by converting any escaped characters to characters
+   outside the ASCII range in accordance with the rules defined in
+   [RFC5122], thus yielding a Jabber ID that can be used for native
+   communication on the XMPP network.
+
+3.4.  Disposition
+
+   A user agent that has processed a Jabber-ID header field can provide
+   appropriate interface elements if it has independent information
+   linking the author of the email or netnews message with the specified
+   Jabber ID (e.g., via a user-controlled address book or automated
+   directory lookup).  Such interface elements might include an
+   indicator of "presence" (i.e., that the author is online and
+   available for communication via XMPP) if the user is subscribed to
+   the presence of the author, and an element that enables the user to
+   send an instant message or initiate a text chat session with the
+   author.
+
+4.  IANA Considerations
+
+   The IANA has added "Jabber-ID" to the Provisional Message Header
+   Field Names registry.  The completed registration template follows.
+
+   Header field name:  Jabber-ID
+
+   Applicable protocol:  mail, netnews
+
+   Status:  provisional
+
+   Author/Change controller  Peter Saint-Andre <stpeter@jabber.org>
+
+
+
+
+Saint-Andre                   Informational                     [Page 4]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+   Specification document:  RFC 7259
+
+   Related information:  See RFC 6120
+
+5.  Security and Privacy Considerations
+
+   Message headers are an existing standard and are designed to easily
+   accommodate new types.  Although the Jabber-ID header field could be
+   forged, this problem is inherent in Internet email and netnews.
+   However, because a forged Jabber-ID header field might break
+   automated processing, applications are discouraged from depending on
+   the Jabber-ID header field to indicate the authenticity of an email
+   or netnews message, or the identity of its author or sender.
+   Including the Jabber-ID header field among the signer header fields
+   in DomainKeys Identified Mail (DKIM) can help to mitigate against
+   forging of the header (see [RFC6376]).
+
+   Advertising XMPP addresses in email or netnews headers might make it
+   easier for malicious users to harvest XMPP addresses and therefore to
+   send unsolicited bulk communications to the users or applications
+   represented by those addresses.  Providing such a binding between an
+   email address and a Jabber ID can also increase the possibility of
+   drawing a connection between different kinds of communications
+   traffic for purposes of surveillance and other breaches of privacy.
+   Care ought to be taken in balancing the benefits of open information
+   exchange against the potential costs of security and privacy
+   weaknesses.  An email or netnews user agent that is capable of
+   including the Jabber-ID header field in outgoing email or netnews
+   messages needs to provide an option for its user to disable inclusion
+   of the Jabber-ID header field generally, on a per-recipient basis,
+   and on a per-message basis.
+
+   The security and privacy considerations discussed in [RFC3986],
+   [RFC3987], [RFC5122], [RFC6120], and [RFC6121] also apply to the
+   Jabber-ID message header.
+
+6.  References
+
+6.1.  Normative References
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66, RFC
+              3986, January 2005.
+
+   [RFC3987]  Duerst, M. and M. Suignard, "Internationalized Resource
+              Identifiers (IRIs)", RFC 3987, January 2005.
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 5]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+   [RFC5122]  Saint-Andre, P., "Internationalized Resource Identifiers
+              (IRIs) and Uniform Resource Identifiers (URIs) for the
+              Extensible Messaging and Presence Protocol (XMPP)", RFC
+              5122, February 2008.
+
+   [RFC5234]  Crocker, D. and P. Overell, "Augmented BNF for Syntax
+              Specifications: ABNF", STD 68, RFC 5234, January 2008.
+
+   [RFC5322]  Resnick, P., Ed., "Internet Message Format", RFC 5322,
+              October 2008.
+
+   [RFC6120]  Saint-Andre, P., "Extensible Messaging and Presence
+              Protocol (XMPP): Core", RFC 6120, March 2011.
+
+   [UNICODE]  The Unicode Consortium, "The Unicode Standard, Version
+              6.3", (Mountain View, CA: The Unicode Consortium, 2013.
+              ISBN 978-1-936213-08-5),
+              <http://www.unicode.org/versions/Unicode6.3.0/>.
+
+6.2.  Informative References
+
+   [RFC20]    Cerf, V., "ASCII format for network interchange", RFC 20,
+              October 1969.
+
+   [RFC5536]  Murchison, K., Lindsey, C., and D. Kohn, "Netnews Article
+              Format", RFC 5536, November 2009.
+
+   [RFC6121]  Saint-Andre, P., "Extensible Messaging and Presence
+              Protocol (XMPP): Instant Messaging and Presence", RFC
+              6121, March 2011.
+
+   [RFC6376]  Crocker, D., Hansen, T., and M. Kucherawy, "DomainKeys
+              Identified Mail (DKIM) Signatures", RFC 6376, September
+              2011.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 6]
+
+RFC 7259                        Jabber-ID                       May 2014
+
+
+Appendix A.  Acknowledgements
+
+   Thanks to Dave Cridland, Stephen Farrell, Russ Housley, and Alexey
+   Melnikov for their feedback.
+
+Author's Address
+
+   Peter Saint-Andre
+   &yet
+
+   EMail: ietf@stpeter.im
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Saint-Andre                   Informational                     [Page 7]
+


### PR DESCRIPTION
Original source: [www.ietf.org/rfc/rfc7259.txt](<www.ietf.org/rfc/rfc7259.txt>)

**NOTE:** This is an automatic commit. See the archive workflow.
