### PR TITLE
Update archive.yml workflow to trim `www.` prefix from directories

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -68,7 +68,8 @@ jobs:
               sed -E 's/^https?:\/\/web.archive.org\/web\/[0-9]+\/(https?:\/\/)?/https:\/\//' |
               sed -E 's/^https?:\/\///' |
               sed -E 's/^ftps?:\/\///' |
-              sed -E 's/^ia[0-9]+.us.archive.org\/[0-9]+\/items\//archive.org\/download\//'
+              sed -E 's/^ia[0-9]+.us.archive.org\/[0-9]+\/items\//archive.org\/download\//' |
+              sed -E 's/^www.//'
           )
 
           # Get the url of the file (with any sanitisation)
@@ -163,7 +164,8 @@ jobs:
                 sed -E 's/^https?:\/\/web.archive.org\/web\/[0-9]+\/(https?:\/\/)?/https:\/\//' |
                 sed -E 's/^https?:\/\///' |
                 sed -E 's/^ftps?:\/\///' |
-                sed -E 's/^ia[0-9]+.us.archive.org\/[0-9]+\/items\//archive.org\/download\//'
+                sed -E 's/^ia[0-9]+.us.archive.org\/[0-9]+\/items\//archive.org\/download\//' |
+                sed -E 's/^www.//'
             )"
           )
 


### PR DESCRIPTION
This will hopefully help reduce duplicates in the directory structure where the same file is archived under `www.example.com/path/file` and `example.com/path/file`; these are obviously the same thing.