### PR TITLE
Update timeout to quit early and give chance to clean up / push

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Mirror Directory
         continue-on-error: true # Don't worry if it could not be mirrored, some individual files may fail but can be manually recovered later
-        timeout-minutes: 600
-        run: wget --no-verbose --execute robots=off --random-wait --wait 5 --recursive -level=inf --no-parent --convert-links --page-requisites --content-on-error --content-disposition "${URL}"
+        timeout-minutes: 595 # max time out is 600, quit and at least try to commit / push what was downloaded so far 
+        run: wget --no-verbose --execute robots=off --random-wait --wait 15 --recursive -level=inf --no-parent --convert-links --page-requisites --content-on-error --content-disposition "${URL}"
         env:
           URL: ${{ steps.target.outputs.url }}
 


### PR DESCRIPTION
The idea is that a partial push is acceptable for a directory since a PR is required anyway